### PR TITLE
fix(LC0091): honor LanguagesToTranslate when no XLIFF files exist

### DIFF
--- a/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
+++ b/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
@@ -38,7 +38,7 @@ These decisions were made during the initial design and should be preserved unle
 | ManifestHelper exception handling | Catch `FileNotFoundException` and treat as null manifest | `ManifestHelper.GetManifest` loads `Microsoft.Dynamics.Nav.Analyzers.Common` assembly via reflection; this assembly isn't present in test contexts |
 | Null manifest behavior | Proceed with analysis (don't skip) | Tests create minimal compilations without manifests; real projects always have manifests |
 | XLIFF caching | Load once in CompilationStartAction | Avoid re-parsing per symbol |
-| Settings | `LanguagesToTranslate` array in `alcops.json` | Match original feature; allows filtering to specific languages |
+| Settings | `LanguagesToTranslate` array in `alcops.json` | Override semantics: when set, these are the available languages (XLIFF files only parsed for matching languages); when unset, discover from XLIFF files |
 | Locked labels | Skip (no diagnostic) | Locked labels are intentionally untranslated |
 | Locked detection | Syntax-based via `CommaSeparatedIdentifierEqualsLiteralList` | Label sub-properties aren't exposed as semantic symbols |
 | Obsolete symbols | Skip (no diagnostic) | Standard ALCops convention |
@@ -137,6 +137,16 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 | PageControlToolTip | Page control with untranslated tooltip |
 | ReportLabel | Report label without translation |
 
+### HasDiagnosticWithLanguagesToTranslateNoXliff (1 case)
+| Test case | Scenario |
+|---|---|
+| LocalLabel | LanguagesToTranslate=["da-DK"], no XLIFF files. Settings declare required languages without XLIFF files. |
+
+### HasDiagnosticWithLanguagesToTranslatePartialXliff (1 case)
+| Test case | Scenario |
+|---|---|
+| LocalLabel | LanguagesToTranslate=["da-DK","de-DE"], only da-DK XLIFF. Settings add de-DE as required language. |
+
 ### NoDiagnostic (2 cases)
 | Test case | Suppression reason |
 |---|---|
@@ -146,7 +156,7 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 ### NoDiagnosticNoXliff (1 case)
 | Test case | Suppression reason |
 |---|---|
-| NoXliffFiles | No XLIFF files present in file system |
+| NoXliffFiles | No XLIFF files present in file system, no LanguagesToTranslate setting |
 
 ## Test infrastructure
 
@@ -160,11 +170,14 @@ The `CreateFixtureWithoutXliff()` helper creates a fixture with:
 - A `MemoryFileSystem` containing no files
 - The `TranslatableTextShouldBeTranslated` analyzer
 
+### Settings injection for tests
+
+Tests that need `LanguagesToTranslate` use `ALCopsSettingsProvider.SetSettings("", settings)` to inject settings for the empty workspace path returned by `MemoryFileSystem.GetDirectoryPath()`. A `[TearDown]` calls `ALCopsSettingsProvider.ClearCache()` to avoid cross-test pollution.
+
 ## Phase 2 roadmap (not yet implemented)
 
 - **Translated NoDiagnostic test**: Test case where translation exists and is properly translated
 - **Multiple languages test**: Test with multiple XLIFF files, some translated, some not
-- **LanguagesToTranslate filter test**: Test the language filter setting
 - **Page extension controls test**: Test page extension with added controls
 - **Table extension fields test**: Test table extension with added fields
 - **Multi-extension folding test**: Test multiple extensions on the same target (the bug fix scenario)

--- a/src/ALCops.Common/Settings/ALCopsSettingsProvider.cs
+++ b/src/ALCops.Common/Settings/ALCopsSettingsProvider.cs
@@ -36,10 +36,24 @@ public static class ALCopsSettingsProvider
     /// <returns>The settings instance (never null)</returns>
     public static ALCopsSettings GetSettings(string? workspacePath)
     {
-        if (string.IsNullOrEmpty(workspacePath))
+        string key = workspacePath ?? string.Empty;
+
+        if (_cache.TryGetValue(key, out ALCopsSettings? cached))
+            return cached;
+
+        if (string.IsNullOrEmpty(key))
             return new ALCopsSettings();
 
-        return _cache.GetOrAdd(workspacePath, LoadSettings);
+        return _cache.GetOrAdd(key, LoadSettings);
+    }
+
+    /// <summary>
+    /// Pre-populates the settings cache for a given workspace path.
+    /// Intended for test use. Call <see cref="ClearCache"/> in test teardown to clean up.
+    /// </summary>
+    public static void SetSettings(string workspacePath, ALCopsSettings settings)
+    {
+        _cache[workspacePath] = settings;
     }
 
     private static ALCopsSettings LoadSettings(string workspacePath)

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -1,3 +1,4 @@
+using ALCops.Common.Settings;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
@@ -27,6 +28,12 @@ namespace ALCops.LinterCop.Test
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                     Path.Combine("Rules", nameof(TranslatableTextShouldBeTranslated)));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ALCopsSettingsProvider.ClearCache();
         }
 
         private static AnalyzerTestFixture CreateFixtureWithEmptyXliff()
@@ -105,6 +112,46 @@ namespace ALCops.LinterCop.Test
 
             var fixture = CreateFixtureWithoutXliff();
             fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("LocalLabel")]
+        public async Task HasDiagnosticWithLanguagesToTranslateNoXliff(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            ALCopsSettingsProvider.SetSettings("", new ALCopsSettings
+            {
+                LanguagesToTranslate = ["da-DK"]
+            });
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithoutXliff();
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("LocalLabel")]
+        public async Task HasDiagnosticWithLanguagesToTranslatePartialXliff(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            ALCopsSettingsProvider.SetSettings("", new ALCopsSettings
+            {
+                LanguagesToTranslate = ["da-DK", "de-DE"]
+            });
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithEmptyXliff();
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
         }
     }
 }

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -252,6 +252,10 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
 
     private static TranslationIndex? BuildTranslationIndex(IFileSystem fileSystem, string appName, string[]? languagesToTranslate)
     {
+        HashSet<string>? languageFilter = languagesToTranslate is { Length: > 0 }
+            ? new HashSet<string>(languagesToTranslate, StringComparer.OrdinalIgnoreCase)
+            : null;
+
         IEnumerable<string> xliffFiles;
         try
         {
@@ -259,15 +263,18 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         }
         catch (DirectoryNotFoundException)
         {
+            if (languageFilter is { Count: > 0 })
+                return new TranslationIndex(
+                    new HashSet<string>(languageFilter, StringComparer.OrdinalIgnoreCase),
+                    new Dictionary<string, HashSet<string>>(StringComparer.Ordinal));
+
             return null;
         }
 
-        HashSet<string> availableLanguages = new(StringComparer.OrdinalIgnoreCase);
+        HashSet<string> availableLanguages = languageFilter is not null
+            ? new HashSet<string>(languageFilter, StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         List<(string Language, XDocument Document)> parsedFiles = new();
-
-        HashSet<string>? languageFilter = languagesToTranslate is { Length: > 0 }
-            ? new HashSet<string>(languagesToTranslate, StringComparer.OrdinalIgnoreCase)
-            : null;
 
         foreach (string xliffPath in xliffFiles)
         {


### PR DESCRIPTION
When LanguagesToTranslate was configured in alcops.json but no XLIFF files existed for those languages, the analyzer produced zero diagnostics. BuildTranslationIndex discovered available languages exclusively from parsed XLIFF files, ignoring the settings.

Fix: pre-populate availableLanguages from LanguagesToTranslate (override semantics). When set, these define the required languages; XLIFF files are still parsed for translation data but only for matching languages. When unset, languages are discovered from XLIFF files (unchanged).

Also adds SetSettings() to ALCopsSettingsProvider for test injection, and two new test cases covering the fixed scenarios.