### PR TITLE
feat: add TestType property support to FC0002 casing check

### DIFF
--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -1187,6 +1187,20 @@ public static class EnumProvider
     }
 
     /// <summary>
+    /// TestTypeKind enum values
+    /// </summary>
+    public static class TestTypeKind
+    {
+#if NETSTANDARD2_1
+        public static readonly Lazy<ImmutableDictionary<string, string>> CanonicalNames =
+            new Lazy<ImmutableDictionary<string, string>>(() => ImmutableDictionary<string, string>.Empty, LazyThreadSafetyMode.PublicationOnly);
+#else
+        public static readonly Lazy<ImmutableDictionary<string, string>> CanonicalNames =
+            CreateEnumDictionary<NavCodeAnalysis.TestTypeKind>();
+#endif
+    }
+
+    /// <summary>
     /// TextEncodingKind enum values
     /// </summary>
     public static class TextEncodingKind

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
@@ -31,6 +31,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("OptionDataType")]
         [TestCase("Property")]
         [TestCase("TextConstDataType")]
+        [TestCase("TestType")]
         [TestCase("TriggerDeclaration")]
         public async Task HasDiagnostic(string testCase)
         {
@@ -38,6 +39,12 @@ namespace ALCops.FormattingCop.Test
                 ["Property", "DataType", "TriggerDeclaration"],
                 testCase,
                 "14.0"
+            );
+
+            SkipTestIfVersionIsTooLow(
+                ["TestType"],
+                testCase,
+                "16.0"
             );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -59,14 +66,21 @@ namespace ALCops.FormattingCop.Test
         [TestCase("OptionDataType")]
         [TestCase("Property")]
         [TestCase("TextConstDataType")]
+        [TestCase("TestType")]
         [TestCase("TriggerDeclaration")]
         [TestCase("VariableNamedAfterKeyword")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["Property", "DataType", "TriggerDeclaration"],
+                ["Property", "DataType", "TriggerDeclaration", "TestType"],
                 testCase,
                 "14.0"
+            );
+
+            SkipTestIfVersionIsTooLow(
+                ["TestType"],
+                testCase,
+                "16.0"
             );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/TestType.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/TestType.al
@@ -1,0 +1,5 @@
+codeunit 50100 "My Test Codeunit"
+{
+    Subtype = Test;
+    [|TESTTYPE|] = [|UNITTEST|];
+}

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/TestType.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/TestType.al
@@ -1,0 +1,5 @@
+codeunit 50100 "My Test Codeunit"
+{
+    Subtype = Test;
+    [|TestType|] = [|UnitTest|];
+}

--- a/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
+++ b/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
@@ -664,6 +664,7 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
             { "TestHttpRequestPolicy",  EnumProvider.TestHttpRequestPolicyKind.CanonicalNames },
             { "TestIsolation",          EnumProvider.TestIsolationKind.CanonicalNames },
             { "TestPermissions",        EnumProvider.TestPermissionsKind.CanonicalNames },
+            { "TestType",               EnumProvider.TestTypeKind.CanonicalNames },
             { "TextEncoding",           EnumProvider.TextEncodingKind.CanonicalNames },
             { "TextType",               EnumProvider.TextTypeKind.CanonicalNames },
             { "Type",                   EnumProvider.MergeCanonicalNames(


### PR DESCRIPTION
Add TestTypeKind enum to EnumProvider and register it in the CasingMismatchIdentifier property value dictionaries. This resolves the false positive FC0002i diagnostic when using the TestType property introduced in BC runtime 16.0.

Closes #133