### PR TITLE
fix(AC0026): skip fields with ObsoleteState = Removed

### DIFF
--- a/src/ALCops.ApplicationCop.Test/Rules/AllowInCustomizationsForOmittedFields/AllowInCustomizationsForOmittedFields.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/AllowInCustomizationsForOmittedFields/AllowInCustomizationsForOmittedFields.cs
@@ -45,6 +45,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("FieldTypeNotSupported")]
         [TestCase("FlowFilterField")]
         [TestCase("ObsoleteStatePending")]
+        [TestCase("ObsoleteStateRemoved")]
         [TestCase("TableExtension")]
         public async Task NoDiagnostic(string testCase)
         {

--- a/src/ALCops.ApplicationCop.Test/Rules/AllowInCustomizationsForOmittedFields/NoDiagnostic/ObsoleteStateRemoved.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/AllowInCustomizationsForOmittedFields/NoDiagnostic/ObsoleteStateRemoved.al
@@ -1,0 +1,14 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[10]) { }
+        field(2; [|MyField|]; Integer)
+        {
+            ObsoleteState = Removed;
+            ObsoleteReason = 'Use other field';
+        }
+    }
+}
+
+page 50000 MyPage { SourceTable = MyTable; }

--- a/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
@@ -129,12 +129,8 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
             if (field.GetProperty(EnumProvider.PropertyKind.AllowInCustomizations) is not null)
                 continue;
 
-            var obsoleteState = field.GetEnumPropertyValue<ObsoleteStateKind>(EnumProvider.PropertyKind.ObsoleteState);
-            if (obsoleteState is not null &&
-               obsoleteState.Value != EnumProvider.ObsoleteStateKind.No)
-            {
+            if (field.IsObsolete())
                 continue;
-            }
 
             var navTypeKind = field.OriginalDefinition.GetTypeSymbol().GetNavTypeKindSafe();
             if (!IsSupportedType(navTypeKind))


### PR DESCRIPTION
Fix #122 

GetEnumPropertyValue<ObsoleteStateKind> returns No for Removed fields, causing false positives. Replace with field.IsObsolete() which reliably checks IsObsoleteRemoved/IsObsoletePending on the symbol directly.