### PR TITLE
fix(DC0004): detect XML doc comments when attributes precede procedure keyword

### DIFF
--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/HasDiagnostic/ProcedureWithAttribute.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/HasDiagnostic/ProcedureWithAttribute.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    [NonDebuggable]
+    procedure [|MyProcedure|]()
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/ProcedureDocumentationCommentWithAttribute.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/ProcedureDocumentationCommentWithAttribute.al
@@ -1,0 +1,11 @@
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Sets the call body content from a stream.
+    /// </summary>
+    /// <param name="ContentStream">The instream containing the call body.</param>
+    [NonDebuggable]
+    procedure [|MyProcedure|](ContentStream: InStream)
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/ProcedureDocumentationCommentWithMultipleAttributes.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/ProcedureDocumentationCommentWithMultipleAttributes.al
@@ -1,0 +1,11 @@
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// My procedure.
+    /// </summary>
+    [NonDebuggable]
+    [Scope('OnPrem')]
+    procedure [|MyProcedure|]()
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/PublicProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/PublicProcedureRequiresDocumentation.cs
@@ -21,6 +21,7 @@ namespace ALCops.DocumentationCop.Test
         [Test]
         [TestCase("Procedure")]
         [TestCase("ProcedureWithComment")]
+        [TestCase("ProcedureWithAttribute")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -32,6 +33,8 @@ namespace ALCops.DocumentationCop.Test
         [Test]
         [TestCase("CodeunitAccessInternal")]
         [TestCase("ProcedureDocumentationComment")]
+        [TestCase("ProcedureDocumentationCommentWithAttribute")]
+        [TestCase("ProcedureDocumentationCommentWithMultipleAttributes")]
         [TestCase("ProcedureInternal")]
         [TestCase("ProcedureLocal")]
         public async Task NoDiagnostic(string testCase)

--- a/src/ALCops.DocumentationCop/Analyzers/PublicProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/PublicProcedureRequiresDocumentation.cs
@@ -45,7 +45,7 @@ public sealed class PublicProcedureRequiresDocumentation : DiagnosticAnalyzer
 
     private static bool HasXmlDocumentation(MethodDeclarationSyntax method)
     {
-        var trivia = method.ProcedureKeyword.LeadingTrivia;
+        var trivia = method.GetLeadingTrivia();
 
         return trivia.Any(t =>
             t.Kind == EnumProvider.SyntaxKind.SingleLineDocumentationCommentTrivia ||


### PR DESCRIPTION
Fixes: #102