### PR TITLE
fix(PC0026): skip diagnostic on API pages without exposed fields

### DIFF
--- a/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/MandatoryFieldMissingOnApiPage.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/MandatoryFieldMissingOnApiPage.cs
@@ -6,7 +6,7 @@ namespace ALCops.PlatformCop.Test
     public class MandatoryFieldMissingOnApiPage : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
-        private static readonly Analyzers.FilterStringSingleQuoteEscaping _analyzer = new();
+        private static readonly Analyzers.MandatoryFieldMissingOnApiPage _analyzer = new();
         private string _testCasePath;
 
         [SetUp]
@@ -36,6 +36,8 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("FieldsIdAndLastModifiedDateTimeDeclared")]
+        [TestCase("NoFieldsExposed")]
+        [TestCase("NoSourceTable")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/NoDiagnostic/NoFieldsExposed.al
+++ b/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/NoDiagnostic/NoFieldsExposed.al
@@ -1,0 +1,17 @@
+page 50100 [|MyApiPage|]
+{
+    PageType = API;
+    APIPublisher = 'myPublisher';
+    APIGroup = 'myGroup';
+    EntityName = 'myEntityName';
+    EntitySetName = 'myEntitySetName';
+    SourceTable = MyTable;
+    DelayedInsert = true;
+ 
+    [ServiceEnabled]
+    procedure GetData(request: Text): Text
+    begin
+    end;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/NoDiagnostic/NoSourceTable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/MandatoryFieldMissingOnApiPage/NoDiagnostic/NoSourceTable.al
@@ -1,0 +1,10 @@
+page 50100 [|MyApiPage|]
+{
+    PageType = API;
+    APIPublisher = 'myPublisher';
+    APIGroup = 'myGroup';
+    APIVersion = 'v1.0';
+    EntityName = 'myEntityName';
+    EntitySetName = 'myEntitySetName';
+    DelayedInsert = true;
+}

--- a/src/ALCops.PlatformCop/Analyzers/MandatoryFieldMissingOnApiPage.cs
+++ b/src/ALCops.PlatformCop/Analyzers/MandatoryFieldMissingOnApiPage.cs
@@ -40,6 +40,9 @@ public sealed class MandatoryFieldMissingOnApiPage : DiagnosticAnalyzer
             .Where(c => c.ControlKind == EnumProvider.ControlKind.Field && c.RelatedFieldSymbol is not null)
             .ToArray();
 
+        if (fieldControls.Length == 0)
+            return;
+
         var exposed = new HashSet<(string FieldName, string ControlName)>();
         foreach (var c in fieldControls)
         {


### PR DESCRIPTION
API pages that expose no field controls (e.g., service-only pages with [ServiceEnabled] procedures) no longer trigger PC0026. The rule now returns early when fieldControls is empty.

Also fixes a copy-paste error in the test class where _analyzer referenced FilterStringSingleQuoteEscaping instead of MandatoryFieldMissingOnApiPage.

Closes #150