### PR TITLE
fix(ci): add retry logic and User-Agent to Marketplace.ps1

### DIFF
--- a/.github/actions/get-bc-devtools/Get-Sources.ps1
+++ b/.github/actions/get-bc-devtools/Get-Sources.ps1
@@ -47,7 +47,12 @@ function Get-TargetFrameworkCache {
 # Read TargetFramework data for lookup
 $targetFrameworkCache = Get-TargetFrameworkCache -JsonPath $JsonPath
 
-$marketplace = & "$PSScriptRoot/Marketplace.ps1" | ConvertFrom-Json
+$marketplace = try {
+    & "$PSScriptRoot/Marketplace.ps1" | ConvertFrom-Json
+}
+catch {
+    throw "Marketplace query failed: $($_.Exception.Message)"
+}
 
 $marketplaceLatest = $marketplace `
 | Where-Object properties -ne $null `
@@ -80,7 +85,12 @@ foreach ($item in $marketplace) {
     }
 }
 
-$nupkgs = & "$PSScriptRoot/NuGet-Packages.ps1" | ConvertFrom-Json
+$nupkgs = try {
+    & "$PSScriptRoot/NuGet-Packages.ps1" | ConvertFrom-Json
+}
+catch {
+    throw "NuGet package query failed: $($_.Exception.Message)"
+}
 
 $nugetLatest =
 $nupkgs |
@@ -114,7 +124,12 @@ foreach ($item in $nupkgs) {
     }
 }
 
-$bcArtifacts = & "$PSScriptRoot/BC-Artifacts.ps1" | ConvertFrom-Json
+$bcArtifacts = try {
+    & "$PSScriptRoot/BC-Artifacts.ps1" | ConvertFrom-Json
+}
+catch {
+    throw "BC Artifacts query failed: $($_.Exception.Message)"
+}
 
 $bcArtifactLatest =
 ($bcArtifacts | Where-Object { $_.select -eq 'Current' } | Select-Object -First 1).version

--- a/.github/actions/get-bc-devtools/Marketplace.ps1
+++ b/.github/actions/get-bc-devtools/Marketplace.ps1
@@ -7,22 +7,38 @@ Marketplace publisher short name. Default: ms-dynamics-smb
 
 .PARAMETER Extension
 Extension short name. Default: al
+
+.PARAMETER TimeoutSec
+HTTP timeout per attempt. Default: 30
+
+.PARAMETER Retries
+Number of retry attempts on transient failures. Default: 3
 #>
 
 [CmdletBinding()]
 param(
     [string]$Publisher = 'ms-dynamics-smb',
-    [string]$Extension = 'al'
+    [string]$Extension = 'al',
+    [int]$TimeoutSec = 30,
+    [int]$Retries = 3
 )
 
 $ErrorActionPreference = 'Stop'
+
+if ($Retries -lt 1) {
+    $Retries = 1
+}
 
 function Invoke-MarketplaceQuery {
     param(
         [Parameter(Mandatory)]
         [string]$Publisher,
         [Parameter(Mandatory)]
-        [string]$Extension
+        [string]$Extension,
+        [Parameter(Mandatory)]
+        [int]$TimeoutSec,
+        [Parameter(Mandatory)]
+        [int]$Retries
     )
 
     # Build the extension identifier used in filterType 7
@@ -54,7 +70,31 @@ function Invoke-MarketplaceQuery {
 
     $uri = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=3.0-preview.1'
 
-    $response = Invoke-RestMethod -Method POST -Uri $uri -ContentType 'application/json' -Body ($payload | ConvertTo-Json -Depth 10)
+    $context = if ($env:GITHUB_ACTIONS) { "GitHub Actions; $env:GITHUB_REPOSITORY" } else { $env:COMPUTERNAME }
+    $headers = @{
+        'User-Agent' = "PowerShell/$($PSVersionTable.PSVersion) MarketplaceQuery/1.0 ($context)"
+    }
+
+    # Retry loop with exponential backoff
+    $response = $null
+    $attempt = 0
+    $lastErr = $null
+
+    while (-not $response -and $attempt -lt $Retries) {
+        try {
+            $attempt++
+            $response = Invoke-RestMethod -Method POST -Uri $uri -ContentType 'application/json' -Headers $headers -Body ($payload | ConvertTo-Json -Depth 10) -TimeoutSec $TimeoutSec
+        }
+        catch {
+            $lastErr = $_
+            if ($attempt -ge $Retries) {
+                throw "Failed to query VS Marketplace for '$extensionId' after $attempt attempt(s). $($_.Exception.Message)"
+            }
+            $backoffSec = [Math]::Min(2 * $attempt, 10)
+            Write-Warning "VS Marketplace request failed (attempt $attempt/$Retries): $($_.Exception.Message). Retrying in ${backoffSec}s..."
+            Start-Sleep -Seconds $backoffSec
+        }
+    }
 
     if (-not $response.results -or -not $response.results[0].extensions) {
         throw "No extensions returned for '$extensionId'."
@@ -91,7 +131,7 @@ function ConvertTo-Version {
 }
 
 # Query the marketplace
-$marketplace = Invoke-MarketplaceQuery -Publisher $Publisher -Extension $Extension
+$marketplace = Invoke-MarketplaceQuery -Publisher $Publisher -Extension $Extension -TimeoutSec $TimeoutSec -Retries $Retries
 
 # Hardcoded filter for minimum AL Language version 12.x
 $marketplaceFiltered = $marketplace.versions | Where-Object { $(ConvertTo-Version($_.version)) -ge [System.Version]::Parse("12.0.0") }


### PR DESCRIPTION
The VS Marketplace API intermittently returns 403 (Forbidden) on GitHub Actions runners, causing the Setup job to fail with no retries.

Changes:
- Marketplace.ps1: add retry loop with exponential backoff (3 attempts), User-Agent header (CI-aware with local fallback), and configurable TimeoutSec/Retries parameters — matching the pattern in NuGet-Packages.ps1
- Get-Sources.ps1: wrap each source-script call in try/catch with source-specific error prefixes for clearer failure diagnostics