### PR TITLE
fix(FC0002): use correct XmlPort casing for ObjectType option access

### DIFF
--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
@@ -33,6 +33,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("TextConstDataType")]
         [TestCase("TestType")]
         [TestCase("TriggerDeclaration")]
+        [TestCase("ObjectTypeOptionAccess")]
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
@@ -69,6 +70,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("TestType")]
         [TestCase("TriggerDeclaration")]
         [TestCase("VariableNamedAfterKeyword")]
+        [TestCase("ObjectTypeOptionAccess")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/ObjectTypeOptionAccess.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/ObjectTypeOptionAccess.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): ObjectType
+    begin
+        exit(ObjectType::[|xmlport|]);
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/ObjectTypeOptionAccess.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/ObjectTypeOptionAccess.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): ObjectType
+    begin
+        exit(ObjectType::[|XmlPort|]);
+    end;
+}

--- a/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
+++ b/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
@@ -418,7 +418,12 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
             CompareAgainstDictionary(ctx, expression.Identifier, _symbolKindDictionary);
 
             if (symbolKindDict.ContainsKey(nameText))
-                CompareAgainstDictionary(ctx, name.Identifier, _symbolKindDictionary);
+            {
+                var memberDict = string.Equals(expressionText, "ObjectType", StringComparison.OrdinalIgnoreCase)
+                    ? _objectTypeMemberDictionary
+                    : _symbolKindDictionary;
+                CompareAgainstDictionary(ctx, name.Identifier, memberDict);
+            }
         }
     }
 
@@ -622,6 +627,11 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
         builder["ObjectType"] = "ObjectType";
         return builder.ToImmutable();
     });
+
+    // ObjectType option members use SymbolKind enum names directly (e.g., XmlPort, not Xmlport).
+    private static readonly Lazy<ImmutableDictionary<string, string>> _objectTypeMemberDictionary = new(() =>
+        Enum.GetNames(typeof(SymbolKind))
+            .ToImmutableDictionary(s => s, s => s, StringComparer.OrdinalIgnoreCase));
 
     // Dynamically discovers canonical enum property values from the SDK's PropertyInfoLookup.
     // Iterates all SymbolKind × PropertyKind combinations and merges options per PropertyKind.


### PR DESCRIPTION
ObjectType::XmlPort was incorrectly flagged, suggesting Xmlport (lowercase p). The _symbolKindDictionary remaps XmlPort→Xmlport, which is correct for type references (Xmlport::MyXmlport) but wrong for ObjectType member access where the SymbolKind enum canonical form is XmlPort (uppercase P).

Add _objectTypeMemberDictionary using raw SymbolKind enum names and use it for right-side comparison when left side is ObjectType.

Cherry-picked from 9e698d3 (development) with conflict resolution.

Fixes #150