### PR TITLE
LC0095: Add UsePartialRecordsOnRead analyzer and code fix

### DIFF
--- a/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
@@ -1,0 +1,165 @@
+---
+applyTo: 'src/ALCops.LinterCop/**/UsePartialRecordsOnRead*'
+---
+
+# LC0095: UsePartialRecordsOnRead
+
+## Purpose
+
+Recommends using `SetLoadFields` (or `AddLoadFields`/`SetBaseLoadFields`) before read operations on local record variables. Without partial records, the runtime loads ALL normal fields including those from table extensions, causing unnecessary SQL joins and 2-9x slower data access.
+
+**References:**
+- [Discussion #155](https://github.com/ALCops/Analyzers/discussions/155)
+- [Community discussion](https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/218)
+- [MS Docs: Using Partial Records](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-partial-records)
+- [MS Docs: Record.SetLoadFields](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/record/record-setloadfields-method)
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `LC0095` |
+| Category | Performance |
+| Severity | Info |
+| Enabled by default | true |
+| MessageFormat | `Use SetLoadFields before '{0}.{1}()' to improve performance by loading only the fields that are needed.` |
+| Version gate | `Spring2021OrGreater` (SetLoadFields introduced in runtime 6.0, BC17) |
+
+## Design decisions
+
+These decisions were made during the initial design and should be preserved unless explicitly revisited:
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scope | Phase 1: local variables only | Global variables require cross-method analysis; deferred to Phase 2 |
+| Function pass | Suppress on ANY function/event pass (including built-in methods like PAGE.Run) | Conservative: avoids false positives when the callee might access any field |
+| Temporary tables | Skip | No SQL Server backing, no table extension join benefit. Matches AA0242 behavior |
+| Severity | Info | Performance suggestion, not a correctness issue |
+| Field access required | No (report on read operation alone) | User preference; may generate noise on patterns like `if Rec.Get(Key) then` |
+| RecordRef | Included | Skip temp/table-type checks (not statically determinable for RecordRef) |
+| Record table type | Normal only | Skip CDS, Exchange, temporary, and other non-SQL table types |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterCodeBlockAction` (not `RegisterOperationAction`) to analyze entire method/trigger bodies in a single pass. This avoids redundant walks when multiple read operations exist on the same variable.
+
+### Analysis flow
+
+1. Extract local variables of type `Record` (non-temp, Normal table) or `RecordRef` from `IMethodSymbol.LocalVariables`
+2. Get `IOperation` tree from the code block via `SemanticModel.GetOperation(body)`
+3. Walk with `SetLoadFieldsWalker` (extends `OperationWalker`), tracking per-variable:
+   - `ReadLocations`: Get, Find, FindFirst, FindLast, FindSet calls
+   - `HasLoadFieldsCall`: SetLoadFields, AddLoadFields, SetBaseLoadFields present
+   - `HasWriteOp`: Insert, Modify, ModifyAll, Delete, DeleteAll, Rename, TransferFields, Init, Copy
+   - `PassedToFunction`: Variable appears as argument to ANY invocation, or a non-built-in method is called ON the variable
+4. Report at each read location where none of the suppression conditions are met
+
+### Key implementation detail: argument checking
+
+The walker checks ALL invocations (both built-in and user-defined) for tracked variables in arguments. This is necessary because built-in methods like `PAGE.Run(PageId, Record)` pass the record to a page that will access its fields. The `GetVariableNameFromArgument` method only matches direct variable identifiers (e.g., `Item` in `PAGE.Run(PAGE::"Item Card", Item)`), not field access expressions (e.g., `MyTable."No."` in `SetRange`), so this doesn't cause false positives on record method arguments.
+
+## Known issues and workarounds
+
+### BoundObjectAccess InvalidCastException
+
+The SDK's `OperationExtensions.GetSymbol()` throws `InvalidCastException` when the operation instance is a `BoundObjectAccess`. This type reports `Kind = FieldAccess` but doesn't implement `IFieldAccess`, so the SDK's internal cast fails. The analyzer uses a `TryGetSymbol()` wrapper that catches `InvalidCastException` and returns null.
+
+This is an SDK bug. If a future SDK version fixes it, the try-catch becomes a no-op (harmless to keep).
+
+## Method classification
+
+### Read methods (trigger diagnostic)
+`Get`, `Find`, `FindFirst`, `FindLast`, `FindSet`
+
+### Load fields methods (suppress diagnostic)
+`SetLoadFields`, `AddLoadFields`, `SetBaseLoadFields`
+
+### Write/mutation methods (suppress entire variable)
+`Insert`, `Modify`, `ModifyAll`, `Delete`, `DeleteAll`, `Rename`, `TransferFields`, `Init`, `Copy`
+
+## Relationship to AA0242
+
+AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** to LC0095:
+
+- **AA0242**: Fires when `SetLoadFields` IS present but accessed fields are missing from it (detects JIT loads)
+- **LC0095**: Fires when `SetLoadFields` is entirely absent (recommends adding it)
+
+## Phase 2 roadmap (not yet implemented)
+
+- **Global variables**: Analyze all methods in the object; check access modifiers (protected variables can't use SetLoadFields from outside); detect writes across any method
+- **Parameter variables**: Analyze calling context to determine if the parameter is used only for reading
+- **Cross-procedure tracing**: Track record variables passed by `var` reference through call chains
+- **RecordRef enhanced**: Resolve the opened table at compile time when possible
+- **SetBaseLoadFields/AddLoadFields recommendations**: Separate rule for recommending one over the other
+
+## Test coverage
+
+26 test cases organized as:
+
+### HasDiagnostic (6 cases)
+| Test case | Scenario |
+|---|---|
+| LocalRecordGet | Basic Get() without SetLoadFields |
+| LocalRecordFindFirst | FindFirst() |
+| LocalRecordFindSet | FindSet() + Next loop |
+| LocalRecordFindLast | FindLast() |
+| LocalRecordFind | Find() |
+| LocalRecordMultipleReads | Multiple read ops on same variable (both should report) |
+
+### NoDiagnostic (16 cases)
+| Test case | Suppression reason |
+|---|---|
+| HasSetLoadFields | SetLoadFields already present |
+| HasAddLoadFields | AddLoadFields already present |
+| HasSetBaseLoadFields | SetBaseLoadFields already present |
+| HasModify | Write operation (Modify) |
+| HasInsert | Write operation (Insert) |
+| HasDelete | Write operation (Delete) |
+| HasDeleteAll | Write operation (DeleteAll) |
+| HasModifyAll | Write operation (ModifyAll) |
+| HasRename | Write operation (Rename) |
+| PassedToFunction | Variable passed to user-defined function |
+| PassedToEvent | Variable passed to IntegrationEvent publisher |
+| PassedToPageRun | Variable passed to PAGE.Run() |
+| TemporaryTable | Temporary record variable |
+| GlobalVariable | Global variable (Phase 1: skip) |
+| ParameterVariable | Parameter variable (not a local) |
+| IsEmptyOnly | Only IsEmpty call, no read operation |
+
+### HasFix (4 cases)
+| Test case | Scenario |
+|---|---|
+| SingleField | One field accessed, inserts SetLoadFields with that field |
+| MultipleFields | Two fields accessed, inserts SetLoadFields with both (sorted alphabetically) |
+| QuotedFieldName | Field with spaces, properly quoted in SetLoadFields |
+| NoFieldAccess | No field access found, falls back to primary key fields |
+
+## CodeFix: UsePartialRecordsOnReadCodeFixProvider
+
+### Purpose
+
+Provides a QuickFix "ALCops: Add SetLoadFields" that inserts a `SetLoadFields` call immediately before the read operation, pre-populated with the fields accessed on the variable in the method body.
+
+### Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scope | Record variables only (not RecordRef) | RecordRef.SetLoadFields takes integer field numbers, not statically determinable |
+| No field access case | Primary key fields as fallback | Establishes the partial records pattern; PK fields are always loaded |
+| Field detection | In the CodeFix via SemanticModel | Zero analyzer overhead; `Document.GetSemanticModelAsync()` is available |
+| Field ordering | Alphabetical (case-insensitive) | Deterministic output regardless of source order |
+| Field filtering | Normal fields only | Skip FlowField, FlowFilter, Blob (SetLoadFields returns false for these) |
+| Insertion position | New statement before the read operation's containing statement | Matches MS docs conventions |
+
+### Architecture
+
+1. **CodeFix receives** the diagnostic span
+2. **Gets SemanticModel** via `document.GetSemanticModelAsync()` (proven pattern from PossibleOverflowAssigning CodeFix)
+3. **Resolves the variable** and record type from the invocation instance
+4. **Walks the operation tree** with `FieldAccessCollector` (OperationWalker) to find all Normal fields accessed on the variable
+5. **Falls back to PK fields** when no Normal field accesses are found
+6. **Sorts fields alphabetically** for deterministic output
+7. **Builds** `Record.SetLoadFields(Record.Field1, Record.Field2)` syntax using `SyntaxFactory`
+8. **Inserts** before the read statement using `root.InsertNodesBefore()`

--- a/.github/instructions/netstandard21-compatibility.instructions.md
+++ b/.github/instructions/netstandard21-compatibility.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: 'src/ALCops.*/**'
+---
+
+# netstandard2.1 Backward Compatibility
+
+All analyzer and common projects multi-target in CI: `netstandard2.1;net8.0`. Several C# 9+ features require `System.Runtime.CompilerServices.IsExternalInit`, which does not exist in `netstandard2.1`. Code that compiles fine locally (net8.0 only) will fail in CI without conditional compilation guards.
+
+## Features that require guards
+
+| Feature | Problem on netstandard2.1 | Guard pattern |
+|---|---|---|
+| `record` / `record struct` | CS0518: `IsExternalInit` is not defined | `#if NETSTANDARD2_1` with manual struct/class |
+| `init` property accessors | CS0518: `IsExternalInit` is not defined | `#if NETSTANDARD2_1` with `set` accessor |
+| `with` expressions on structs | Depends on `IsExternalInit` | Avoid or guard with `#if` |
+
+## Required pattern for record types
+
+Use `#if NETSTANDARD2_1` to provide a manual struct for the older target, and a `record struct` for net8.0+:
+
+```csharp
+#if NETSTANDARD2_1
+    private readonly struct MyInfo
+    {
+        public string Name { get; }
+        public int Value { get; }
+
+        public MyInfo(string name, int value)
+        {
+            Name = name;
+            Value = value;
+        }
+    }
+#else
+    private readonly record struct MyInfo(string Name, int Value);
+#endif
+```
+
+## Required pattern for init-only properties
+
+Use `set` instead of `init` on netstandard2.1:
+
+```csharp
+#if NETSTANDARD2_1
+    public string? MyProperty { get; set; }
+#else
+    public string? MyProperty { get; init; }
+#endif
+```
+
+## Existing examples in the codebase
+
+| File | Pattern |
+|---|---|
+| `ALCops.LinterCop/Analyzers/CognitiveComplexityRecursionGraphService.cs` | `MethodDeclarationInfo` record struct |
+| `ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs` | `ReadInfo` record struct |
+| `ALCops.PlatformCop/Analyzers/TransferFieldsRelations.cs` | `ObjectName` and `TableRelation` record structs |
+| `ALCops.Common/Helpers/AppSourceCopConfigurationProvider.cs` | `init` to `set` accessor |
+| `ALCops.LinterCop/CodeFixes/BuiltInDateTimeMethod.cs` | `CodeFixProperties` record |
+| `ALCops.LinterCop/CodeFixes/ObjectIdInDeclaration.cs` | `CodeFixProperties` record |
+
+## Checklist before committing
+
+1. Search your new/modified files for `record `, `record struct`, and `{ get; init` patterns.
+2. If any are present, wrap them in `#if NETSTANDARD2_1` / `#else` / `#endif` guards.
+3. The netstandard2.1 block must use a regular `struct` or `class` with explicit constructor and get-only properties (no `init`).
+4. When in doubt, look at existing examples listed above.

--- a/.github/instructions/netstandard21-compatibility.instructions.md
+++ b/.github/instructions/netstandard21-compatibility.instructions.md
@@ -4,15 +4,41 @@ applyTo: 'src/ALCops.*/**'
 
 # netstandard2.1 Backward Compatibility
 
-All analyzer and common projects multi-target in CI: `netstandard2.1;net8.0`. Several C# 9+ features require `System.Runtime.CompilerServices.IsExternalInit`, which does not exist in `netstandard2.1`. Code that compiles fine locally (net8.0 only) will fail in CI without conditional compilation guards.
+All analyzer and common projects multi-target in CI: `netstandard2.1;net8.0`. Several C# 9+ features and newer SDK APIs are unavailable in `netstandard2.1`. Code that compiles fine locally (net8.0 only) will fail in CI without conditional compilation guards.
 
-## Features that require guards
+## C# language features that require guards
 
 | Feature | Problem on netstandard2.1 | Guard pattern |
 |---|---|---|
 | `record` / `record struct` | CS0518: `IsExternalInit` is not defined | `#if NETSTANDARD2_1` with manual struct/class |
 | `init` property accessors | CS0518: `IsExternalInit` is not defined | `#if NETSTANDARD2_1` with `set` accessor |
 | `with` expressions on structs | Depends on `IsExternalInit` | Avoid or guard with `#if` |
+
+## SDK API differences between target frameworks
+
+Some `Microsoft.Dynamics.Nav.CodeAnalysis` APIs only exist in newer SDK versions (net8.0). When using these APIs, provide a netstandard2.1 fallback.
+
+| API | Available in | netstandard2.1 workaround |
+|---|---|---|
+| `IFieldSymbol.Type` | net8.0 only | `fieldSymbol.OriginalDefinition.GetTypeSymbol()` |
+
+### Pattern for `IFieldSymbol.Type`
+
+```csharp
+#if NETSTANDARD2_1
+var fieldType = fieldSymbol.OriginalDefinition.GetTypeSymbol();
+if (fieldType?.NavTypeKind == EnumProvider.NavTypeKind.Blob)
+    return;
+#else
+if (fieldSymbol.Type?.NavTypeKind == EnumProvider.NavTypeKind.Blob)
+    return;
+#endif
+```
+
+Existing examples:
+- `ALCops.PlatformCop/Analyzers/RecordGetProcedureArguments.cs` (lines 129-133)
+- `ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs` (lines 552-556)
+- `ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs` (FieldAccessCollector)
 
 ## Required pattern for record types
 
@@ -64,4 +90,5 @@ Use `set` instead of `init` on netstandard2.1:
 1. Search your new/modified files for `record `, `record struct`, and `{ get; init` patterns.
 2. If any are present, wrap them in `#if NETSTANDARD2_1` / `#else` / `#endif` guards.
 3. The netstandard2.1 block must use a regular `struct` or `class` with explicit constructor and get-only properties (no `init`).
-4. When in doubt, look at existing examples listed above.
+4. Search for `IFieldSymbol` `.Type` usage; use `OriginalDefinition.GetTypeSymbol()` on netstandard2.1.
+5. When in doubt, look at existing examples listed above.

--- a/.github/instructions/netstandard21-compatibility.instructions.md
+++ b/.github/instructions/netstandard21-compatibility.instructions.md
@@ -20,9 +20,11 @@ Some `Microsoft.Dynamics.Nav.CodeAnalysis` APIs only exist in newer SDK versions
 
 | API | Available in | netstandard2.1 workaround |
 |---|---|---|
-| `IFieldSymbol.Type` | net8.0 only | `fieldSymbol.OriginalDefinition.GetTypeSymbol()` |
+| `IFieldSymbol.Type` | net8.0 only | `fieldSymbol.OriginalDefinition.GetTypeSymbol()` (requires `using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols`) |
 
 ### Pattern for `IFieldSymbol.Type`
+
+Requires `using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;` for the `GetTypeSymbol()` extension method on netstandard2.1.
 
 ```csharp
 #if NETSTANDARD2_1
@@ -90,5 +92,5 @@ Use `set` instead of `init` on netstandard2.1:
 1. Search your new/modified files for `record `, `record struct`, and `{ get; init` patterns.
 2. If any are present, wrap them in `#if NETSTANDARD2_1` / `#else` / `#endif` guards.
 3. The netstandard2.1 block must use a regular `struct` or `class` with explicit constructor and get-only properties (no `init`).
-4. Search for `IFieldSymbol` `.Type` usage; use `OriginalDefinition.GetTypeSymbol()` on netstandard2.1.
+4. Search for `IFieldSymbol` `.Type` usage; use `OriginalDefinition.GetTypeSymbol()` on netstandard2.1 (requires `using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols`).
 5. When in doubt, look at existing examples listed above.

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFind.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFind.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Find()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindFirst.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindFirst.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.FindFirst()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindLast.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindLast.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.FindLast()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindSet.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordFindSet.al
@@ -1,0 +1,28 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Decimal
+    var
+        MyTable: Record MyTable;
+        Total: Decimal;
+    begin
+        [|MyTable.FindSet()|];
+        repeat
+            Total += MyTable.Amount;
+        until MyTable.Next() = 0;
+        exit(Total);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGet.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGet.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordMultipleReads.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordMultipleReads.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        [|MyTable.FindFirst()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordRefFindFirst.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordRefFindFirst.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyRecordRef: RecordRef;
+    begin
+        MyRecordRef.Open(Database::MyTable);
+        [|MyRecordRef.FindFirst()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/current.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/current.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.FindFirst()|];
+        exit(MyTable.MyField + MyTable.Description);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+        field(3; Description; Text[250]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/expected.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/expected.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.Description, MyTable.MyField);
+        MyTable.FindFirst();
+        exit(MyTable.MyField + MyTable.Description);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+        field(3; Description; Text[250]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/current.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/current.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Boolean
+    var
+        MyTable: Record MyTable;
+    begin
+        exit([|MyTable.Get()|]);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Boolean
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable."Primary Key");
+        exit(MyTable.Get());
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/current.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/current.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable."My Field Name");
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; "My Field Name"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable."My Field Name");
+        MyTable.Get();
+        exit(MyTable."My Field Name");
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; "My Field Name"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/current.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/current.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        MyTable.Get();
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/CDSTable.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/CDSTable.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    TableType = CDS;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/GlobalVariable.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/GlobalVariable.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        MyTable: Record MyTable;
+
+    procedure MyProcedure(): Text
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasAddLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasAddLoadFields.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.AddLoadFields(MyTable.MyField);
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasCopy.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasCopy.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+        OtherTable: Record MyTable;
+    begin
+        MyTable.Copy(OtherTable);
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasDelete.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasDelete.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        MyTable.Delete();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasDeleteAll.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasDeleteAll.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetRange(MyTable.MyField, 'Test');
+        [|MyTable.DeleteAll()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasInit.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasInit.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Init();
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasInsert.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasInsert.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Init();
+        MyTable."Primary Key" := 'NEW';
+        MyTable.MyField := 'Test';
+        [|MyTable.Insert()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasModify.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasModify.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        MyTable.MyField := 'Updated';
+        MyTable.Modify();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasModifyAll.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasModifyAll.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetRange(MyTable.MyField, 'Test');
+        [|MyTable.ModifyAll(MyTable.MyField, 'Updated')|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasRename.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasRename.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        MyTable.Rename('NEW');
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetBaseLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetBaseLoadFields.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetBaseLoadFields();
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetLoadFields.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasTransferFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasTransferFields.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.TransferFields(MyTable);
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/IsEmptyOnly.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/IsEmptyOnly.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Boolean
+    var
+        MyTable: Record MyTable;
+    begin
+        exit([|MyTable.IsEmpty()|]);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ParameterVariable.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ParameterVariable.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyTable: Record MyTable): Text
+    begin
+        [|MyTable.Get()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToEvent.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToEvent.al
@@ -1,0 +1,29 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        OnAfterGetRecord(MyTable);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterGetRecord(MyRecord: Record MyTable)
+    begin
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToFunction.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToFunction.al
@@ -1,0 +1,29 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        ProcessRecord(MyTable);
+    end;
+
+    local procedure ProcessRecord(MyRecord: Record MyTable)
+    begin
+        // do something
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToPageRun.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/PassedToPageRun.al
@@ -1,0 +1,38 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        PAGE.Run(PAGE::MyPage, MyTable);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}
+
+page 50100 MyPage
+{
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            field("Primary Key"; Rec."Primary Key") { }
+            field(MyField; Rec.MyField) { }
+        }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/TemporaryTable.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/TemporaryTable.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        [|MyTable.FindFirst()|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -1,0 +1,90 @@
+using ALCops.LinterCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.LinterCop.Test
+{
+    public class UsePartialRecordsOnRead : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.UsePartialRecordsOnRead _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.UsePartialRecordsOnRead>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(UsePartialRecordsOnRead)));
+        }
+
+        [Test]
+        [TestCase("LocalRecordGet")]
+        [TestCase("LocalRecordFindFirst")]
+        [TestCase("LocalRecordFindSet")]
+        [TestCase("LocalRecordFindLast")]
+        [TestCase("LocalRecordFind")]
+        [TestCase("LocalRecordMultipleReads")]
+        [TestCase("LocalRecordRefFindFirst")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.UsePartialRecordsOnRead);
+        }
+
+        [Test]
+        [TestCase("HasSetLoadFields")]
+        [TestCase("HasAddLoadFields")]
+        [TestCase("HasSetBaseLoadFields")]
+        [TestCase("HasModify")]
+        [TestCase("HasInsert")]
+        [TestCase("HasDelete")]
+        [TestCase("HasDeleteAll")]
+        [TestCase("HasModifyAll")]
+        [TestCase("HasRename")]
+        [TestCase("PassedToFunction")]
+        [TestCase("PassedToEvent")]
+        [TestCase("PassedToPageRun")]
+        [TestCase("TemporaryTable")]
+        [TestCase("GlobalVariable")]
+        [TestCase("ParameterVariable")]
+        [TestCase("IsEmptyOnly")]
+        [TestCase("HasTransferFields")]
+        [TestCase("HasInit")]
+        [TestCase("HasCopy")]
+        [TestCase("CDSTable")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.UsePartialRecordsOnRead);
+        }
+
+        [Test]
+        [TestCase("SingleField")]
+        [TestCase("MultipleFields")]
+        [TestCase("QuotedFieldName")]
+        [TestCase("NoFieldAccess")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<UsePartialRecordsOnReadCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.UsePartialRecordsOnRead);
+        }
+    }
+}

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.cs
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.cs
@@ -769,6 +769,42 @@ namespace ALCops.LinterCop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ALCops: Add SetLoadFields.
+        /// </summary>
+        internal static string UsePartialRecordsOnReadCodeAction {
+            get {
+                return ResourceManager.GetString("UsePartialRecordsOnReadCodeAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When reading records from the database using Get, Find, FindFirst, FindLast, or FindSet, use SetLoadFields to specify which fields to load. This avoids loading all normal fields (including those from table extensions), reducing SQL joins and data transfer. For performance reasons, it is not recommended to use partial records on a record that will do inserts, deletes, renames, field transfers, or copies to temporary records..
+        /// </summary>
+        internal static string UsePartialRecordsOnReadDescription {
+            get {
+                return ResourceManager.GetString("UsePartialRecordsOnReadDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use SetLoadFields before &apos;{0}.{1}()&apos; to improve performance by loading only the fields that are needed..
+        /// </summary>
+        internal static string UsePartialRecordsOnReadMessageFormat {
+            get {
+                return ResourceManager.GetString("UsePartialRecordsOnReadMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use partial records on read operation.
+        /// </summary>
+        internal static string UsePartialRecordsOnReadTitle {
+            get {
+                return ResourceManager.GetString("UsePartialRecordsOnReadTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Instead of relying on Rec.Count(), consider using a Query object or a combination of Rec.Find(&apos;-&apos;) and Rec.Next() for faster and more efficient record checks..
         /// </summary>
         internal static string UseQueryOrFindWithNextInsteadOfCountDescription {

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -363,6 +363,18 @@
   <data name="UseSecretTextForSensitiveTextDescription" xml:space="preserve">
     <value>Using SecretText prevents confidential information such as API keys, tokens, passwords, and similar secrets from being exposed through the AL debugger during regular or snapshot debugging.</value>
   </data>
+  <data name="UsePartialRecordsOnReadTitle" xml:space="preserve">
+    <value>Use partial records on read operation</value>
+  </data>
+  <data name="UsePartialRecordsOnReadMessageFormat" xml:space="preserve">
+    <value>Use SetLoadFields before '{0}.{1}()' to improve performance by loading only the fields that are needed.</value>
+  </data>
+  <data name="UsePartialRecordsOnReadDescription" xml:space="preserve">
+    <value>When reading records from the database using Get, Find, FindFirst, FindLast, or FindSet, use SetLoadFields to specify which fields to load. This avoids loading all normal fields (including those from table extensions), reducing SQL joins and data transfer. For performance reasons, it is not recommended to use partial records on a record that will do inserts, deletes, renames, field transfers, or copies to temporary records.</value>
+  </data>
+  <data name="UsePartialRecordsOnReadCodeAction" xml:space="preserve">
+    <value>ALCops: Add SetLoadFields</value>
+  </data>
   <data name="AllowInCustomizationsRedundancyTitle" xml:space="preserve">
     <value>Redundant AllowInCustomizations on field</value>
   </data>

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -261,9 +261,6 @@
   <data name="InternalProcedureOnlyUsedInCurrentObjectDescription" xml:space="preserve">
     <value>This internal procedure is only referenced within its declaring object. Using internal visibility is unnecessary in this case. Making the procedure local reduces the exposed surface area and improves intent clarity.</value>
   </data>
-  <data name="DataClassificationRedundancyCodeAction" xml:space="preserve">
-    <value>ALCops: Remove redundant DataClassification</value>
-  </data>
   <data name="InterfaceObjectNameGuideTitle" xml:space="preserve">
     <value>Use the standard 'I' prefix for interface object names.</value>
   </data>

--- a/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
@@ -1,0 +1,209 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.LinterCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
+{
+    private static readonly HashSet<string> ReadMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Get", "Find", "FindFirst", "FindLast", "FindSet"
+    };
+
+    private static readonly HashSet<string> LoadFieldsMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SetLoadFields", "AddLoadFields", "SetBaseLoadFields"
+    };
+
+    private static readonly HashSet<string> WriteMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll",
+        "Rename", "TransferFields", "Init", "Copy"
+    };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UsePartialRecordsOnRead);
+
+    // SetLoadFields was introduced in runtime 6.0 (BC17, Fall 2020).
+    // Fall2020OrGreater would be ideal but is not available it seems
+    // Spring2021OrGreater (BC18) is the closest safe version guard available.
+    public override VersionCompatibility SupportedVersions =>
+        VersionProvider.VersionCompatibility.Spring2021OrGreater;
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterCodeBlockAction(this.AnalyzeCodeBlock);
+
+    private void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
+    {
+        if (context.IsObsolete() ||
+            context.CodeBlock is not MethodOrTriggerDeclarationSyntax methodOrTrigger)
+            return;
+
+        if (context.OwningSymbol is not IMethodSymbol methodSymbol)
+            return;
+
+        var body = methodOrTrigger.Body;
+        if (body is null)
+            return;
+
+        var trackedVariables = CollectEligibleLocalVariables(methodSymbol);
+        if (trackedVariables.Count == 0)
+            return;
+
+        var operation = context.SemanticModel.GetOperation(body, context.CancellationToken);
+        if (operation is null)
+            return;
+
+        var walker = new SetLoadFieldsWalker(trackedVariables, context.CancellationToken);
+        walker.Visit(operation);
+
+        foreach (var kvp in trackedVariables)
+        {
+            var state = kvp.Value;
+
+            if (state.ReadLocations.Count == 0 ||
+                state.HasLoadFieldsCall ||
+                state.HasWriteOp ||
+                state.PassedToFunction)
+                continue;
+
+            foreach (var readInfo in state.ReadLocations)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.UsePartialRecordsOnRead,
+                    readInfo.Location,
+                    kvp.Key, readInfo.MethodName));
+            }
+        }
+    }
+
+    private static Dictionary<string, VariableState> CollectEligibleLocalVariables(IMethodSymbol methodSymbol)
+    {
+        var result = new Dictionary<string, VariableState>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var local in methodSymbol.LocalVariables)
+        {
+            if (IsEligibleVariable(local))
+                result[local.Name] = new VariableState();
+        }
+
+        return result;
+    }
+
+    private static bool IsEligibleVariable(IVariableSymbol variable)
+    {
+        var type = variable.Type;
+        if (type is null)
+            return false;
+
+        if (type is IRecordTypeSymbol recordType)
+        {
+            if (recordType.Temporary)
+                return false;
+
+            if (recordType.OriginalDefinition is ITableTypeSymbol tableType
+                && tableType.TableType != EnumProvider.TableTypeKind.Normal)
+                return false;
+
+            return true;
+        }
+
+        if (type.NavTypeKind == EnumProvider.NavTypeKind.RecordRef)
+            return true;
+
+        return false;
+    }
+
+    private sealed class VariableState
+    {
+        public List<ReadInfo> ReadLocations { get; } = new();
+        public bool HasLoadFieldsCall { get; set; }
+        public bool HasWriteOp { get; set; }
+        public bool PassedToFunction { get; set; }
+    }
+
+    private readonly record struct ReadInfo(Location Location, string MethodName);
+
+    private sealed class SetLoadFieldsWalker : OperationWalker
+    {
+        private readonly Dictionary<string, VariableState> _trackedVariables;
+        private readonly CancellationToken _cancellationToken;
+
+        public SetLoadFieldsWalker(Dictionary<string, VariableState> trackedVariables,
+            CancellationToken cancellationToken)
+        {
+            _trackedVariables = trackedVariables;
+            _cancellationToken = cancellationToken;
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+            var instanceSymbol = operation.Instance?.GetSymbol();
+
+            if (instanceSymbol != null &&
+                _trackedVariables.TryGetValue(instanceSymbol.Name, out var state))
+            {
+                ClassifyInstanceMethodCall(operation, state);
+            }
+
+            CheckArgumentsForTrackedVariables(operation);
+
+            base.VisitInvocationExpression(operation);
+        }
+
+        private static void ClassifyInstanceMethodCall(IInvocationExpression operation, VariableState state)
+        {
+            var methodName = operation.TargetMethod.Name;
+
+            if (operation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
+            {
+                if (ReadMethods.Contains(methodName))
+                    state.ReadLocations.Add(new ReadInfo(operation.Syntax.GetLocation(), methodName));
+                else if (LoadFieldsMethods.Contains(methodName))
+                    state.HasLoadFieldsCall = true;
+                else if (WriteMethods.Contains(methodName))
+                    state.HasWriteOp = true;
+            }
+            else
+            {
+                // Non-built-in method called on the record variable (table-defined method)
+                state.PassedToFunction = true;
+            }
+        }
+
+        private void CheckArgumentsForTrackedVariables(IInvocationExpression operation)
+        {
+            for (int i = 0; i < operation.Arguments.Length; i++)
+            {
+                var varName = GetVariableNameFromArgument(operation.Arguments[i]);
+                if (varName != null && _trackedVariables.TryGetValue(varName, out var state))
+                    state.PassedToFunction = true;
+            }
+        }
+
+        private static string? GetVariableNameFromArgument(IArgument argument)
+        {
+            var value = argument.Value;
+
+            if (value is IConversionExpression conversion)
+            {
+                if (conversion.Syntax is IdentifierNameSyntax convIdent)
+                    return convIdent.Identifier.ValueText;
+
+                value = conversion.Operand;
+            }
+
+            if (value?.Syntax is IdentifierNameSyntax directIdent)
+                return directIdent.Identifier.ValueText;
+
+            return null;
+        }
+    }
+}

--- a/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
@@ -128,7 +128,21 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
         public bool PassedToFunction { get; set; }
     }
 
+#if NETSTANDARD2_1
+    private readonly struct ReadInfo
+    {
+        public Location Location { get; }
+        public string MethodName { get; }
+
+        public ReadInfo(Location location, string methodName)
+        {
+            Location = location;
+            MethodName = methodName;
+        }
+    }
+#else
     private readonly record struct ReadInfo(Location Location, string MethodName);
+#endif
 
     private sealed class SetLoadFieldsWalker : OperationWalker
     {

--- a/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -5,6 +5,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;

--- a/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -230,19 +230,16 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
             if (fieldSymbol.FieldClass != EnumProvider.FieldClassKind.Normal)
                 return;
 
+#if NETSTANDARD2_1
+            var fieldType = fieldSymbol.OriginalDefinition.GetTypeSymbol();
+            if (fieldType?.NavTypeKind == EnumProvider.NavTypeKind.Blob)
+                return;
+#else
             if (fieldSymbol.Type?.NavTypeKind == EnumProvider.NavTypeKind.Blob)
                 return;
+#endif
 
-            ISymbol? instanceSymbol = null;
-            try
-            {
-                instanceSymbol = operation.Instance?.GetSymbol();
-            }
-            catch (InvalidCastException)
-            {
-                // BoundObjectAccess SDK bug workaround
-            }
-
+            ISymbol? instanceSymbol = operation.Instance?.GetSymbol();
             if (instanceSymbol is null ||
                 !string.Equals(instanceSymbol.Name, _variableName, StringComparison.OrdinalIgnoreCase))
                 return;

--- a/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -1,0 +1,253 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.LinterCop.CodeFixes;
+
+[CodeFixProvider(nameof(UsePartialRecordsOnReadCodeFixProvider))]
+public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
+{
+    private class UsePartialRecordsOnReadCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public UsePartialRecordsOnReadCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.UsePartialRecordsOnRead.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+         WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        SyntaxNode node = syntaxRoot.FindNode(span);
+        if (node is not InvocationExpressionSyntax invocation)
+            return;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        // Only offer fix for Record types (not RecordRef)
+        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken);
+        if (symbolInfo.Symbol is not IVariableSymbol variableSymbol)
+            return;
+
+        if (variableSymbol.Type is not IRecordTypeSymbol)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(node, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static UsePartialRecordsOnReadCodeAction CreateCodeAction(
+        SyntaxNode node, Document document, bool generateFixAll)
+    {
+        return new UsePartialRecordsOnReadCodeAction(
+            LinterCopAnalyzers.UsePartialRecordsOnReadCodeAction,
+            ct => InsertSetLoadFields(document, node, ct),
+            nameof(UsePartialRecordsOnReadCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> InsertSetLoadFields(
+        Document document, SyntaxNode node, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+        Task<SemanticModel> semanticModelTask = document.GetSemanticModelAsync(cancellationToken);
+
+        if (node is not InvocationExpressionSyntax invocation)
+            return document;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return document;
+
+        var semanticModel = await semanticModelTask.ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken);
+        if (symbolInfo.Symbol is not IVariableSymbol variableSymbol)
+            return document;
+
+        if (variableSymbol.Type is not IRecordTypeSymbol recordType)
+            return document;
+
+        var variableName = variableSymbol.Name;
+
+        // Collect accessed field names from the method body
+        var fieldNames = CollectAccessedFields(
+            invocation, variableName, recordType, semanticModel, cancellationToken);
+
+        // Build SetLoadFields invocation statement
+        var setLoadFieldsStatement = BuildSetLoadFieldsStatement(variableName, fieldNames);
+
+        // Find the statement containing the read operation
+        var containingStatement = FindContainingStatement(invocation);
+        if (containingStatement is null)
+            return document;
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var newRoot = root.InsertNodesBefore(containingStatement, new[] { setLoadFieldsStatement });
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static List<string> CollectAccessedFields(
+        InvocationExpressionSyntax readInvocation,
+        string variableName,
+        IRecordTypeSymbol recordType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Find the containing method/trigger body (not an inner begin..end block)
+        var block = readInvocation.FirstAncestorOrSelf<MethodOrTriggerDeclarationSyntax>()?.Body;
+        if (block is null)
+            return GetPrimaryKeyFieldNames(recordType);
+
+        var operation = semanticModel.GetOperation(block, cancellationToken);
+        if (operation is null)
+            return GetPrimaryKeyFieldNames(recordType);
+
+        var collector = new FieldAccessCollector(variableName);
+        collector.Visit(operation);
+
+        if (collector.AccessedFields.Count == 0)
+            return GetPrimaryKeyFieldNames(recordType);
+
+        var fields = collector.AccessedFields.ToList();
+        fields.Sort(StringComparer.OrdinalIgnoreCase);
+        return fields;
+    }
+
+    private static List<string> GetPrimaryKeyFieldNames(IRecordTypeSymbol recordType)
+    {
+        var result = new List<string>();
+
+        if (recordType.OriginalDefinition is ITableTypeSymbol tableType)
+        {
+            var pkFields = tableType.PrimaryKey?.Fields;
+            if (pkFields is { IsDefault: false })
+            {
+                foreach (var field in pkFields)
+                    result.Add(field.Name);
+            }
+        }
+
+        return result;
+    }
+
+    private static ExpressionStatementSyntax BuildSetLoadFieldsStatement(
+        string variableName, List<string> fieldNames)
+    {
+        var variableIdentifier = SyntaxFactory.IdentifierName(variableName);
+
+        var setLoadFieldsAccess = SyntaxFactory.MemberAccessExpression(
+            variableIdentifier,
+            SyntaxFactory.Token(EnumProvider.SyntaxKind.DotToken),
+            SyntaxFactory.IdentifierName("SetLoadFields"));
+
+        var arguments = new SeparatedSyntaxList<CodeExpressionSyntax>();
+        foreach (var fieldName in fieldNames)
+        {
+            var fieldAccess = SyntaxFactory.MemberAccessExpression(
+                SyntaxFactory.IdentifierName(variableName),
+                SyntaxFactory.Token(EnumProvider.SyntaxKind.DotToken),
+                SyntaxFactory.IdentifierName(
+                    SyntaxFactory.Identifier(fieldName.QuoteIdentifierIfNeededWithReflection())));
+
+            arguments = arguments.Add(fieldAccess);
+        }
+
+        var argumentList = SyntaxFactory.ArgumentList(arguments);
+        var invocationExpr = SyntaxFactory.InvocationExpression(setLoadFieldsAccess, argumentList);
+
+        return SyntaxFactory.ExpressionStatement(invocationExpr,
+            SyntaxFactory.Token(EnumProvider.SyntaxKind.SemicolonToken));
+    }
+
+    private static StatementSyntax? FindContainingStatement(SyntaxNode node)
+    {
+        var current = node.Parent;
+        while (current != null)
+        {
+            if (current is StatementSyntax statement && current.Parent is BlockSyntax)
+                return statement;
+            current = current.Parent;
+        }
+        return null;
+    }
+
+    private sealed class FieldAccessCollector : OperationWalker
+    {
+        private readonly string _variableName;
+
+        public HashSet<string> AccessedFields { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public FieldAccessCollector(string variableName)
+        {
+            _variableName = variableName;
+        }
+
+        public override void VisitFieldAccess(IFieldAccess operation)
+        {
+            var fieldSymbol = operation.FieldSymbol;
+            if (fieldSymbol is null)
+                return;
+
+            if (fieldSymbol.FieldClass != EnumProvider.FieldClassKind.Normal)
+                return;
+
+            if (fieldSymbol.Type?.NavTypeKind == EnumProvider.NavTypeKind.Blob)
+                return;
+
+            ISymbol? instanceSymbol = null;
+            try
+            {
+                instanceSymbol = operation.Instance?.GetSymbol();
+            }
+            catch (InvalidCastException)
+            {
+                // BoundObjectAccess SDK bug workaround
+            }
+
+            if (instanceSymbol is null ||
+                !string.Equals(instanceSymbol.Name, _variableName, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            AccessedFields.Add(fieldSymbol.Name);
+        }
+    }
+}

--- a/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -7,7 +7,6 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 
 namespace ALCops.LinterCop.CodeFixes;

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -264,6 +264,16 @@ public static class DiagnosticDescriptors
         description: LinterCopAnalyzers.UseQueryOrFindWithNextInsteadOfCountDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseQueryOrFindWithNextInsteadOfCount));
 
+    public static readonly DiagnosticDescriptor UsePartialRecordsOnRead = new(
+        id: DiagnosticIds.UsePartialRecordsOnRead,
+        title: LinterCopAnalyzers.UsePartialRecordsOnReadTitle,
+        messageFormat: LinterCopAnalyzers.UsePartialRecordsOnReadMessageFormat,
+        category: Category.Performance,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.UsePartialRecordsOnReadDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.UsePartialRecordsOnRead));
+
     public static readonly DiagnosticDescriptor UseSecretTextForSensitiveText = new(
         id: DiagnosticIds.UseSecretTextForSensitiveText,
         title: LinterCopAnalyzers.UseSecretTextForSensitiveTextTitle,

--- a/src/ALCops.LinterCop/DiagnosticIds.cs
+++ b/src/ALCops.LinterCop/DiagnosticIds.cs
@@ -28,4 +28,5 @@ public static class DiagnosticIds
     public static readonly string CognitiveComplexityIncrement = "LC0089i";
     public static readonly string CognitiveComplexityThresholdExceeded = "LC0090";
     public static readonly string AllowInCustomizationsRedundancy = "LC0094";
+    public static readonly string UsePartialRecordsOnRead = "LC0095";
 }


### PR DESCRIPTION
Recommend using SetLoadFields before read operations on local record variables to improve performance by avoiding unnecessary SQL joins from table extensions.

Analyzer:
- Registers via RegisterCodeBlockAction for single-pass method analysis
- Reports on Get, Find, FindFirst, FindLast, FindSet without prior SetLoadFields/AddLoadFields/SetBaseLoadFields
- Supports both Record and RecordRef variables
- Suppresses for: temp tables, non-Normal table types, global/parameter variables, write operations (Insert, Modify, Delete, etc.), and variables passed to any function or event
- Gated to Spring2021OrGreater (runtime 6.0+)

CodeFix (Record variables only):
- Auto-inserts SetLoadFields populated with accessed Normal fields
- Falls back to primary key fields when no field access is found
- Fields sorted alphabetically for deterministic output

Tests: 7 HasDiagnostic, 20 NoDiagnostic, 4 HasFix