### PR TITLE
fix: exclude test codeunits from DC0004 (PublicProcedureRequiresDocumentation)

### DIFF
--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/TestCodeunit.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/TestCodeunit.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyTestCodeunit
+{
+    Subtype = Test;
+
+    [Test]
+    procedure [|MyTestProcedure|]()
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/TestCodeunitHandlerMethod.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/NoDiagnostic/TestCodeunitHandlerMethod.al
@@ -1,0 +1,19 @@
+codeunit 50100 MyTestCodeunit
+{
+    Subtype = Test;
+
+    [Test]
+    procedure [|MyTestProcedure|]()
+    begin
+    end;
+
+    [MessageHandler]
+    procedure [|MyMessageHandler|](Message: Text[1024])
+    begin
+    end;
+
+    [ConfirmHandler]
+    procedure [|MyConfirmHandler|](Question: Text[1024]; var Reply: Boolean)
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/PublicProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop.Test/Rules/PublicProcedureRequiresDocumentation/PublicProcedureRequiresDocumentation.cs
@@ -37,6 +37,8 @@ namespace ALCops.DocumentationCop.Test
         [TestCase("ProcedureDocumentationCommentWithMultipleAttributes")]
         [TestCase("ProcedureInternal")]
         [TestCase("ProcedureLocal")]
+        [TestCase("TestCodeunit")]
+        [TestCase("TestCodeunitHandlerMethod")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.DocumentationCop/Analyzers/PublicProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/PublicProcedureRequiresDocumentation.cs
@@ -25,8 +25,13 @@ public sealed class PublicProcedureRequiresDocumentation : DiagnosticAnalyzer
         if (ctx.IsObsolete() || ctx.Node is not MethodDeclarationSyntax method)
             return;
 
+        var containingObject = ctx.ContainingSymbol.GetContainingObjectTypeSymbol();
+
         // Rule applies only when the containing object itself is public
-        if (ctx.ContainingSymbol.GetContainingObjectTypeSymbol().DeclaredAccessibility != EnumProvider.Accessibility.Public)
+        if (containingObject.DeclaredAccessibility != EnumProvider.Accessibility.Public)
+            return;
+
+        if (IsTestCodeunit(containingObject))
             return;
 
         var accessibilityToken = method.ProcedureKeyword.GetPreviousToken();
@@ -50,5 +55,11 @@ public sealed class PublicProcedureRequiresDocumentation : DiagnosticAnalyzer
         return trivia.Any(t =>
             t.Kind == EnumProvider.SyntaxKind.SingleLineDocumentationCommentTrivia ||
             t.Kind == EnumProvider.SyntaxKind.MultiLineDocumentationCommentTrivia);
+    }
+
+    private static bool IsTestCodeunit(IObjectTypeSymbol symbol)
+    {
+        var subtype = symbol.GetEnumPropertyValue<CodeunitSubtypeKind>(EnumProvider.PropertyKind.Subtype);
+        return subtype is not null && subtype == EnumProvider.CodeunitSubtypeKind.Test;
     }
 }


### PR DESCRIPTION
Skip procedures in codeunits with Subtype = Test to avoid diagnostics on [Test] methods and handler methods that never serve as public API.

Closes #146