### PR TITLE
feat: add LC0096 UnnecessaryRecordParameterInMethodCall analyzer

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -1,0 +1,851 @@
+---
+applyTo: 'src/ALCops.*/Analyzers/**'
+---
+
+# ALCops Analyzer Development Guide
+
+ALCops Analyzers is a collection of 6 AL code analyzers for Business Central, built on the `Microsoft.Dynamics.Nav.CodeAnalysis` SDK. Each analyzer ("cop") lives in its own project and targets a specific concern.
+
+## Project Structure
+
+```
+src/
+  ALCops.ApplicationCop/       # AC prefix - Business logic and application patterns
+  ALCops.DocumentationCop/     # DC prefix - Code documentation rules
+  ALCops.FormattingCop/        # FC prefix - Code style and formatting
+  ALCops.LinterCop/            # LC prefix - General linting and code quality
+  ALCops.PlatformCop/          # PC prefix - Platform correctness and runtime safety
+  ALCops.TestAutomationCop/    # TA prefix - Test codeunit conventions
+  ALCops.Common/               # Shared utilities, extensions, reflection helpers
+  ALCops.Analyzers/            # Umbrella package that bundles all cops
+```
+
+Each cop project follows the same internal layout:
+
+```
+ALCops.<CopName>/
+  Analyzers/                   # Analyzer classes (one class per rule or closely related rules)
+  CodeFixes/                   # Optional code fix providers
+  DiagnosticIds.cs             # All diagnostic ID constants for this cop
+  DiagnosticDescriptors.cs     # All DiagnosticDescriptor definitions for this cop
+  ALCops.<CopName>Analyzers.resx  # Resource file for diagnostic messages
+```
+
+## Diagnostic ID Conventions
+
+Each cop uses a 2-letter prefix followed by a 4-digit number:
+
+| Cop               | Prefix | Example |
+|--------------------|--------|---------|
+| ApplicationCop     | AC     | AC0001  |
+| DocumentationCop   | DC     | DC0001  |
+| FormattingCop      | FC     | FC0001  |
+| LinterCop          | LC     | LC0003  |
+| PlatformCop        | PC     | PC0001  |
+| TestAutomationCop  | TA     | TA0001  |
+
+IDs are defined as `public static readonly string` in `DiagnosticIds.cs`:
+
+```csharp
+namespace ALCops.PlatformCop;
+
+public static class DiagnosticIds
+{
+    public static readonly string EditableFlowField = "PC0001";
+    public static readonly string AutoIncrementInTemporaryTable = "PC0002";
+    // ...
+}
+```
+
+The constant name is a PascalCase description of the rule. Choose the next available number in the sequence for the cop you are adding to. Check the existing IDs first to avoid gaps or collisions.
+
+## DiagnosticDescriptors
+
+Each cop has a `DiagnosticDescriptors.cs` file that constructs `DiagnosticDescriptor` instances. These reference:
+- The ID from `DiagnosticIds`
+- Messages from the `.resx` resource file (via the auto-generated resource class)
+- A category from the inner `Category` class
+- A help URI pointing to alcops.dev
+
+```csharp
+using System.Globalization;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace ALCops.PlatformCop;
+
+public static class DiagnosticDescriptors
+{
+    public static readonly DiagnosticDescriptor AutoIncrementInTemporaryTable = new(
+        id: DiagnosticIds.AutoIncrementInTemporaryTable,
+        title: PlatformCopAnalyzers.AutoIncrementInTemporaryTableTitle,
+        messageFormat: PlatformCopAnalyzers.AutoIncrementInTemporaryTableMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.AutoIncrementInTemporaryTableDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AutoIncrementInTemporaryTable));
+
+    // Help URI format: https://alcops.dev/docs/analyzers/<copname>/<id>/
+    public static string GetHelpUri(string identifier)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "https://alcops.dev/docs/analyzers/platformcop/{0}/",
+            identifier.ToLower());
+    }
+
+    internal static class Category
+    {
+        public const string Design = "Design";
+        public const string Naming = "Naming";
+        public const string Style = "Style";
+        public const string Usage = "Usage";
+        public const string Performance = "Performance";
+        public const string Security = "Security";
+    }
+}
+```
+
+Key points:
+- The descriptor field name must match the `DiagnosticIds` constant name.
+- `title` uses the `*Title` resource, `messageFormat` uses `*MessageFormat`, `description` uses `*Description`.
+- `messageFormat` supports `{0}`, `{1}` placeholders for parameterized messages passed via `Diagnostic.Create(...)`.
+- `defaultSeverity` is typically `Warning`. Use `Error` for rules that catch definite runtime failures, `Info` for suggestions/metrics.
+- `isEnabledByDefault` is `true` for most rules. Set to `false` for opt-in rules (metrics, opinionated style).
+- The `GetHelpUri` format varies per cop: replace `platformcop` with `lintercop`, `applicationcop`, etc.
+
+## Resource Files (.resx)
+
+Diagnostic messages live in `ALCops.<CopName>Analyzers.resx`. The build auto-generates a strongly-typed class (e.g., `PlatformCopAnalyzers`, `LinterCopAnalyzers`) from this file.
+
+Naming convention for each rule (using `AutoIncrementInTemporaryTable` as example):
+
+```xml
+<data name="AutoIncrementInTemporaryTableTitle" xml:space="preserve">
+  <value>AutoIncrement fields are not supported in temporary tables</value>
+</data>
+<data name="AutoIncrementInTemporaryTableMessageFormat" xml:space="preserve">
+  <value>AutoIncrement is used in a table with TableType = Temporary, which will cause a runtime error. Remove AutoIncrement or make the table non-temporary.</value>
+</data>
+<data name="AutoIncrementInTemporaryTableDescription" xml:space="preserve">
+  <value>AutoIncrement relies on SQL Server to generate the next value when inserting records. Temporary tables are only in-memory in Business Central and are not created on SQL Server, so SQL Server cannot generate AutoIncrement values. This results in runtime failures when code inserts into the temporary table.</value>
+</data>
+```
+
+Required entries per rule:
+- `<RuleName>Title` - short summary (used as the diagnostic title)
+- `<RuleName>MessageFormat` - the message shown to the user, may contain `{0}`, `{1}` placeholders
+- `<RuleName>Description` - detailed explanation of why this rule exists
+
+Optional entry:
+- `<RuleName>CodeAction` - display text for an associated code fix (e.g., `ALCops: Remove redundant ApplicationArea`)
+
+For parameterized messages, use standard .NET format strings:
+```xml
+<data name="AccessPropertyExplicitlySetMessageFormat" xml:space="preserve">
+  <value>{0} '{1}' does not explicitly have the Access property set.</value>
+</data>
+```
+
+## Analyzer Class Pattern
+
+All analyzers inherit from `DiagnosticAnalyzer` and are decorated with `[DiagnosticAnalyzer]`.
+
+### Minimal Template (Symbol-based)
+
+```csharp
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace ALCops.<CopName>.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class MyNewAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MyNewRule);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSymbolAction(
+            this.AnalyzeSymbol,
+            EnumProvider.SymbolKind.Table  // register for relevant symbol kinds
+        );
+
+    private void AnalyzeSymbol(SymbolAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete())  // always skip obsolete symbols
+            return;
+
+        // Analysis logic here...
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.MyNewRule,
+            ctx.Symbol.GetLocation(),
+            arg0, arg1));  // args fill {0}, {1} in messageFormat
+    }
+}
+```
+
+### Registration Methods
+
+Choose the registration method based on what you need to analyze:
+
+| Method | Context Type | Use When |
+|--------|-------------|----------|
+| `RegisterSymbolAction` | `SymbolAnalysisContext` | Analyzing declared symbols (tables, pages, fields, methods). Most common. |
+| `RegisterOperationAction` | `OperationAnalysisContext` | Analyzing operations in method bodies (invocations, assignments). |
+| `RegisterSyntaxNodeAction` | `SyntaxNodeAnalysisContext` | Analyzing specific syntax nodes (string literals, identifiers). |
+| `RegisterCodeBlockAction` | `CodeBlockAnalysisContext` | Analyzing entire method/trigger bodies (complexity metrics). |
+| `RegisterCompilationAction` | `CompilationAnalysisContext` | Analyzing the full compilation (manifest checks, cross-object analysis). |
+| `RegisterCompilationStartAction` | `CompilationStartAnalysisContext` | Registering additional actions at compilation start (multi-pass analysis). |
+
+### CompilationStart + SymbolAction (expensive resource loading)
+
+When an analyzer needs to load expensive resources once per compilation (XLIFF files, settings, cross-object indexes), use `RegisterCompilationStartAction` to load them, then register per-symbol actions that use the cached data:
+
+```csharp
+public override void Initialize(AnalysisContext context) =>
+    context.RegisterCompilationStartAction(CompilationStart);
+
+private void CompilationStart(CompilationStartAnalysisContext ctx)
+{
+    // 1. Load expensive resources once
+    var fileSystem = ctx.Compilation.FileSystem;
+    if (fileSystem is null)
+        return;
+
+    var settings = ALCopsSettingsProvider.GetSettings(fileSystem.GetDirectoryPath());
+
+    // 2. Build index / cache
+    var translationIndex = BuildIndex(fileSystem);
+    if (translationIndex is null)
+        return;
+
+    // 3. Register per-symbol action that uses the cached data
+    ctx.RegisterSymbolAction(
+        symbolCtx => AnalyzeSymbol(symbolCtx, translationIndex, settings),
+        EnumProvider.SymbolKind.Table,
+        EnumProvider.SymbolKind.Page);
+}
+```
+
+Key points:
+- Exit early (don't register the symbol action) if the resource loading fails or returns no data. This makes the rule a no-op for projects without the resource.
+- Pass loaded data via lambda captures or a state object, not instance fields (analyzers should be stateless).
+- `Compilation.FileSystem` returns `null` when no file system is available (e.g., some test or IDE contexts).
+
+### Symbol Analysis (most common)
+
+Registers for symbol kinds via `EnumProvider.SymbolKind.*`:
+
+```csharp
+public override void Initialize(AnalysisContext context) =>
+    context.RegisterSymbolAction(
+        this.AnalyzeAccessProperty,
+        EnumProvider.SymbolKind.Codeunit,
+        EnumProvider.SymbolKind.Table,
+        EnumProvider.SymbolKind.Page
+    );
+
+private void AnalyzeAccessProperty(SymbolAnalysisContext ctx)
+{
+    if (ctx.IsObsolete())
+        return;
+
+    if (ctx.Symbol.GetProperty(EnumProvider.PropertyKind.Access) is not null)
+        return;
+
+    ctx.ReportDiagnostic(Diagnostic.Create(
+        DiagnosticDescriptors.AccessPropertyExplicitlySet,
+        ctx.Symbol.GetLocation(),
+        ctx.Symbol.Kind.ToString(),
+        ctx.Symbol.Name));
+}
+```
+
+### Operation Analysis (method invocations)
+
+Registers for operation kinds via `EnumProvider.OperationKind.*`:
+
+```csharp
+public override void Initialize(AnalysisContext context) =>
+    context.RegisterOperationAction(
+        AnalyzeInvocation,
+        EnumProvider.OperationKind.InvocationExpression);
+
+private void AnalyzeInvocation(OperationAnalysisContext ctx)
+{
+    if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
+        return;
+
+    if (invocation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+        invocation.TargetMethod.Name != "Commit")
+        return;
+
+    ctx.ReportDiagnostic(Diagnostic.Create(
+        DiagnosticDescriptors.CommitRequiresComment,
+        ctx.Operation.Syntax.GetLocation()));
+}
+```
+
+### Syntax Node Analysis (raw syntax tree)
+
+Registers for syntax kinds via `EnumProvider.SyntaxKind.*`:
+
+```csharp
+public override void Initialize(AnalysisContext context) =>
+    context.RegisterSyntaxNodeAction(
+        AnalyzeStringLiteral,
+        EnumProvider.SyntaxKind.StringLiteralValue);
+
+private static void AnalyzeStringLiteral(SyntaxNodeAnalysisContext ctx)
+{
+    if (ctx.IsObsolete() || ctx.Node is not StringLiteralValueSyntax stringLiteral)
+        return;
+
+    // Use ctx.SemanticModel for symbol resolution
+    // Use ctx.ContainingSymbol for the enclosing symbol
+    // Use ctx.Node for the syntax tree
+
+    ctx.ReportDiagnostic(Diagnostic.Create(
+        DiagnosticDescriptors.MyRule,
+        ctx.Node.GetLocation(),
+        args));
+}
+```
+
+## EnumProvider (Critical Pattern)
+
+Never reference `Microsoft.Dynamics.Nav.CodeAnalysis` enum values directly. Always use `EnumProvider` from `ALCops.Common.Reflection`. This provides backward compatibility across SDK versions via reflection-based caching.
+
+```csharp
+// CORRECT
+EnumProvider.SymbolKind.Table
+EnumProvider.PropertyKind.Access
+EnumProvider.MethodKind.BuiltInMethod
+EnumProvider.SyntaxKind.StringLiteralValue
+
+// WRONG - will break across SDK versions
+SymbolKind.Table
+PropertyKind.Access
+```
+
+Each `EnumProvider` nested class exposes a `CanonicalNames` property (`Lazy<ImmutableDictionary<string, string>>`) that maps case-insensitive enum value names to their canonical form. These are auto-generated from `Enum.GetNames()` at runtime, so they're self-maintaining across SDK versions.
+
+## Semantic Model APIs
+
+The `SemanticModel` provides symbol resolution beyond what pure syntax analysis offers. Use it when you need canonical names, type information, or cross-object references.
+
+### Getting the SemanticModel
+
+```csharp
+// From SymbolAnalysisContext (most common)
+var root = ctx.Symbol.DeclaringSyntaxReference?.GetSyntax(ctx.CancellationToken);
+var semanticModel = ctx.Compilation.GetSemanticModel(root.SyntaxTree);
+
+// From SyntaxNodeAnalysisContext
+var semanticModel = ctx.SemanticModel;
+```
+
+### GetSymbolInfo vs GetDeclaredSymbol
+
+These two methods serve different purposes and work on different node types:
+
+| Method | Purpose | Returns |
+|--------|---------|---------|
+| `GetSymbolInfo(node)` | Resolves a **reference** to a symbol | The symbol being referenced |
+| `GetDeclaredSymbol(node)` | Gets the symbol **declared by** a node | The declared symbol itself |
+
+### Resolution Matrix
+
+Not all syntax node types resolve via the semantic model. This matrix shows what works:
+
+| Syntax Node Type | GetDeclaredSymbol | GetSymbolInfo | Returns Canonical? | Recommended Strategy |
+|---|---|---|---|---|
+| `PropertySyntax` | ✅ `IPropertySymbol` | ❌ | `PropertyKind`=canonical, `Value`/`ValueText`=SOURCE | `GetDeclaredSymbol` → `PropertyKind.ToString()` |
+| `PropertyNameSyntax` | ❌ | ✅ `IPropertySymbol` | `PropertyKind`=canonical, `Name`=SOURCE | `GetSymbolInfo` → `PropertyKind.ToString()` |
+| `EnumPropertyValueSyntax` | ❌ | ❌ | N/A | Dictionary lookup (see Dynamic SDK Discovery) |
+| `SimpleNamedDataTypeSyntax` | ❌ | ❌ | N/A | `NavTypeKind` dictionary lookup |
+| `MemberAttributeSyntax` | ❌ | ❌ | N/A | `AttributeKind.CanonicalNames` dictionary |
+| `IdentifierNameSyntax` | ❌ | ✅ various | `Name`=canonical | `GetSymbolInfo` → `ISymbol.Name` |
+| `QualifiedNameSyntax` | ❌ | ✅ various | `Name`=canonical | `GetSymbolInfo` → `ISymbol.Name` |
+| `TriggerDeclarationSyntax` | ✅ `IMethodSymbol` | ❌ | `Name`=canonical | `GetDeclaredSymbol` → `IMethodSymbol.Name` |
+| `FieldSyntax` | ✅ `IFieldSymbol` | ❌ | `Name`=SOURCE (user-defined) | N/A (user-defined names) |
+
+### IPropertySymbol Deep-Dive
+
+`IPropertySymbol` (from `GetDeclaredSymbol` on `PropertySyntax` or `GetSymbolInfo` on `PropertyNameSyntax`) has three key properties:
+
+| Property | Returns | Example (source: `ACCESS = Public`) |
+|---|---|---|
+| `PropertyKind` | Canonical `PropertyKind` enum value | `PropertyKind.Access` |
+| `PropertyKind.ToString()` | Canonical property name string | `"Access"` |
+| `Value` | Source-text value (runtime type varies) | `SourceOptionSymbol` with `.ToString()` = `"Public"` |
+| `ValueText` | Source-text value as string | `"Public"` (matches source, NOT necessarily canonical) |
+
+**Critical**: `Value` and `ValueText` return **source text**, not canonical form. For enum property values, `Value` is a `SourceOptionSymbol` (internal type implementing `IOptionSymbol`), and its `.ToString()` also returns source text. Only `PropertyKind.ToString()` is reliable for canonical form.
+
+### Identifier Resolution Batching
+
+When resolving many identifiers via `GetSymbolInfo`, batch them for performance:
+
+```csharp
+// Group identifiers by their text, resolve one representative per group
+var groups = identifiers
+    .ToLookup(node => node.Identifier.ValueText, StringComparer.Ordinal);
+
+foreach (var group in groups)
+{
+    var representative = group.OrderBy(n => n.Position).Last();
+    
+    if (semanticModel.GetSymbolInfo(representative, ct).Symbol is not ISymbol symbol)
+        continue;
+
+    // Apply the canonical name to ALL nodes in the group
+    foreach (var node in group)
+        CompareIdentifier(ctx, node.Identifier, symbol.Name);
+}
+```
+
+This avoids redundant `GetSymbolInfo` calls for identifiers that reference the same symbol.
+
+## Operation-Level Symbol Resolution
+
+When working inside `RegisterOperationAction`, the bound operation tree already has symbols resolved. Prefer `IOperation.GetSymbol()` over `SemanticModel.GetSymbolInfo()` in this context.
+
+### `IOperation.GetSymbol()` vs `SemanticModel.GetSymbolInfo()`
+
+| Method | Context | Cost | Use When |
+|---|---|---|---|
+| `IOperation.GetSymbol()` | Operation analysis | O(1) property accessor on the bound tree | You have an `IOperation` (invocation instance, argument value, field access) |
+| `SemanticModel.GetSymbolInfo(node)` | Syntax analysis | Performs semantic resolution | You have a `SyntaxNode` and no operation tree |
+
+`IOperation.GetSymbol()` is a property accessor that reads from the already-resolved bound tree, not a semantic resolution call. There is no performance benefit to pre-filtering with text checks before calling it.
+
+```csharp
+// In an OperationAnalysisContext callback:
+
+// Resolve the instance of a method invocation
+var instanceSymbol = invocation.Instance.GetSymbol();
+
+// Resolve an argument's value
+var argumentSymbol = argument.Value.GetSymbol();
+
+// Compare two symbols by identity (same variable, same declaration)
+if (instanceSymbol is not null && instanceSymbol.Equals(argumentSymbol))
+    // same symbol
+```
+
+### Unwrapping `IConversionExpression`
+
+The SDK frequently wraps argument values in `IConversionExpression` for implicit type conversions (e.g., passing a `Record "Sales Header"` where the parameter type is `Record "Sales Header"`). When this happens, `argument.Value.GetSymbol()` returns null because the conversion itself has no symbol. Unwrap through the conversion to get the actual operand's symbol:
+
+```csharp
+private static ISymbol? ResolveArgumentSymbol(IArgument argument)
+{
+    var symbol = argument.Value.GetSymbol();
+    if (symbol is not null)
+        return symbol;
+
+    if (argument.Value is IConversionExpression conversion)
+        return conversion.Operand.GetSymbol();
+
+    return null;
+}
+```
+
+This pattern appears across the codebase (e.g., `TransferFieldsSchemaCompatibility`, `PossibleOverflowAssigning`, `UsePartialRecordsOnRead`, `UnnecessaryRecordParameterInMethodCall`). Always try unwrapping when `GetSymbol()` returns null on an argument value.
+
+## Dynamic SDK Discovery via PropertyInfoLookup
+
+The SDK's `PropertyInfoLookup` class provides a static method to query property metadata at runtime, enabling self-maintaining enum property value resolution without manual dictionaries.
+
+### How It Works
+
+`PropertyInfoLookup.Lookup(SymbolKind, PropertyKind)` is a **public static method** that returns a `PropertyTypeInfo`. For properties that accept enum values, the result is an `EnumPropertyTypeInfo` (internal subclass) with an `Options` property containing `EnumPropertyMemberInfo` objects. Each `EnumPropertyMemberInfo.Name` is the **canonical form** of the option value.
+
+```
+PropertyInfoLookup.Lookup(SymbolKind.Codeunit, PropertyKind.Access)
+  → EnumPropertyTypeInfo
+    → Options: [EnumPropertyMemberInfo { Name="Public" }, EnumPropertyMemberInfo { Name="Internal" }]
+
+PropertyInfoLookup.Lookup(SymbolKind.Page, PropertyKind.PageType)
+  → EnumPropertyTypeInfo
+    → Options: [{ Name="Card" }, { Name="List" }, { Name="RoleCenter" }, ...]
+```
+
+### Building a Self-Maintaining Dictionary
+
+Since `EnumPropertyTypeInfo` and `EnumPropertyMemberInfo` are internal types, access them via reflection. The pattern iterates all `SymbolKind × PropertyKind` combinations at startup and merges options per `PropertyKind`:
+
+```csharp
+private static readonly Lazy<Dictionary<PropertyKind, ImmutableDictionary<string, string>>>
+    _enumPropertyValuesByKind = new(() =>
+{
+    var result = new Dictionary<PropertyKind, ImmutableDictionary<string, string>>();
+
+    var lookupMethod = typeof(PropertyInfoLookup)
+        .GetMethod("Lookup", BindingFlags.Public | BindingFlags.Static);
+    if (lookupMethod is null) return result;
+
+    // Find internal types via safe assembly scanning
+    Type[] sdkTypes;
+    try { sdkTypes = typeof(PropertyInfoLookup).Assembly.GetTypes(); }
+    catch (ReflectionTypeLoadException ex)
+    { sdkTypes = ex.Types.Where(t => t != null).ToArray()!; }
+
+    var enumPropTypeInfo = sdkTypes.FirstOrDefault(t => t?.Name == "EnumPropertyTypeInfo");
+    var optionsProp = enumPropTypeInfo?.GetProperty("Options",
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    if (enumPropTypeInfo is null || optionsProp is null) return result;
+
+    PropertyInfo? nameProp = null;
+    foreach (var sk in Enum.GetValues<SymbolKind>())
+        foreach (var pk in Enum.GetValues<PropertyKind>())
+        {
+            try
+            {
+                var info = lookupMethod.Invoke(null, new object[] { sk, pk });
+                if (info?.GetType() != enumPropTypeInfo) continue;
+
+                if (optionsProp.GetValue(info) is not IEnumerable options) continue;
+
+                if (!result.ContainsKey(pk))
+                    result[pk] = ImmutableDictionary<string, string>.Empty;
+
+                var builder = result[pk].ToBuilder();
+                builder.KeyComparer = StringComparer.OrdinalIgnoreCase;
+
+                foreach (var opt in options)
+                {
+                    nameProp ??= opt.GetType().GetProperty("Name");
+                    if (nameProp?.GetValue(opt) is string name && !builder.ContainsKey(name))
+                        builder[name] = name;
+                }
+                result[pk] = builder.ToImmutable();
+            }
+            catch { } // Silently skip version-incompatible combinations
+        }
+
+    return result;
+}, LazyThreadSafetyMode.PublicationOnly);
+```
+
+### Key Facts
+
+- Discovers **60 PropertyKinds** with **253 unique option values** from the current SDK
+- **Zero case collisions** across all option names (verified)
+- **6 PropertyKinds** produce different options depending on SymbolKind: `Access`, `AllowInCustomizations`, `ObsoleteState`, `Scope`, `Subtype`, `Type`. Merging across all SymbolKinds handles this.
+- New enum properties added in future AL SDK versions are **automatically discovered**
+- All reflection uses `Lazy<T>` with `LazyThreadSafetyMode.PublicationOnly` per project conventions
+- Wrap assembly type scanning in `try/catch (ReflectionTypeLoadException)` since some SDK types may fail to load (e.g., `System.Text.Json` version mismatch)
+
+### When to Use This Pattern
+
+Use `PropertyInfoLookup`-based discovery when you need canonical forms of **enum property values** (e.g., `Access = Public`, `PageType = Card`). For other canonical name needs:
+- **Property names**: Use `IPropertySymbol.PropertyKind.ToString()` (semantic model, no dictionary needed)
+- **Data type names**: Use `NavTypeKind` enum via `Enum.GetNames()` (self-maintaining)
+- **Attribute names**: Use `EnumProvider.AttributeKind.CanonicalNames` (self-maintaining)
+- **Symbol kind names**: Use `SymbolKind` enum via `Enum.GetNames()` (self-maintaining)
+- **User-defined identifiers**: Use `GetSymbolInfo()` → `ISymbol.Name` (IntelliSense-equivalent)
+
+## Common Utilities (ALCops.Common)
+
+### AnalysisContextExtensions
+
+Always call `IsObsolete()` early in your analysis method to skip obsolete symbols. Available for all context types:
+
+```csharp
+ctx.IsObsolete()  // works on SymbolAnalysisContext, OperationAnalysisContext,
+                  // SyntaxNodeAnalysisContext, CodeBlockAnalysisContext
+```
+
+Also available:
+- `ctx.IsDiagnosticEnabled(descriptor)` - check if a diagnostic is suppressed (SyntaxNodeAnalysisContext only)
+
+### SymbolInterfaceExtensions
+
+```csharp
+symbol.IsObsolete()                          // check all obsolete states (pending, removed, moved)
+symbol.GetPageTypeSymbol()                   // cast to IPageTypeSymbol
+symbol.GetFlattenedControls()                // get all controls from page or page extension
+symbol.GetFullyQualifiedObjectName()         // "Namespace.ObjectName"
+symbol.GetContainingNamespaceQualifiedNameWithReflection()
+```
+
+### ManifestHelper
+
+Access the app manifest (app.json) from the compilation:
+
+```csharp
+var manifest = ManifestHelper.GetManifest(ctx.Compilation);
+if (manifest is not null && manifest.Runtime >= RuntimeVersion.Spring2021)
+    // feature is supported
+```
+
+**Important:** `ManifestHelper.GetManifest` loads `Microsoft.Dynamics.Nav.Analyzers.Common` assembly via reflection. In test contexts (minimal compilations without the full SDK runtime), this assembly isn't available, causing a `FileNotFoundException`. Analyzers that call `ManifestHelper.GetManifest` must handle this:
+
+```csharp
+NavAppManifest? manifest = null;
+try
+{
+    manifest = ManifestHelper.GetManifest(ctx.Compilation);
+}
+catch (FileNotFoundException)
+{
+    // Expected in test contexts where Microsoft.Dynamics.Nav.Analyzers.Common isn't available
+}
+```
+
+Note: `CompilationWithAnalyzers` silently swallows all exceptions from analyzer callbacks, making this extremely hard to diagnose without explicit try-catch. The analyzer just appears to produce no diagnostics.
+
+### SyntaxNodeExtensions
+
+Helpers for reading label/property syntax:
+- `GetBooleanPropertyValue(IdentifierProperty.Locked)` - check if a label is locked
+- `GetIntegerPropertyValue(IdentifierProperty.MaxLength)` - read MaxLength property
+
+### Same-Module Checks via `ContainingModule`
+
+When a rule should only flag calls to methods defined in the developer's own app (not dependencies or platform), compare `ContainingModule` using object equality. Do not compare app IDs or names as strings.
+
+```csharp
+private static bool IsInCurrentModule(OperationAnalysisContext ctx, IMethodSymbol targetMethod)
+{
+    var currentModule = ctx.ContainingSymbol.ContainingModule;
+    var targetModule = targetMethod.ContainingModule;
+
+    if (currentModule is null || targetModule is null)
+        return false;
+
+    return currentModule == targetModule;
+}
+```
+
+`ContainingModule` is available on any `ISymbol`. The `==` operator performs reference equality on the module objects, which is reliable because the compiler creates one module instance per app. This is preferable to string-based app ID comparison because it's simpler, faster, and immune to formatting differences.
+
+### Version-Gating Analyzers
+
+If a rule only applies to certain BC runtime versions, override `SupportedVersions`:
+
+```csharp
+public override VersionCompatibility SupportedVersions =>
+    VersionProvider.VersionCompatibility.Fall2024OrGreater;
+```
+
+## Writing Tests
+
+Tests use NUnit with `RoslynTestKit`. Each test lives in a folder matching the rule name under `Rules/`.
+
+### Test Structure
+
+```
+ALCops.<CopName>.Test/
+  Rules/
+    <RuleName>/
+      <RuleName>.cs              # Test class
+      HasDiagnostic/             # AL files that SHOULD trigger the diagnostic
+        <TestCase>.al
+      NoDiagnostic/              # AL files that should NOT trigger the diagnostic
+        <TestCase>.al
+```
+
+### Test Class Pattern
+
+```csharp
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test
+{
+    public class AutoIncrementInTemporaryTable : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.AutoIncrementInTemporaryTable>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(AutoIncrementInTemporaryTable)));
+        }
+
+        [Test]
+        [TestCase("AutoIncrementFieldInTemporaryTable")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AutoIncrementInTemporaryTable);
+        }
+
+        [Test]
+        [TestCase("AutoIncrementFieldInTable")]
+        [TestCase("RegularFieldInTemporaryTable")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.AutoIncrementInTemporaryTable);
+        }
+    }
+}
+```
+
+### Test AL Files
+
+Use `[|...|]` markers to indicate where the diagnostic should (or should not) fire:
+
+```al
+// HasDiagnostic/AutoIncrementFieldInTemporaryTable.al
+table 50100 MyTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            [|AutoIncrement = true|];
+        }
+    }
+}
+```
+
+```al
+// NoDiagnostic/AutoIncrementFieldInTable.al
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            [|AutoIncrement = false|];
+        }
+    }
+}
+```
+
+## Step-by-Step: Adding a New Rule
+
+Suppose you are adding rule `PC0029` to PlatformCop.
+
+### 1. Add the diagnostic ID
+
+In `src/ALCops.PlatformCop/DiagnosticIds.cs`, add:
+
+```csharp
+public static readonly string MyNewRule = "PC0029";
+```
+
+### 2. Add resource strings
+
+In `src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx`, add three `<data>` entries:
+
+```xml
+<data name="MyNewRuleTitle" xml:space="preserve">
+  <value>Short title for the rule</value>
+</data>
+<data name="MyNewRuleMessageFormat" xml:space="preserve">
+  <value>The {0} '{1}' has a problem because...</value>
+</data>
+<data name="MyNewRuleDescription" xml:space="preserve">
+  <value>Detailed explanation of why this rule exists and what it checks.</value>
+</data>
+```
+
+### 3. Add the diagnostic descriptor
+
+In `src/ALCops.PlatformCop/DiagnosticDescriptors.cs`, add:
+
+```csharp
+public static readonly DiagnosticDescriptor MyNewRule = new(
+    id: DiagnosticIds.MyNewRule,
+    title: PlatformCopAnalyzers.MyNewRuleTitle,
+    messageFormat: PlatformCopAnalyzers.MyNewRuleMessageFormat,
+    category: Category.Design,
+    defaultSeverity: DiagnosticSeverity.Warning,
+    isEnabledByDefault: true,
+    description: PlatformCopAnalyzers.MyNewRuleDescription,
+    helpLinkUri: GetHelpUri(DiagnosticIds.MyNewRule));
+```
+
+### 4. Create the analyzer class
+
+Create `src/ALCops.PlatformCop/Analyzers/MyNewRule.cs`:
+
+```csharp
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class MyNewRule : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MyNewRule);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSymbolAction(
+            this.Analyze,
+            EnumProvider.SymbolKind.Table);
+
+    private void Analyze(SymbolAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete())
+            return;
+
+        // Your analysis logic...
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.MyNewRule,
+            ctx.Symbol.GetLocation(),
+            ctx.Symbol.Kind.ToString(),
+            ctx.Symbol.Name));
+    }
+}
+```
+
+### 5. Write tests
+
+Create the test folder structure:
+
+```
+src/ALCops.PlatformCop.Test/Rules/MyNewRule/
+  MyNewRule.cs
+  HasDiagnostic/
+    <TestCase>.al
+  NoDiagnostic/
+    <TestCase>.al
+```
+
+Write the test class following the pattern above, using `RoslynFixtureFactory.Create<Analyzers.MyNewRule>()`.
+
+### 6. Build and verify
+
+Build the solution and run the tests to confirm the analyzer works.
+
+## Common Pitfalls
+
+- **Always use `EnumProvider`** for SDK enum values. Direct references break across BC versions.
+- **Always check `IsObsolete()` first** in every analysis method. Reporting on obsolete code creates noise.
+- **Never compare raw syntax text to identify symbols.** Do not use `syntax.ToString()`, `node.Identifier.ValueText`, or similar text-based checks to determine what a variable, method, or expression refers to. These are fragile (case-sensitive, whitespace-dependent, miss implicit conversions) and produce incorrect results when the source text doesn't match the canonical symbol name. Instead, resolve the symbol via `IOperation.GetSymbol()`, `SemanticModel.GetSymbolInfo()`, or `SemanticModel.GetDeclaredSymbol()`, then compare using symbol identity (`symbol.Equals(other)`) or symbol properties (`symbol.Kind`, `symbol.Name`). Checking `ISymbol.Name` after resolution is acceptable because it's the compiler-resolved canonical form, not raw source text.
+- **Use `CancellationToken`** via `ctx.CancellationToken.ThrowIfCancellationRequested()` in loops over large collections (e.g., iterating all fields in a table).
+- **Mark analyzer classes `sealed`** unless there is a specific reason for inheritance.
+- **One analyzer class per rule or tightly related rule group.** The `AnalyzeCountMethod` analyzer handles both `LC0081` (IsEmpty) and `LC0082` (FindWithNext) because they share the same analysis logic.
+- **Use `ImmutableArray.Create()`** for `SupportedDiagnostics`, listing all descriptors the analyzer may report.
+- **Location matters.** Report diagnostics at the most specific location: the offending property, syntax node, or symbol, not the entire object.

--- a/.github/instructions/codefix-development.instructions.md
+++ b/.github/instructions/codefix-development.instructions.md
@@ -1,0 +1,523 @@
+---
+applyTo: 'src/ALCops.*/CodeFixes/**'
+---
+
+# CodeFix Development Guide
+
+This document covers how to implement `CodeFixProvider` classes in the ALCops Analyzers project. A CodeFix offers an automatic quick-fix for a diagnostic reported by an analyzer.
+
+## Which cops have CodeFixes
+
+| Project | Prefix | CodeFixes |
+|---|---|---|
+| `ALCops.PlatformCop` | `PC` | 13 implementations |
+| `ALCops.ApplicationCop` | `AC` | 11 implementations |
+| `ALCops.LinterCop` | `LC` | 6 implementations |
+| `ALCops.FormattingCop` | `FC` | 2 implementations |
+| `ALCops.DocumentationCop` | `DC` | None |
+| `ALCops.TestAutomationCop` | `TA` | None |
+
+## Base class and registration
+
+Every CodeFix provider:
+
+1. Inherits from `Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes.CodeFixProvider`
+2. Is decorated with `[CodeFixProvider(name)]` from `Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef`
+3. Is discovered automatically via MEF (`System.Composition.AttributedModel`). No explicit registration needed.
+
+Required overrides:
+
+- `FixableDiagnosticIds` (property, `ImmutableArray<string>`) - declares which diagnostic IDs this provider handles
+- `GetFixAllProvider()` (method) - always returns `WellKnownFixAllProviders.BatchFixer`
+- `RegisterCodeFixesAsync(CodeFixContext ctx)` (method) - entry point that registers fix actions
+
+## Diagnostic ID linkage
+
+A CodeFix is paired with its analyzer through the diagnostic ID string. The chain is:
+
+```
+DiagnosticIds.cs          →  public static readonly string MyRule = "XX0001";
+DiagnosticDescriptors.cs  →  public static readonly DiagnosticDescriptor MyRule = new(id: DiagnosticIds.MyRule, ...);
+Analyzers/MyRule.cs       →  ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.MyRule, location));
+CodeFixes/MyRule.cs       →  FixableDiagnosticIds => ImmutableArray.Create(DiagnosticDescriptors.MyRule.Id);
+```
+
+The analyzer must already exist and report the diagnostic before a CodeFix can act on it.
+
+## Naming conventions
+
+- **Class name**: `{RuleName}CodeFix` or `{RuleName}CodeFixProvider` (both patterns exist, but `CodeFixProvider` suffix is more common in newer code)
+- **File name**: `{RuleName}.cs`, placed in `CodeFixes/` directory
+- **Namespace**: `ALCops.{CopName}.CodeFixes`
+- **Inner CodeAction class**: `{RuleName}CodeAction` (private, nested)
+- **CodeFixProvider attribute**: `[CodeFixProvider(nameof(ClassName))]` or `[CodeFixProvider("ClassName")]`
+- **Resx key for the fix title**: `{RuleName}CodeAction` (e.g. `EditableFlowFieldCodeAction`)
+
+## Required using directives
+
+Every CodeFix file needs these imports:
+
+```csharp
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+```
+
+Additional imports as needed:
+
+```csharp
+using ALCops.Common.Reflection;  // EnumProvider, PropertyAccessor, etc.
+using System.Reflection;          // when using reflection-based helpers
+```
+
+## Standard CodeFix structure
+
+Every CodeFix in this project follows the same structural pattern. Here is the canonical template derived from actual implementations:
+
+```csharp
+using System.Collections.Immutable;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.{CopName}.CodeFixes;
+
+[CodeFixProvider(nameof(MyRuleCodeFixProvider))]
+public sealed class MyRuleCodeFixProvider : CodeFixProvider
+{
+    // Inner CodeAction class (always present, always private)
+    private class MyRuleCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public MyRuleCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.MyRule.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+         WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(CodeFixContext ctx, SyntaxNode syntaxRoot,
+        TextSpan span, Document document)
+    {
+        SyntaxNode node = syntaxRoot.FindNode(span);
+        ctx.RegisterCodeFix(
+            CreateCodeAction(node, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static MyRuleCodeAction CreateCodeAction(SyntaxNode node, Document document,
+        bool generateFixAll)
+    {
+        return new MyRuleCodeAction(
+            {CopName}Analyzers.MyRuleCodeAction,  // title from .resx
+            ct => ApplyFix(document, node, ct),
+            nameof(MyRuleCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(Document document, SyntaxNode node,
+        CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        // 1. Navigate to the relevant parent node
+        // 2. Build the replacement node
+        // 3. Swap in the syntax tree
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var newRoot = root.ReplaceNode(originalNode, newNode);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}
+```
+
+Key points about this structure:
+
+- The class is always `sealed`.
+- `GetSyntaxRootAsync` is called early and awaited later (the `Task<SyntaxNode> syntaxRootTask` pattern), so the syntax tree loads in parallel with node analysis.
+- The inner `CodeAction` class inherits `CodeAction.DocumentChangeAction`, with `Kind` always set to `CodeActionKind.QuickFix`.
+- The fix title comes from the `.resx` resource file (e.g. `PlatformCopAnalyzers.EditableFlowFieldCodeAction`).
+- `RegisterInstanceCodeFix` is a static helper that finds the node and calls `RegisterCodeFix`.
+
+## Common fix patterns
+
+### Pattern 1: Property modification (add/update/remove)
+
+Used when a fix needs to add, change, or remove a property on an AL object or field.
+
+**Add a property** (from `EditableFlowField.cs`):
+```csharp
+// Add Editable = false to a field that has no Editable property
+newFieldNode = originalFieldNode.AddPropertyListProperties(
+    SyntaxFactory.Property(EnumProvider.PropertyKind.Editable, GetBooleanFalsePropertyValue()));
+```
+
+**Update a property** (from `EditableFlowField.cs`):
+```csharp
+// Change existing Editable property value to false
+var updatedProperty = editableProperty.WithValue(GetBooleanFalsePropertyValue());
+var newProperties = propertyList.Properties.Select(prop =>
+    prop == editableProperty ? updatedProperty : prop).ToList();
+var newPropertyList = propertyList.WithProperties(SyntaxFactory.List(newProperties));
+```
+
+**Remove a property** (from `AllowInCustomizationsRedundancy.cs`):
+```csharp
+// Remove the AllowInCustomizations property entirely
+var newProperties = originalPropertyList.Properties.Remove(allowInCustomizationsProperty);
+var newPropertyList = originalPropertyList.WithProperties(newProperties);
+```
+
+**Insert at specific position** (from `InstallAndUpgradeCodeunitsShouldBeInternal.cs`):
+```csharp
+// Insert Access = Internal at the beginning of property list
+properties.Insert(0, accessProperty);
+```
+
+### Pattern 2: Expression/invocation replacement
+
+Used when replacing one method call or expression with another.
+
+**Replace method call** (from `RecordInstanceIsolationLevel.cs`):
+```csharp
+// Replace Record.LockTable() with Record.ReadIsolation(IsolationLevel::UpdLock)
+var memberAccess = SyntaxFactory.MemberAccessExpression(expression, "ReadIsolation");
+var argument = SyntaxFactory.OptionAccessExpression(
+    SyntaxFactory.IdentifierName("IsolationLevel"),
+    SyntaxFactory.IdentifierName("UpdLock"));
+var newInvocation = SyntaxFactory.InvocationExpression(memberAccess, argumentList)
+    .WithTriviaFrom(invocation);
+```
+
+**Wrap in invocation** (from `UseParenthesisForFunctionCall.cs`):
+```csharp
+// Add parentheses: MyFunction → MyFunction()
+var newInvocation = SyntaxFactory.InvocationExpression(identifierExpression)
+    .WithTriviaFrom(node);
+```
+
+**Replace comparison** (from `GuidEmptyStringComparison.cs`):
+```csharp
+// Replace guid == '' with System.IsNullGuid(guid)
+var invocation = SyntaxFactory.InvocationExpression(
+    SyntaxFactory.MemberAccessExpression(
+        SyntaxFactory.IdentifierName("System"),
+        "IsNullGuid"),
+    argumentList);
+```
+
+### Pattern 3: Text replacement
+
+Used for simple textual changes (rare, only `CasingMismatchKeyword.cs`):
+```csharp
+var sourceText = await document.GetTextAsync(cancellationToken);
+var newSourceText = sourceText.WithChanges(new TextChange(span, properties.CanonicalText));
+return document.WithText(newSourceText);
+```
+
+### Pattern 4: Label property manipulation
+
+Used when adding `Locked = true` to label values (from `EmptyCaptionLocked.cs`, `LabelWithTokSuffixMustBeLocked.cs`):
+```csharp
+// Find the LabelPropertyValueSyntax
+// Check if it has an existing properties list
+// Add or update the Locked = true entry
+```
+
+## Passing data from analyzer to CodeFix via diagnostic properties
+
+When the CodeFix needs information computed by the analyzer (e.g. a replacement name), the analyzer passes it through `ImmutableDictionary<string, string>` properties on the diagnostic:
+
+**In the analyzer:**
+```csharp
+var properties = ImmutableDictionary<string, string>.Empty
+    .Add("ReplacementMethodName", replacementMethod.Expression.ToString());
+
+ctx.ReportDiagnostic(Diagnostic.Create(
+    DiagnosticDescriptors.MyRule,
+    location,
+    properties,   // ← passed here
+    messageArg1, messageArg2));
+```
+
+**In the CodeFix:**
+```csharp
+var diagnostic = ctx.Diagnostics[0];
+var properties = CodeFixProperties.TryParse(diagnostic.Properties);
+if (properties is null) return;
+```
+
+This requires a `CodeFixProperties` helper class with multi-target support:
+
+```csharp
+#if NETSTANDARD2_1
+// C# 9 records require IsExternalInit which doesn't exist in netstandard2.1
+private sealed class CodeFixProperties
+{
+    public string ReplacementMethodName { get; }
+
+    private CodeFixProperties(string replacementMethodName)
+    {
+        ReplacementMethodName = replacementMethodName;
+    }
+
+    public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+    {
+        if (properties is null)
+            return null;
+
+        if (!properties.TryGetValue(nameof(ReplacementMethodName), out var value)
+            || string.IsNullOrEmpty(value))
+            return null;
+
+        return new CodeFixProperties(value);
+    }
+}
+#endif
+
+#if NET8_0_OR_GREATER
+private sealed record CodeFixProperties(string ReplacementMethodName)
+{
+    public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+    {
+        if (properties is null)
+            return null;
+
+        if (!properties.TryGetValue(nameof(ReplacementMethodName), out var value)
+            || string.IsNullOrEmpty(value))
+            return null;
+
+        return new CodeFixProperties(value);
+    }
+}
+#endif
+```
+
+Only use this pattern when the CodeFix needs computed data from the analyzer. Most CodeFixes reconstruct what they need directly from the syntax tree.
+
+## SyntaxFactory reference
+
+Common `SyntaxFactory` methods used in CodeFixes:
+
+```csharp
+// Properties
+SyntaxFactory.Property(EnumProvider.PropertyKind.Editable, propertyValue)
+SyntaxFactory.BooleanPropertyValue(SyntaxFactory.BooleanLiteralValue(token))
+SyntaxFactory.EnumPropertyValue(value)
+
+// Tokens
+SyntaxFactory.Token(EnumProvider.SyntaxKind.FalseKeyword)
+SyntaxFactory.Token(EnumProvider.SyntaxKind.TrueKeyword)
+
+// Identifiers and names
+SyntaxFactory.IdentifierName(name)
+SyntaxFactory.Identifier(name)
+SyntaxFactory.QualifiedName(left, right)
+
+// Expressions
+SyntaxFactory.InvocationExpression(expression)
+SyntaxFactory.InvocationExpression(expression, argumentList)
+SyntaxFactory.MemberAccessExpression(expression, memberName)
+SyntaxFactory.OptionAccessExpression(enumName, memberName)
+
+// Parameters
+SyntaxFactory.Parameter(varKeyword, name, colonToken, type)
+
+// Lists
+SyntaxFactory.List(items)
+```
+
+Syntax tree navigation:
+
+```csharp
+node.Parent                                    // direct parent
+node.FirstAncestorOrSelf<FieldSyntax>()        // walk up to specific type
+syntaxRoot.FindNode(span)                      // find node at diagnostic span
+syntaxRoot.FindNode(span, getInnermostNodeForTie: true)  // prefer innermost
+
+// Modifying nodes
+root.ReplaceNode(oldNode, newNode)             // swap one node
+node.WithPropertyList(newPropertyList)         // replace property list
+node.AddPropertyListProperties(property)       // add to property list
+newNode.WithTriviaFrom(oldNode)                // preserve whitespace/comments
+```
+
+## Step-by-step: adding a new CodeFix
+
+### 1. Verify the analyzer exists
+
+The analyzer must already exist in `Analyzers/` with its diagnostic ID in `DiagnosticIds.cs` and `DiagnosticDescriptors.cs`. The CodeFix targets an existing diagnostic.
+
+### 2. Add the CodeAction title to the .resx file
+
+Add a new entry to `ALCops.{CopName}Analyzers.resx`:
+
+```xml
+<data name="MyRuleCodeAction" xml:space="preserve">
+  <value>Fix: description of what the fix does</value>
+</data>
+```
+
+This generates a property on the strongly-typed `{CopName}Analyzers` class that you reference as the CodeAction title.
+
+### 3. Create the CodeFix class
+
+Create `src/ALCops.{CopName}/CodeFixes/MyRule.cs` using the standard structure shown above. Key decisions:
+
+- Does the fix need data from the analyzer? If yes, use the diagnostic properties pattern with `CodeFixProperties`.
+- What syntax node type does the diagnostic target? Use `FindNode(span)` and navigate to the parent you need.
+- What transformation? Add/remove/replace property, replace expression, or text replacement.
+
+### 4. Add test cases
+
+In the test project `src/ALCops.{CopName}.Test/Rules/MyRule/`:
+
+Create the `HasFix/` subdirectory with test case folders. Each test case has two files:
+- `current.al` - the AL code with the diagnostic (use `[|...|]` markers around the diagnostic span)
+- `expected.al` - the AL code after the fix is applied (no markers)
+
+The `[|...|]` marker in `current.al` identifies where the diagnostic is reported.
+
+### 5. Add the HasFix test method
+
+In the existing test class for the rule, add:
+
+```csharp
+using ALCops.{CopName}.CodeFixes;
+
+// ... inside the test class:
+
+[Test]
+[TestCase("TestCaseName")]
+public async Task HasFix(string testCase)
+{
+    var currentCode = await File.ReadAllTextAsync(
+        Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+        .ConfigureAwait(false);
+
+    var expectedCode = await File.ReadAllTextAsync(
+        Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+        .ConfigureAwait(false);
+
+    var fixture = RoslynFixtureFactory.Create<MyRuleCodeFixProvider>(
+        new CodeFixTestFixtureConfig
+        {
+            AdditionalAnalyzers = [_analyzer]
+        });
+
+    fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.MyRule);
+}
+```
+
+Key details:
+- `RoslynFixtureFactory.Create<T>()` takes the CodeFix type as generic parameter (not the analyzer)
+- `AdditionalAnalyzers` must include the analyzer instance so diagnostics are produced
+- `fixture.TestCodeFix()` verifies the transformation from current to expected code
+
+### 6. Build and test
+
+```bash
+dotnet build ALCops.sln
+dotnet test ALCops.sln --filter "FullyQualifiedName~MyRule"
+```
+
+## Test infrastructure
+
+- **Test framework**: NUnit 4.x
+- **Test kit**: `ALCops.RoslynTestKit` (custom package, version 0.4.1)
+- **Base class**: `NavCodeAnalysisBase` (from RoslynTestKit)
+- **Fixture factory**: `RoslynFixtureFactory.Create<T>()` for both analyzers and code fixes
+- **Test projects** always target `net8.0` only
+
+Test directory structure for a rule with a CodeFix:
+
+```
+Rules/
+└── MyRule/
+    ├── MyRule.cs               # Test class
+    ├── HasDiagnostic/          # .al files where diagnostic IS expected
+    │   ├── TestCase1.al
+    │   └── TestCase2.al
+    ├── NoDiagnostic/           # .al files where diagnostic is NOT expected
+    │   ├── ValidCase1.al
+    │   └── ValidCase2.al
+    └── HasFix/                 # CodeFix test cases (current → expected)
+        └── TestCaseName/
+            ├── current.al      # Input code (with [|...|] marker)
+            └── expected.al     # Expected output after fix
+```
+
+Three test method patterns:
+- `HasDiagnostic(string testCase)` - verifies diagnostic fires at markers
+- `NoDiagnostic(string testCase)` - verifies no false positives
+- `HasFix(string testCase)` - verifies the CodeFix produces the expected output
+
+## Existing implementations reference
+
+| Cop | File | Diagnostic | Fix type |
+|---|---|---|---|
+| PlatformCop | `EditableFlowField.cs` | PC0001 | Add/update `Editable = false` property |
+| PlatformCop | `GuidEmptyStringComparison.cs` | PC0015 | Replace `guid == ''` with `System.IsNullGuid(guid)` |
+| PlatformCop | `EventSubscriberVarKeyword.cs` | PC0010 | Add `var` keyword to parameter |
+| PlatformCop | `EventPublisherIsHandledByVar.cs` | PC0009 | Add `var` keyword to IsHandled parameter |
+| PlatformCop | `ExtensiblePropertyExplicitlySet.cs` | PC0012 | Set Extensible property |
+| PlatformCop | `JsonTokenJPathUsesDoubleQuotes.cs` | PC0016 | Replace double quotes with single quotes in JPath |
+| PlatformCop | `SetRangeWithFilterOperators.cs` | PC0003 | Replace SetRange with SetFilter |
+| PlatformCop | `FilterStringSingleQuoteEscaping.cs` | PC0019 | Fix quote escaping in filter strings |
+| PlatformCop | `OperatorAndPlaceholderInFilterExpression.cs` | PC0017 | Fix filter expression operators |
+| PlatformCop | `MandatoryFieldMissingOnApiPage.cs` | PC0022 | Add mandatory field to API page |
+| PlatformCop | `ApplicationAreaOnApiPage.cs` | PC0013 | Remove ApplicationArea from API page |
+| PlatformCop | `PossibleOverflowAssigningAppendMaxLengthToLabel.cs` | PC0024 | Apply MaxLength/CopyStr to prevent overflow |
+| PlatformCop | `PossibleOverflowAssigningApplyCopyStr.cs` | PC0024 | Apply CopyStr to prevent overflow |
+| ApplicationCop | `EmptyCaptionLocked.cs` | AC0033 | Add `Locked = true` to empty caption |
+| ApplicationCop | `LabelWithTokSuffixMustBeLocked.cs` | AC0017 | Add `Locked = true` to Tok-suffixed label |
+| ApplicationCop | `InstallAndUpgradeCodeunitsShouldBeInternal.cs` | AC0011 | Add `Access = Internal` |
+| ApplicationCop | `PublicEventPublisher.cs` | AC0040 | Change event publisher access |
+| ApplicationCop | `NotBlankRequiredOnPrimaryKeyField.cs` | AC0043 | Add NotBlank to PK field |
+| ApplicationCop | `NotBlankNotAllowedOnPrimaryKeyField.cs` | AC0044 | Remove NotBlank from PK field |
+| ApplicationCop | `PermissionSetCaptionLength.cs` | AC0012 | Truncate PermissionSet caption |
+| ApplicationCop | `GlobalLanguageImplementTranslationHelper.cs` | AC0022 | Replace GlobalLanguage with TranslationHelper |
+| ApplicationCop | `RunPageImplementPageManagement.cs` | AC0024 | Replace RunPage with PageManagement |
+| ApplicationCop | `IntegrationEventsInInternalCodeunit*.cs` | AC0029 | Two fixes: remove internal access or convert event type |
+| FormattingCop | `UseParenthesisForFunctionCall.cs` | FC0009 | Add `()` to function calls |
+| FormattingCop | `CasingMismatchKeyword.cs` | FC0004 | Fix keyword casing via text replacement |
+| LinterCop | `AllowInCustomizationsRedundancy.cs` | LC0024 | Remove redundant AllowInCustomizations property |
+| LinterCop | `DataClassificationRedundancy.cs` | LC0025 | Remove redundant DataClassification property |
+| LinterCop | `ApplicationAreaRedundancy.cs` | LC0026 | Remove redundant ApplicationArea property |
+| LinterCop | `RecordInstanceIsolationLevel.cs` | LC0005 | Replace `LockTable()` with `ReadIsolation()` |
+| LinterCop | `BuiltInDateTimeMethod.cs` | LC0022 | Replace deprecated DateTime method |
+| LinterCop | `ObjectIdInDeclaration.cs` | LC0030 | Replace numeric object ID with name reference |

--- a/.github/instructions/common-library.instructions.md
+++ b/.github/instructions/common-library.instructions.md
@@ -1,0 +1,147 @@
+---
+applyTo: 'src/ALCops.Common/**'
+---
+
+# ALCops.Common: Shared Library for AL Analyzers
+
+## Project Role
+
+ALCops.Common is the shared foundation library referenced by **all 13 projects** in the ALCops solution: 6 cop analyzers, their 6 test projects, and the aggregator project (ALCops.Analyzers). Any change here affects every analyzer. Treat backward compatibility as a hard requirement.
+
+## Build Configuration
+
+- **Target frameworks**: `net8.0` locally, `netstandard2.1` + `net8.0` in CI (GitHub Actions)
+- **LangVersion**: `Latest`
+- **Nullable**: `enable` (enforced via `WarningsAsErrors` for CS8600-CS8605)
+- **ImplicitUsings**: `enable`
+- **SDK references**: `Microsoft.Dynamics.Nav.CodeAnalysis` and `Microsoft.Dynamics.Nav.Analyzers.Common` (loaded from `BcDevToolsDir`)
+- **Conditional dependency**: `System.Collections.Immutable 5.0.0` and `Newtonsoft.Json` for `netstandard2.1` only
+
+Always use `#if NETSTANDARD2_1` / `#if NET8_0_OR_GREATER` guards when APIs differ between target frameworks. Example: `System.Text.Json` for net8.0, `Newtonsoft.Json` for netstandard2.1.
+
+## Directory Structure
+
+### Extensions/
+Extension methods on SDK types. Each file extends one type or interface family.
+
+| File | Extends | Key Methods |
+|------|---------|-------------|
+| `AnalysisContextExtensions.cs` | `SymbolAnalysisContext`, `OperationAnalysisContext`, `SyntaxNodeAnalysisContext`, `CodeBlockAnalysisContext` | `IsObsolete()`, `IsDiagnosticEnabled(descriptor)` |
+| `ApplicationObjectTypeSymbolInterfaceExtensions.cs` | `IApplicationObjectTypeSymbol` | `FindMethodByNameAcrossModules(name, compilation)`, `MethodImplementsInterfaceMethod(methodSymbol)` |
+| `ArgumentInterfaceExtensions.cs` | `IArgument` | `GetTypeSymbol()` (handles ConversionExpression, InvocationExpression) |
+| `CompilationExtensions.cs` | `Compilation` | `GetApplicationObjectTypeSymbolsByIdAcrossModulesWithReflection(kind, id)`, `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection(kind)`, `IsDiagnosticEnabled(descriptor)` |
+| `FileSystemInterfaceExtensions.cs` | `IFileSystem` | `GetPermissionSetDocuments()`. Access via `Compilation.FileSystem` (returns `null` when unavailable). For tests, inject `MemoryFileSystem` via `AnalyzerTestFixtureConfig.FileSystem` (RoslynTestKit 1.0.0+). `MemoryFileSystem` keys use forward slashes; `GetDirectoryPath()` returns `""`. |
+| `MethodSymbolInterfaceExtensions.cs` | `IMethodSymbol` | `MethodImplementsInterfaceMethod()`, `MethodImplementsInterfaceMethod(interfaceMethodSymbol)` |
+| `StringExtensions.cs` | `string` | `QuoteIdentifierIfNeededWithReflection(useRelaxedIdentifierRules)` |
+| `SymbolInterfaceExtensions.cs` | `ISymbol` | `GetContainingNamespaceQualifiedNameWithReflection()`, `GetPageTypeSymbol()`, `GetFlattenedControls()`, `GetFullyQualifiedObjectName(quoteIfNeeded)`, `IsObsolete()` |
+| `SyntaxNodeExtensions.cs` | `LabelPropertyValueSyntax`, `LabelSyntax`, `SyntaxNode`, `CommaSeparatedIdentifierEqualsLiteralListSyntax` | `GetIntegerPropertyValue(property)`, `GetBooleanPropertyValue(property)` (overloaded for each syntax type) |
+| `TypeSymbolInterfaceExtensions.cs` | `ITypeSymbol` | `GetTypeLength(ref isError)` |
+| `IdentifierProperty.cs` | N/A (enum) | `Comment`, `Locked`, `MaxLength` |
+
+### Helpers/
+Higher-level utilities that wrap SDK functionality.
+
+| File | Purpose |
+|------|---------|
+| `AppSourceCopConfigurationProvider.cs` | Adapter wrapping `Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration`. Exposes `MandatoryAffixes`, `MandatorySuffix`, `MandatoryPrefix`. Uses init-only setters on net8.0, regular setters on netstandard2.1. |
+| `ManifestHelper.cs` | `GetManifest(Compilation)` returning `NavAppManifest?`. On net8.0 delegates directly; on netstandard2.1 uses reflection to create a typed delegate, trying two different type paths for AL version compatibility. **Throws `FileNotFoundException` in test contexts** because `Microsoft.Dynamics.Nav.Analyzers.Common` assembly isn't available. Analyzers must catch this and treat as null manifest. |
+
+### Reflection/
+Runtime access to internal/version-dependent SDK types. This is the most sensitive area of Common.
+
+| File | Purpose |
+|------|---------|
+| `CompilationHelper.cs` | Accesses non-public `ReferenceManager` and `CompiledModule` properties via `BindingFlags.Instance \| BindingFlags.NonPublic`. Provides `GetApplicationObjectTypeSymbolsByIdAcrossModulesWithReflection()` and `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection()`. |
+| `EnumProvider.cs` | **~1900 lines.** Wraps 60+ Nav.CodeAnalysis enums (SymbolKind, SyntaxKind, NavTypeKind, PropertyKind, AttributeKind, ControlKind, etc.) using `Enum.Parse` with `Lazy<T>` caching. Never reference Nav.CodeAnalysis enum values directly in the codebase; always go through `EnumProvider`. |
+| `PropertyAccessor.cs` | Extension methods `SetPropertyIfExists(name, value)` and `GetPropertyIfExists<T>(name, default)` on `object`. Walks inheritance hierarchy. Silent failure for missing properties. |
+| `SymbolHelper.cs` | `GetContainingNamespaceQualifiedName(symbol)` and `ToDisplayStringWithReflection(symbol)` (netstandard2.1 only). Uses `Lazy<PropertyInfo?>` for cached reflection. |
+| `StringHelper.cs` | `QuoteIdentifierIfNeeded(value, useRelaxedIdentifierRules)`. Detects SDK method signature at runtime (with/without bool parameter) for version compatibility. |
+| `VersionProvider.cs` | Nested `VersionCompatibility` class with properties like `Fall2019OrGreater`, `Spring2024OrGreater`, `Fall2024OrGreater`. Uses `Type.GetField()` reflection to safely access static fields. Returns a "never supported" fallback when a field does not exist in the loaded SDK version. |
+
+### Settings/
+Per-project analyzer configuration.
+
+| File | Purpose |
+|------|---------|
+| `ALCopsSettings.cs` | POCO with three properties: `CognitiveComplexityThreshold` (default 15), `CyclomaticComplexityThreshold` (default 8), `MaintainabilityIndexThreshold` (default 20). |
+| `ALCopsSettingsProvider.cs` | Static provider with `ConcurrentDictionary` cache keyed by workspace path. Loads `alcops.json` from workspace directory, then falls back to assembly directory. JSON parsing is case-insensitive, allows comments and trailing commas. Use `GetSettings(workspacePath)` from analyzers. |
+
+### Constants.cs
+Three constants: `PermissionNodeXPath` (XPath for permission set XML), `Comment`, `Locked`, `MaxLength` (label property name strings matching the SDK's `LabelPropertyHelper`).
+
+## Why Reflection Is Used Everywhere
+
+The `Microsoft.Dynamics.Nav.CodeAnalysis` SDK treats many types, properties, and enum values as internal or changes their signatures between Business Central releases. Direct references would break compilation against older (or newer) SDK versions. The reflection pattern used throughout Common:
+
+1. **Enum values**: `EnumProvider` wraps every enum value in `Lazy<T>` using `Enum.Parse`. In DEBUG builds, missing values throw; in RELEASE, they silently return `default(T)`.
+2. **Properties**: `PropertyAccessor`, `SymbolHelper` use `Lazy<PropertyInfo?>` with `GetProperty()` and cache results.
+3. **Methods**: `StringHelper`, `ManifestHelper` use `Lazy<MethodInfo?>` with `GetMethod()` and create typed delegates.
+4. **Static fields**: `VersionProvider` uses `GetField()` with a "never supported" fallback.
+5. **Internal members**: `CompilationHelper` uses `BindingFlags.NonPublic` to access `ReferenceManager` and `CompiledModule`.
+
+**Key rule**: All `Lazy<T>` instances use `LazyThreadSafetyMode.PublicationOnly` for thread safety without locking overhead. Follow this pattern for any new reflection code.
+
+## Settings System
+
+Analyzers access settings via:
+```csharp
+var workspacePath = context.SemanticModel.Compilation.FileSystem?.GetDirectoryPath();
+var settings = ALCopsSettingsProvider.GetSettings(workspacePath);
+int threshold = settings.CognitiveComplexityThreshold;
+```
+
+Users configure settings by placing an `alcops.json` file in their AL project root:
+```json
+{
+    "CognitiveComplexityThreshold": 20,
+    "CyclomaticComplexityThreshold": 10,
+    "MaintainabilityIndexThreshold": 15
+}
+```
+
+Settings are cached per workspace path for the analyzer session lifetime. Call `ALCopsSettingsProvider.ClearCache()` only in tests.
+
+## Coding Standards
+
+- **Nullable annotations**: All public APIs must have correct nullability. The project treats CS8600-CS8605 as errors.
+- **Extension method conventions**: One static class per extended type. Class named `{TypeName}Extensions`. Methods that use reflection append `WithReflection` to the method name (e.g., `QuoteIdentifierIfNeededWithReflection`, `GetContainingNamespaceQualifiedNameWithReflection`).
+- **Conditional compilation**: Use `#if NETSTANDARD2_1` for older framework paths, `#if NET8_0_OR_GREATER` for newer ones. Keep both paths tested.
+- **Reflection caching**: Always use `Lazy<T>` with `LazyThreadSafetyMode.PublicationOnly`. Never call `GetProperty()`/`GetMethod()`/`GetField()` in a hot path without caching.
+- **Enum access**: Never reference `Microsoft.Dynamics.Nav.CodeAnalysis` enum values directly. Use `EnumProvider.{EnumName}.{Value}` instead.
+
+## Guidelines for AI Agents
+
+### When to Add to Common vs a Cop Project
+- Add to Common if the utility is needed (or likely to be needed) by two or more cop projects.
+- Add to Common if it wraps SDK internals or handles version compatibility.
+- Keep it in the cop project if it is analyzer-specific logic (e.g., a particular diagnostic rule's helper).
+
+### How to Add a New Extension Method
+1. Find the appropriate file in `Extensions/` by the type you are extending. Create a new file only if no existing file covers that type.
+2. Follow the naming convention: `{TypeName}Extensions` class, same namespace (`ALCops.Common.Extensions`).
+3. If the method uses reflection, suffix the method name with `WithReflection`.
+4. Add null checks; use nullable return types where the value may not exist.
+5. If the method delegates to a reflection helper, put the reflection logic in `Reflection/` and expose a clean extension in `Extensions/`.
+
+### How to Add a New Enum Value to EnumProvider
+1. Open `Reflection/EnumProvider.cs` and find the nested class for the enum type.
+2. Add a new `private static readonly Lazy<T>` field using `ParseEnum<T>(nameof(...))` or a string literal for values that may not exist in all SDK versions.
+3. Add a public static property that returns `_field.Value`.
+4. If the enum value requires conditional compilation for different frameworks, use `#if` guards.
+
+### How to Add a New Setting
+1. Add a new property with a default value to `ALCopsSettings.cs`.
+2. No changes needed to `ALCopsSettingsProvider.cs` (JSON deserialization picks it up automatically).
+3. Document the new setting in the project README.
+
+### Backward Compatibility
+- Do not remove or rename public methods, properties, or classes.
+- Do not change method signatures. Add new overloads instead.
+- Do not change default values in `ALCopsSettings` without discussion (users may depend on them).
+- When adding reflection for a new SDK version, keep the fallback path for older versions.
+
+### Testing
+ALCops.Common has **no dedicated test project**. It is tested indirectly through the 6 cop test projects. When modifying Common:
+- Run the full test suite (`dotnet test` at the solution level) to verify no regressions.
+- If adding a new utility, write tests in the cop test project that will use it.
+- Pay special attention to conditional compilation paths; CI builds both `net8.0` and `netstandard2.1`.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -1,0 +1,89 @@
+---
+applyTo: '**'
+---
+
+# Maintaining Instruction Files
+
+This project uses `.github/instructions/*.instructions.md` files to give AI agents context about the codebase, conventions, and design decisions. These files must stay in sync with the code.
+
+## When planning work, always consider instruction file maintenance
+
+Every plan should include a step to create or update instruction files when the work involves any of the following:
+
+| Trigger | Action |
+|---|---|
+| New analyzer rule | Create a rule-specific instruction file |
+| New CodeFix for an existing rule | Update the rule's instruction file with CodeFix details |
+| New project area or shared component | Create an area instruction file |
+| Design decision added or changed | Update the relevant instruction file's design decisions table |
+| New coding pattern established | Update the relevant development guide |
+| Refactor that changes architecture | Update all affected instruction files |
+| Test coverage changes (new categories, edge cases) | Update the test coverage section of the rule's instruction file |
+| Bug fix with a non-obvious workaround | Document in the rule's "Known issues" section |
+
+If none of these apply, explicitly note "No instruction file changes needed" in the plan.
+
+## File naming conventions
+
+| Type | Pattern | Example |
+|---|---|---|
+| Rule-specific | `{id}-{rule-name}.instructions.md` | `lc0095-use-partial-records-on-read.instructions.md` |
+| Area-specific | `{area-name}.instructions.md` | `common-library.instructions.md` |
+| Development guide | `{topic}-development.instructions.md` | `analyzer-development.instructions.md` |
+| Process/CI | `{topic}.instructions.md` | `cicd.instructions.md` |
+
+## applyTo scoping
+
+Choose the narrowest scope that covers the relevant files:
+
+| Scope | Pattern | Use when |
+|---|---|---|
+| Single rule | `'src/ALCops.{Cop}/**/{RuleName}*'` | Rule-specific context (analyzer + codefix + tests) |
+| All analyzers | `'src/ALCops.*/Analyzers/**'` | Analyzer development conventions |
+| All codefixes | `'src/ALCops.*/CodeFixes/**'` | CodeFix development conventions |
+| All tests | `'src/*.Test/**'` | Testing conventions |
+| Shared library | `'src/ALCops.Common/**'` | Common library guidelines |
+| CI/CD | `'.github/**'` | Build, test, release workflows |
+| Global | `'**'` | Project-wide conventions (use sparingly) |
+
+## Content guidelines
+
+### Rule-specific instruction files
+
+These are the most common type. Include:
+
+1. **Purpose**: What the rule checks and why it matters. Include references (GitHub discussions, MS Docs).
+2. **Diagnostic properties**: ID, category, severity, message format, version gate.
+3. **Design decisions table**: Document every non-obvious choice with Decision, Choice, and Rationale columns. This is the most valuable section for future maintainers.
+4. **Architecture**: Registration strategy, analysis flow, key implementation details.
+5. **Known issues and workarounds**: SDK bugs, edge cases, defensive coding patterns.
+6. **Method/symbol classifications**: Tables of methods grouped by behavior (e.g., read methods, write methods, suppression methods).
+7. **Relationship to other rules**: How this rule interacts with or complements other diagnostics.
+8. **Test coverage**: Table of all test cases with scenario descriptions, organized by HasDiagnostic/NoDiagnostic/HasFix.
+9. **Phase 2 / roadmap**: Planned but unimplemented features, to prevent agents from re-discovering the same ideas.
+10. **CodeFix details** (if applicable): Design decisions, architecture, field detection strategy.
+
+### Development guide instruction files
+
+These cover conventions for a category of files. Include:
+
+1. **Project structure**: Directory layout, file naming.
+2. **Templates**: Canonical code patterns that new files should follow.
+3. **Step-by-step guides**: How to add a new analyzer, codefix, test, etc.
+4. **API reference**: Key SDK types, methods, and their usage patterns.
+5. **Common pitfalls**: Mistakes to avoid, with explanations of why.
+
+## Existing instruction files
+
+| File | Scope | Purpose |
+|---|---|---|
+| `project-overview.instructions.md` | `'**'` | Solution structure, dependencies, build config |
+| `analyzer-development.instructions.md` | `'src/ALCops.*/Analyzers/**'` | How to write analyzers |
+| `codefix-development.instructions.md` | `'src/ALCops.*/CodeFixes/**'` | How to write code fixes |
+| `testing.instructions.md` | `'src/*.Test/**'` | Test conventions and patterns |
+| `common-library.instructions.md` | `'src/ALCops.Common/**'` | Shared library guidelines |
+| `cicd.instructions.md` | `'.github/**'` | CI/CD workflows and scripts |
+| `lc0095-use-partial-records-on-read.instructions.md` | `'src/ALCops.LinterCop/**/UsePartialRecordsOnRead*'` | LC0095 rule details |
+| `lc0096-unnecessary-record-parameter.instructions.md` | `'src/ALCops.LinterCop/**/UnnecessaryRecordParameterInMethodCall*'` | LC0096 rule details |
+| `lc0092-naming-pattern.instructions.md` | `'src/ALCops.LinterCop/**/NamingPattern*'` | LC0092 rule details |
+| `lc0091-translatable-text-should-be-translated.instructions.md` | `'src/ALCops.LinterCop/**/TranslatableTextShouldBeTranslated*'` | LC0091 rule details |

--- a/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
+++ b/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
@@ -1,0 +1,134 @@
+---
+applyTo: 'src/ALCops.LinterCop/**/UnnecessaryRecordParameterInMethodCall*'
+---
+
+# LC0096: UnnecessaryRecordParameterInMethodCall
+
+## Purpose
+
+Detects redundant record parameters passed to methods where the same record variable is already the invocation instance. Covers two patterns:
+
+1. **External call**: `MyRecord.DoSth(MyRecord)` from any context
+2. **Internal call**: `DoSth(Rec)` inside tables, pages, and their extensions
+
+**References:**
+- [BusinessCentral.LinterCop LC0094](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0094) (original rule)
+- [BC.LinterCop PR #1132](https://github.com/StefanMaron/BusinessCentral.LinterCop/pull/1132)
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `LC0096` |
+| Category | Usage |
+| Severity | Warning |
+| Enabled by default | true |
+| MessageFormat | `The record variable '{0}' is passed as an argument to a method that is already invoked on the same record. Remove the redundant parameter.` |
+| Version gate | None |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Cop | LinterCop (LC0096) | Code quality/readability rule, not runtime safety or app conventions |
+| ID | LC0096 | LC0094 is taken by AllowInCustomizationsRedundancy; LC0095 is highest existing |
+| Scope | Tables, Pages, Table Extensions, Page Extensions | All objects with implicit `Rec`. Pages: local methods only |
+| Severity | Warning | Actionable code smell, not a runtime error |
+| CodeFix | None (v1) | Removing the arg breaks compilation without also changing the callee signature |
+| Module restriction | Current module only (object equality) | Avoids flagging calls to dependency methods the developer can't refactor |
+| Event publishers | Skip | Passing `Rec` to events is idiomatic AL; event signatures are public contracts |
+| Page local-only | Only flag `DoSth(Rec)` on pages when target method is `local` | Public/internal page methods accepting the source record is intentional API design for decoupling and testability. Tables flag all because the table IS the record. |
+| Rec matching | `IsSynthesized` + `SemanticFacts.IsSameName` | Matches only the compiler-generated Rec variable (not user-declared globals). Name check discriminates Rec from xRec (both synthesized). |
+| Implicit `with` | Not affected | Implicit with only adds `Rec.` as a scope prefix for field/method lookup. It does NOT inject `Rec` as a method argument. `MyProcedure(Rec)` requires explicit mention of `Rec` regardless of implicit with. |
+| Category | Usage | Incorrect/discouraged use of AL constructs |
+| netstandard2.1 | Full support | No net8.0-only APIs used |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterOperationAction` on `OperationKind.InvocationExpression` for single-pass per-invocation analysis.
+
+### Analysis flow (optimized for early exit)
+
+1. `IsObsolete()` check (cheapest)
+2. Cast to `IInvocationExpression`
+3. `Arguments.IsEmpty` check
+4. `TargetMethod.IsEvent` check (skip event publishers)
+5. Branch on `Instance`:
+   - **Non-null instance** → External call path (`AnalyzeExternalCall`)
+   - **Null instance** → Internal call path (`AnalyzeInternalCall`)
+
+### External call path
+
+1. Check `Instance.Type.NavTypeKind == Record`
+2. Check module restriction via `ContainingModule` object equality
+3. Skip built-in methods
+4. Resolve instance symbol
+5. For each argument: resolve symbol via `ResolveArgumentSymbol`, then symbol identity check via `Equals()`
+6. Report at argument location
+
+### Internal call path
+
+1. Get containing object syntax
+2. Check it's a table, page, or extension thereof
+3. **For pages/page extensions**: skip if target method is NOT `local` (public/internal methods are intentional API design)
+4. Check module restriction
+5. Skip built-in methods
+6. For each argument: resolve symbol, check `Kind == GlobalVariable`, `IsSynthesized`, and `SemanticFacts.IsSameName(name, "Rec")`
+7. Report at argument location
+
+### Performance optimizations
+
+- **Symbol-based checks only**: Uses `IOperation.GetSymbol()` (a property accessor on the bound tree, O(1)) instead of text-based `syntax.ToString()` comparisons
+- **Early exits**: Non-record invocations, empty arguments, events, and built-in methods all exit before any symbol resolution
+- **No SemanticModel retrieval**: Uses `IOperation.GetSymbol()` and `IArgument.Value.GetSymbol()` instead of `SemanticModel.GetSymbolInfo()`
+- **Conversion unwrapping**: `ResolveArgumentSymbol` handles `IConversionExpression` wrapping in a single utility method
+
+## Known issues and workarounds
+
+### IConversionExpression wrapping
+
+Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.Value.GetSymbol()` returns null, the analyzer unwraps through the conversion and calls `GetSymbol()` on the operand.
+
+## Differences from original BC.LinterCop LC0094
+
+| Aspect | BC.LinterCop LC0094 | ALCops LC0096 |
+|---|---|---|
+| Scope | Tables only | Tables, pages, table extensions, page extensions |
+| Page methods | N/A (no page support) | Only local methods flagged (public/internal are intentional API) |
+| Module check | String-based `Compilation.ModuleName` comparison | `ContainingModule` object equality |
+| Rec matching | String comparison against "Rec" | `IsSynthesized` guard + `SemanticFacts.IsSameName` (matches compiler-generated Rec only, discriminates from xRec) |
+| Performance | SemanticModel retrieval before type check | Type check and early exits before any symbol work |
+| Helper dependency | External `HelperFunctions.IsOperationInvokedInTable` | Inline syntax check, no external helper |
+
+## Test coverage
+
+### HasDiagnostic (6 cases)
+
+| Test case | Scenario |
+|---|---|
+| ExternalRecordMethodCall | `MyRecord.DoSth(MyRecord)` from a codeunit |
+| InternalTableMethodCall | `DoSth(Rec)` inside a table |
+| InternalPageMethodCall | `DoSth(Rec)` inside a page (local method) |
+| InternalTableExtensionMethodCall | `DoSth(Rec)` inside a table extension |
+| InternalPageExtensionMethodCall | `DoSth(Rec)` inside a page extension (local method) |
+| MultipleArguments | `MyRecord.DoSth(OtherParam, MyRecord)` flags matching arg |
+
+### NoDiagnostic (6 cases)
+
+| Test case | Suppression reason |
+|---|---|
+| DifferentParameter | `MyRecord.DoSth(MyRecord2)` different variable |
+| EventPublisher | `OnBeforeDoSth(Rec, IsHandled)` event publisher skipped |
+| BuiltInMethods | `Clear(MyTable)` built-in method |
+| PageRunModal | `Page.RunModal(Page::MyPage, MyTable)` built-in, not on the record |
+| FieldAccessExpression | `MyTable.DoSth(MyTable."Name")` field value, not the record |
+| PublicPageMethodWithRec | `CalculateInBackground(Rec)` on public page method (intentional API) |
+
+## Phase 2 roadmap (not yet implemented)
+
+- **CodeFix**: Remove the redundant parameter from both call site and method signature
+- **RecordRef**: Extend to `RecordRef` variables
+- **xRec detection**: Flag `MyRecord.DoSth(xRec)` in contexts where xRec semantics are not needed
+- **Cross-module analysis**: Optional mode to flag cross-module calls (configurable)

--- a/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
+++ b/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
@@ -8,8 +8,8 @@ applyTo: 'src/ALCops.LinterCop/**/UnnecessaryRecordParameterInMethodCall*'
 
 Detects redundant record parameters passed to methods where the same record variable is already the invocation instance. Covers two patterns:
 
-1. **External call**: `MyRecord.DoSth(MyRecord)` from any context
-2. **Internal call**: `DoSth(Rec)` inside tables, pages, and their extensions
+1. **External call**: `MyRecord.MyProcedure(MyRecord)` from any context
+2. **Internal call**: `MyProcedure(Rec)` inside tables, pages, and their extensions
 
 **References:**
 - [BusinessCentral.LinterCop LC0094](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0094) (original rule)
@@ -37,7 +37,7 @@ Detects redundant record parameters passed to methods where the same record vari
 | CodeFix | None (v1) | Removing the arg breaks compilation without also changing the callee signature |
 | Module restriction | Current module only (object equality) | Avoids flagging calls to dependency methods the developer can't refactor |
 | Event publishers | Skip | Passing `Rec` to events is idiomatic AL; event signatures are public contracts |
-| Page local-only | Only flag `DoSth(Rec)` on pages when target method is `local` | Public/internal page methods accepting the source record is intentional API design for decoupling and testability. Tables flag all because the table IS the record. |
+| Page local-only | Only flag `MyProcedure(Rec)` on pages when target method is `local` | Public/internal page methods accepting the source record is intentional API design for decoupling and testability. Tables flag all because the table IS the record. |
 | Rec matching | `IsSynthesized` + `SemanticFacts.IsSameName` | Matches only the compiler-generated Rec variable (not user-declared globals). Name check discriminates Rec from xRec (both synthesized). |
 | Implicit `with` | Not affected | Implicit with only adds `Rec.` as a scope prefix for field/method lookup. It does NOT inject `Rec` as a method argument. `MyProcedure(Rec)` requires explicit mention of `Rec` regardless of implicit with. |
 | Category | Usage | Incorrect/discouraged use of AL constructs |
@@ -108,27 +108,27 @@ Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.V
 
 | Test case | Scenario |
 |---|---|
-| ExternalRecordMethodCall | `MyRecord.DoSth(MyRecord)` from a codeunit |
-| InternalTableMethodCall | `DoSth(Rec)` inside a table |
-| InternalPageMethodCall | `DoSth(Rec)` inside a page (local method) |
-| InternalTableExtensionMethodCall | `DoSth(Rec)` inside a table extension |
-| InternalPageExtensionMethodCall | `DoSth(Rec)` inside a page extension (local method) |
-| MultipleArguments | `MyRecord.DoSth(OtherParam, MyRecord)` flags matching arg |
+| ExternalRecordMethodCall | `MyRecord.MyProcedure(MyRecord)` from a codeunit |
+| InternalTableMethodCall | `MyProcedure(Rec)` inside a table |
+| InternalPageMethodCall | `MyProcedure(Rec)` inside a page (local method) |
+| InternalTableExtensionMethodCall | `MyProcedure(Rec)` inside a table extension |
+| InternalPageExtensionMethodCall | `MyProcedure(Rec)` inside a page extension (local method) |
+| MultipleArguments | `MyRecord.MyProcedure(OtherParam, MyRecord)` flags matching arg |
 
 ### NoDiagnostic (6 cases)
 
 | Test case | Suppression reason |
 |---|---|
-| DifferentParameter | `MyRecord.DoSth(MyRecord2)` different variable |
-| EventPublisher | `OnBeforeDoSth(Rec, IsHandled)` event publisher skipped |
+| DifferentParameter | `MyRecord.MyProcedure(MyRecord2)` different variable |
+| EventPublisher | `OnBeforeMyProcedure(Rec, IsHandled)` event publisher skipped |
 | BuiltInMethods | `Clear(MyTable)` built-in method |
 | PageRunModal | `Page.RunModal(Page::MyPage, MyTable)` built-in, not on the record |
-| FieldAccessExpression | `MyTable.DoSth(MyTable."Name")` field value, not the record |
+| FieldAccessExpression | `MyTable.MyProcedure(MyTable."Name")` field value, not the record |
 | PublicPageMethodWithRec | `CalculateInBackground(Rec)` on public page method (intentional API) |
 
 ## Phase 2 roadmap (not yet implemented)
 
 - **CodeFix**: Remove the redundant parameter from both call site and method signature
 - **RecordRef**: Extend to `RecordRef` variables
-- **xRec detection**: Flag `MyRecord.DoSth(xRec)` in contexts where xRec semantics are not needed
+- **xRec detection**: Flag `MyRecord.MyProcedure(xRec)` in contexts where xRec semantics are not needed
 - **Cross-module analysis**: Optional mode to flag cross-module calls (configurable)

--- a/.github/instructions/project-overview.instructions.md
+++ b/.github/instructions/project-overview.instructions.md
@@ -1,0 +1,176 @@
+---
+applyTo: '**'
+---
+
+# ALCops Analyzers: Project Overview
+
+ALCops Analyzers is a collection of six custom code analyzers for the AL programming language (Microsoft Dynamics 365 Business Central). It is a .NET solution built on the `Microsoft.Dynamics.Nav.CodeAnalysis` SDK.
+
+## Solution structure
+
+The solution (`ALCops.sln`) contains 13 projects in the `src/` directory. A 14th project (`ALCops.Analyzers`) exists in `src/` but is not in the `.sln` file; it is a CI-only NuGet meta-package.
+
+### Shared library
+
+- **`ALCops.Common`**: Shared library referenced by all analyzer projects. Contains:
+  - `Settings/` : `ALCopsSettings.cs`, `ALCopsSettingsProvider.cs` (per-project config via `alcops.json`)
+  - `Extensions/` : Syntax node, symbol, compilation, and type extension methods
+  - `Helpers/` : `ManifestHelper.cs`, `AppSourceCopConfigurationProvider.cs`
+  - `Reflection/` : `CompilationHelper.cs`, `EnumProvider.cs`, `PropertyAccessor.cs`, `SymbolHelper.cs`, `VersionProvider.cs`, `StringHelper.cs`
+  - `Constants.cs` : Shared constant values
+
+### Analyzer projects (6)
+
+Each analyzer project follows the same structure:
+
+| Project | Diagnostic prefix | Help URI slug |
+|---|---|---|
+| `ALCops.ApplicationCop` | `AC` | `applicationcop` |
+| `ALCops.DocumentationCop` | `DC` | `documentationcop` |
+| `ALCops.FormattingCop` | `FC` | `formattingcop` |
+| `ALCops.LinterCop` | `LC` | `lintercop` |
+| `ALCops.PlatformCop` | `PC` | `platformcop` |
+| `ALCops.TestAutomationCop` | `TA` | `testautomationCop` |
+
+Standard files in each analyzer project:
+- `DiagnosticIds.cs` : Static readonly string fields mapping rule names to IDs (e.g. `"LC0003"`, `"AC0001"`)
+- `DiagnosticDescriptors.cs` : `DiagnosticDescriptor` instances using the `Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics` API, with categories (Design, Naming, Style, Usage, Performance, Security) and help URIs
+- `ALCops.{CopName}Analyzers.resx` : Resource file for diagnostic messages (title, messageFormat, description). Generates a strongly-typed class `{CopName}Analyzers` via MSBuild
+- `ALCops.{CopName}Analyzers.cs` : Auto-generated strongly-typed resource accessor (excluded during CI builds via `<Compile Condition="'$(ContinuousIntegrationBuild)' == 'true'" Remove="..."/>`)
+- `Analyzers/` : One `.cs` file per analyzer rule. Each class is decorated with `[DiagnosticAnalyzer]` and extends `DiagnosticAnalyzer`
+- `CodeFixes/` (when present) : One `.cs` file per code fix. Each class is decorated with `[CodeFixProvider]` and extends `CodeFixProvider`
+
+CodeFixes directories exist in: ApplicationCop, FormattingCop, LinterCop, PlatformCop.
+DocumentationCop and TestAutomationCop have no CodeFixes.
+
+### Test projects (6)
+
+Each test project follows the pattern `ALCops.{CopName}.Test`:
+- Uses NUnit 4.x with `ALCops.RoslynTestKit` (custom Roslyn test kit package, version 0.4.1)
+- `AssemblyInfo.cs` : Sets `[assembly: Parallelizable(ParallelScope.All)]`
+- `Rules/` : One folder per rule, containing the test class and subfolders `HasDiagnostic/` and `NoDiagnostic/` (plus `HasFix/` if a code fix exists) with `.al` test fixture files
+- Test classes extend `NavCodeAnalysisBase` and use `RoslynFixtureFactory.Create<T>()`
+- Tests always target `net8.0` only (not multi-target)
+
+### Meta-package
+
+- **`ALCops.Analyzers`** (`src/ALCops.Analyzers/`): NuGet packaging project (not in the `.sln`). References all 6 cops + Common with `PrivateAssets="all"`. Always builds both `netstandard2.1` and `net8.0`. Packs all analyzer DLLs into `lib/netstandard2.1/` and `lib/net8.0/` in the NuGet package. Sets `IncludeBuildOutput=false` and `DevelopmentDependency=true`.
+
+## Dependency graph
+
+```
+ALCops.Common
+  ├── ALCops.ApplicationCop
+  ├── ALCops.DocumentationCop
+  ├── ALCops.FormattingCop
+  ├── ALCops.LinterCop
+  ├── ALCops.PlatformCop
+  └── ALCops.TestAutomationCop
+
+ALCops.{CopName}.Test → ALCops.{CopName} + ALCops.Common
+  (via ProjectReference locally, via binary Reference in CI)
+
+ALCops.Analyzers → all 6 cops + Common (PrivateAssets="all")
+```
+
+All analyzer projects reference `ALCops.Common` via `<ProjectReference>`.
+Test projects use `<ProjectReference>` locally but switch to binary `<Reference>` in CI (controlled by `ContinuousIntegrationBuild`).
+
+External SDK dependencies (not NuGet, local DLLs):
+- `Microsoft.Dynamics.Nav.CodeAnalysis.dll`
+- `Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll` (cops with CodeFixes)
+- `System.Composition.AttributedModel.dll` (cops with CodeFixes)
+- `Microsoft.Dynamics.Nav.Analyzers.Common.dll` (Common only)
+
+These are resolved from `$(BcDevToolsDir)/$(TargetFramework)/`, defaulting to `../../Microsoft.Dynamics.BusinessCentral.Development.Tools`.
+
+## Multi-target framework strategy
+
+Cop and Common projects multi-target conditionally:
+- **Local dev** (`ContinuousIntegrationBuild != true`): `net8.0` only (fast builds)
+- **CI** (`GITHUB_ACTIONS == true` sets `ContinuousIntegrationBuild = true`): `netstandard2.1;net8.0`
+
+This dual-target exists because BC Dev Tools ship in both frameworks. Older BC versions use `netstandard2.1`, newer ones use `net8.0`.
+
+Some analyzers are **net8.0-only** when they depend on SDK APIs that are entirely absent in netstandard2.1. These use a `#if NETSTANDARD2_1` guard around the entire class body, compiling as an empty stub (no diagnostics, no-op initialize) on the older target. See `netstandard21-compatibility.instructions.md` for the pattern. Test-side, use `RequireMinimumVersion("16.0")` to skip tests when the netstandard2.1 SDK is loaded at runtime.
+
+The `netstandard2.1` target requires:
+- `System.Collections.Immutable` NuGet package (version 5.0.0)
+- `Newtonsoft.Json` from BC Dev Tools (Common only, since `System.Text.Json` is unavailable)
+- Conditional `#if NETSTANDARD2_1` / `#if !NETSTANDARD2_1` blocks in source code
+
+Test projects always target `net8.0` only. They use a `NavTargetFramework` property (defaulting to `net8.0`) to select which binary TFM to reference when in CI mode.
+
+## Naming conventions
+
+- **Projects**: `ALCops.{CopName}` and `ALCops.{CopName}.Test`
+- **Namespaces**: Match project names (e.g. `ALCops.LinterCop`, `ALCops.Common.Settings`)
+- **Diagnostic IDs**: 2-letter prefix + 4-digit number: `AC0001`, `DC0001`, `FC0001`, `LC0003`, `PC0001`, `TA0001`
+- **Analyzer classes**: Named after the rule (e.g. `ObjectIdInDeclaration`), placed in `Analyzers/` folder
+- **CodeFix classes**: Named `{RuleName}CodeFixProvider` (e.g. `ObjectIdInDeclarationCodeFixProvider`), placed in `CodeFixes/`
+- **DiagnosticDescriptor fields**: Named after the rule in PascalCase, matching the `DiagnosticIds` field name
+- **Resx keys**: `{RuleName}Title`, `{RuleName}MessageFormat`, `{RuleName}Description`
+- **Test classes**: Named after the rule, placed in `Rules/{RuleName}/`
+- **Test fixture files**: `.al` files in `HasDiagnostic/`, `NoDiagnostic/`, `HasFix/` subfolders
+
+## Help URIs and documentation site
+
+Each diagnostic has a help URI pointing to `https://alcops.dev/docs/analyzers/{copslug}/{id}/` where:
+- `{copslug}` is the lowercase cop name (e.g. `lintercop`, `applicationcop`, `platformcop`)
+- `{id}` is the lowercase diagnostic ID (e.g. `lc0003`, `ac0001`)
+
+The documentation site source lives at `/Users/arthur/repo/ALCops/alcops.dev/` (Hugo-based, separate from this repo).
+
+## Settings system
+
+`ALCopsSettingsProvider` in `ALCops.Common/Settings/` loads configuration from an `alcops.json` file:
+1. First looks in the AL workspace directory
+2. Falls back to the directory containing `ALCops.Common.dll`
+
+Settings are cached per workspace path via `ConcurrentDictionary`. Current configurable thresholds in `ALCopsSettings`:
+- `CognitiveComplexityThreshold` (default: 15)
+- `CyclomaticComplexityThreshold` (default: 8)
+- `MaintainabilityIndexThreshold` (default: 20)
+
+The settings provider uses `Newtonsoft.Json` on `netstandard2.1` and `System.Text.Json` on `net8.0`.
+
+## Versioning
+
+GitVersion with `GitHubFlow/v1` workflow:
+- `main` branch: `alpha` label, `Patch` increment, tracks release branches
+- `release` branch: prevents increment when current commit is tagged (uses tag value)
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`:
+- `build-test.yml` : Reusable workflow for build and test
+- `pull-request.yml` : Runs on PRs
+- `build-and-release.yml` : Build and release pipeline
+- `scheduled-build.yml` : Scheduled builds
+
+## Building locally
+
+```bash
+dotnet build ALCops.sln
+dotnet test ALCops.sln
+```
+
+Requires BC Dev Tools at `../../Microsoft.Dynamics.BusinessCentral.Development.Tools` (relative to repo root) or override with `/p:BcDevToolsDir=<path>`.
+
+## C# language settings
+
+- `LangVersion`: `Latest`
+- `Nullable`: `enable`
+- `ImplicitUsings`: `enable`
+- `WarningsAsErrors`: `CS8600;CS8602;CS8603;CS8604;CS8605` (nullable reference type warnings)
+
+## Adding a new diagnostic rule
+
+1. Add the diagnostic ID to `DiagnosticIds.cs` (use the correct prefix)
+2. Add message strings to the `.resx` file (Title, MessageFormat, Description)
+3. Add the `DiagnosticDescriptor` to `DiagnosticDescriptors.cs` with the correct category, severity, and help URI
+4. Create the analyzer class in `Analyzers/` decorated with `[DiagnosticAnalyzer]`
+5. Optionally create a code fix in `CodeFixes/` decorated with `[CodeFixProvider]`
+6. Create test class in the corresponding test project under `Rules/{RuleName}/`
+7. Add `.al` test fixtures in `HasDiagnostic/` and `NoDiagnostic/` (and `HasFix/` if applicable)
+8. Add documentation page at the docs site (`alcops.dev`)

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,518 @@
+---
+applyTo: 'src/*.Test/**'
+---
+
+# Testing Guide for ALCops Analyzers
+
+This project uses **NUnit 4.1.0** with **ALCops.RoslynTestKit 0.4.1** to test AL code analyzers for Business Central. All test projects target **net8.0**.
+
+## Project Structure
+
+There are 6 analyzer/test project pairs:
+
+| Analyzer Project | Test Project | Namespace |
+|---|---|---|
+| ALCops.ApplicationCop | ALCops.ApplicationCop.Test | `ALCops.ApplicationCop.Test` |
+| ALCops.DocumentationCop | ALCops.DocumentationCop.Test | `ALCops.DocumentationCop.Test` |
+| ALCops.FormattingCop | ALCops.FormattingCop.Test | `ALCops.FormattingCop.Test` |
+| ALCops.LinterCop | ALCops.LinterCop.Test | `ALCops.LinterCop.Test` |
+| ALCops.PlatformCop | ALCops.PlatformCop.Test | `ALCops.PlatformCop.Test` |
+| ALCops.TestAutomationCop | ALCops.TestAutomationCop.Test | `ALCops.TestAutomationCop.Test` |
+
+## Directory Layout per Rule
+
+Each rule has its own directory under `Rules/` in the test project:
+
+```
+src/ALCops.{Cop}.Test/
+├── AssemblyInfo.cs                          # [assembly: Parallelizable(ParallelScope.All)]
+├── ALCops.{Cop}.Test.csproj
+└── Rules/
+    └── {RuleName}/
+        ├── {RuleName}.cs                    # Test class (same name as directory)
+        ├── HasDiagnostic/
+        │   ├── SomeViolation.al             # AL code that SHOULD trigger the diagnostic
+        │   └── AnotherViolation.al
+        ├── NoDiagnostic/
+        │   ├── CorrectUsage.al              # AL code that should NOT trigger the diagnostic
+        │   └── AnotherCorrectUsage.al
+        └── HasFix/                          # Only when a CodeFixProvider exists
+            └── {TestCaseName}/
+                ├── current.al               # Code before the fix
+                └── expected.al              # Code after the fix
+```
+
+## Test Class Template
+
+Every test class follows this exact pattern:
+
+```csharp
+using RoslynTestKit;
+
+namespace ALCops.{Cop}.Test
+{
+    public class {RuleName} : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.{AnalyzerClassName}>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof({RuleName})));
+        }
+
+        [Test]
+        [TestCase("{TestCaseName1}")]
+        [TestCase("{TestCaseName2}")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.{DiagnosticIdConstant});
+        }
+
+        [Test]
+        [TestCase("{CleanCaseName1}")]
+        [TestCase("{CleanCaseName2}")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.{DiagnosticIdConstant});
+        }
+    }
+}
+```
+
+### Key points
+
+- **Base class**: `NavCodeAnalysisBase` (from ALCops.RoslynTestKit). Provides `SkipTestIfVersionIsTooLow()`.
+- **Fixture creation**: `RoslynFixtureFactory.Create<Analyzers.{AnalyzerClassName}>()` returns an `AnalyzerTestFixture`.
+- **NUnit attributes**: `[SetUp]` on setup, `[Test]` + `[TestCase("name")]` on test methods. NUnit is globally imported via `<Using Include="NUnit.Framework" />` in the csproj, so no `using NUnit.Framework;` needed.
+- **Only `using RoslynTestKit;`** is required at the top of the file. Add `using ALCops.{Cop}.CodeFixes;` only if testing a code fix.
+- **Async tests**: All test methods are `async Task`, not `void`.
+- **File loading**: Uses `File.ReadAllTextAsync` with `.ConfigureAwait(false)`.
+- **The test class name matches the directory name**, not necessarily the analyzer class name. For example, the directory `NotBlankNotAllowedOnPrimaryKeyField` might test analyzer class `NotBlankOnPrimaryKeyField`.
+
+## Diagnostic Marker Syntax in .al Files
+
+Markers use `[|...|]` to delimit the exact span where a diagnostic is expected (or verified absent).
+
+### HasDiagnostic files: markers indicate expected diagnostic locations
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if [|MyTable.Count() > 1|] then;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+    }
+}
+```
+
+Multiple markers per file are valid:
+
+```al
+codeunit 50101 "My Codeunit"
+{
+    var
+        MyCodeunit: Codeunit [|50100|];
+        MyPage: Page [|50100|];
+}
+```
+
+### NoDiagnostic files: markers indicate locations verified clean
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if [|MyTable.Count() = 2|] then;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+    }
+}
+```
+
+### HasFix files: no markers, uses current/expected pairs
+
+- `HasFix/{TestCaseName}/current.al` has `[|...|]` markers showing where the diagnostic occurs.
+- `HasFix/{TestCaseName}/expected.al` has the corrected code with no markers.
+
+## Assertion Methods
+
+| Method | Purpose |
+|---|---|
+| `_fixture.HasDiagnosticAtAllMarkers(code, diagnosticId)` | Assert diagnostic reported at every `[|...|]` marker |
+| `_fixture.NoDiagnosticAtAllMarkers(code, diagnosticId)` | Assert NO diagnostic at any `[|...|]` marker |
+| `fixture.TestCodeFix(currentCode, expectedCode, diagnosticDescriptor)` | Assert code fix transforms current into expected |
+
+## Testing Code Fixes
+
+When the analyzer has a `CodeFixProvider`, add a `HasFix` test method:
+
+```csharp
+using ALCops.{Cop}.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.{Cop}.Test
+{
+    public class {RuleName} : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.{AnalyzerClassName} _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.{AnalyzerClassName}>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof({RuleName})));
+        }
+
+        // ... HasDiagnostic and NoDiagnostic methods ...
+
+        [Test]
+        [TestCase("{TestCaseName}")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<{CodeFixProviderClassName}>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.{DescriptorName});
+        }
+    }
+}
+```
+
+Note: `HasFix` uses `DiagnosticDescriptors.{Name}` (the full descriptor object), not `DiagnosticIds.{Name}` (the string ID). Both classes live in the analyzer project.
+
+## Version-Conditional Test Skipping
+
+### Skipping an entire test method (net8.0-only rules)
+
+When a rule is entirely net8.0-only (e.g., it depends on SDK APIs absent in netstandard2.1), use `RequireMinimumVersion` at the top of each test method. This skips ALL test cases when the loaded SDK version is too low, with no arrays to maintain:
+
+```csharp
+[Test]
+[TestCase("LocalLabel")]
+[TestCase("GlobalLabel")]
+[TestCase("TableFieldCaption")]
+public async Task HasDiagnostic(string testCase)
+{
+    RequireMinimumVersion("16.0",
+        "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+    var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+        .ConfigureAwait(false);
+
+    _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.{DiagnosticIdConstant});
+}
+```
+
+Version 16.0 corresponds to the net8.0 SDK. Adding new `[TestCase]` attributes requires no other changes.
+
+### Skipping specific test cases
+
+When only SOME test cases require a minimum version (e.g., a specific AL syntax feature), use `SkipTestIfVersionIsTooLow` with an explicit list of affected test cases:
+
+```csharp
+[Test]
+[TestCase("ConditionalExpressionNested")]
+[TestCase("RegularCase")]
+public async Task HasDiagnostic(string testCase)
+{
+    SkipTestIfVersionIsTooLow(
+        ["ConditionalExpressionNested"],  // only these test cases are skipped
+        testCase,                          // current test case
+        "14.0",                            // minimum version
+        "This test requires .NET 8 or higher due to Conditional Expressions.");  // reason (optional)
+
+    var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+        .ConfigureAwait(false);
+
+    _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.{DiagnosticIdConstant});
+}
+```
+
+**Prefer `RequireMinimumVersion` over `SkipTestIfVersionIsTooLow`** when all test cases in a method share the same version requirement. The array-based approach requires maintaining duplicate lists that must stay in sync with `[TestCase]` attributes.
+
+### Why `#if` pragmas don't work in test projects
+
+Test projects always compile as `net8.0`, so `NETSTANDARD2_1` is never defined. The version difference is a runtime property of which SDK DLL gets loaded (CI tests against both netstandard2.1 and net8.0 analyzer binaries), so it must be a runtime check.
+
+## Testing Analyzers with File System Dependencies
+
+Analyzers that access `Compilation.FileSystem` (e.g., to read XLIFF translation files) need a virtual file system during tests. Use `MemoryFileSystem` (SDK built-in) injected via `AnalyzerTestFixtureConfig.FileSystem` (requires RoslynTestKit 1.0.0+):
+
+```csharp
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+
+private static readonly byte[] EmptyXliffContent = System.Text.Encoding.UTF8.GetBytes(
+    """
+    <?xml version="1.0" encoding="utf-8"?>
+    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+      <file datatype="xml" source-language="en-US" target-language="da-DK" original="TestApp">
+        <body><group id="body"></group></body>
+      </file>
+    </xliff>
+    """);
+
+private static AnalyzerTestFixture CreateFixtureWithEmptyXliff()
+{
+    var files = new Dictionary<string, byte[]>
+    {
+        { "Translations/TestApp.da-DK.xlf", EmptyXliffContent }
+    };
+    var fileSystem = new MemoryFileSystem(files);
+
+    return RoslynFixtureFactory.Create<Analyzers.MyAnalyzer>(
+        new AnalyzerTestFixtureConfig
+        {
+            FileSystem = fileSystem
+        });
+}
+```
+
+Key details about `MemoryFileSystem`:
+- Keys use **forward slashes** (e.g., `"Translations/TestApp.da-DK.xlf"`)
+- `GetDirectoryPath()` always returns `""` (empty string)
+- Accepts `Dictionary<string, byte[]>` in constructor
+
+## Custom Compilation Options
+
+For tests that need non-default compilation settings (e.g., OnPrem target):
+
+```csharp
+[TestCase("HttpClientHandler")]
+public async Task NoDiagnosticWithTargetOnPrem(string testCase)
+{
+    var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+        .ConfigureAwait(false);
+
+    var fixture = RoslynFixtureFactory.Create<Analyzers.{AnalyzerClassName}>(
+        new AnalyzerTestFixtureConfig
+        {
+            CompilationOptions = new CompilationOptions(target: CompilationTarget.OnPrem)
+        });
+
+    fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.{DiagnosticIdConstant});
+}
+```
+
+This requires `using Microsoft.Dynamics.Nav.CodeAnalysis;` for `CompilationOptions` and `CompilationTarget`.
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---|---|---|
+| Test class name | Matches rule directory name | `UseQueryOrFindWithNextInsteadOfCount` |
+| Test method (positive) | `HasDiagnostic` | Always this exact name |
+| Test method (negative) | `NoDiagnostic` | Always this exact name |
+| Test method (code fix) | `HasFix` | Always this exact name |
+| TestCase parameter | PascalCase, describes the scenario | `"RecordCountEqualsOne"` |
+| .al fixture file | `{TestCaseName}.al`, matching the TestCase value | `RecordCountEqualsOne.al` |
+| HasFix directory | `{TestCaseName}/current.al` + `expected.al` | `GlobalVariable/current.al` |
+
+## Writing AL Fixture Files
+
+### Rules for .al fixtures
+
+1. Use object IDs in the 50000-50199 range (test object range).
+2. Include all dependent objects in the same file (tables, enums, codeunits needed by the test).
+3. Keep fixtures minimal: only include code relevant to the rule being tested.
+4. Place `[|...|]` markers precisely around the syntax node the analyzer targets.
+5. Every `HasDiagnostic` fixture must have at least one marker. Every `NoDiagnostic` fixture must also have markers (on the same kind of syntax node, but in a valid scenario).
+
+### Typical fixture structure
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        // The marker wraps the exact expression/statement the analyzer flags
+        [|SomeCodeThatTriggersTheDiagnostic|];
+    end;
+}
+
+// Supporting objects defined in the same file
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+```
+
+## Running Tests
+
+```bash
+# Run all tests in a specific test project
+dotnet test src/ALCops.LinterCop.Test/
+
+# Run tests for a specific rule
+dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~UseQueryOrFindWithNextInsteadOfCount"
+
+# Run only HasDiagnostic tests for a rule
+dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~UseQueryOrFindWithNextInsteadOfCount.HasDiagnostic"
+
+# Run a specific test case
+dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~UseQueryOrFindWithNextInsteadOfCount.HasDiagnostic(\"RecordCountEqualsOne\")"
+
+# Run all test projects
+dotnet test ALCops.sln
+```
+
+Tests run in parallel across assemblies (`[assembly: Parallelizable(ParallelScope.All)]` in `AssemblyInfo.cs`).
+
+## Step-by-Step: Adding Tests for a New Rule
+
+Suppose you are adding tests for a new rule `MyNewRule` in `ALCops.LinterCop`:
+
+### 1. Create the directory structure
+
+```
+src/ALCops.LinterCop.Test/Rules/MyNewRule/
+├── MyNewRule.cs
+├── HasDiagnostic/
+│   ├── ViolationCase1.al
+│   └── ViolationCase2.al
+└── NoDiagnostic/
+    ├── CorrectCase1.al
+    └── CorrectCase2.al
+```
+
+### 2. Write the .al fixture files
+
+**HasDiagnostic/ViolationCase1.al** (code that triggers the diagnostic):
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        [|SomeBadPattern|];
+    end;
+}
+```
+
+**NoDiagnostic/CorrectCase1.al** (code that does not trigger the diagnostic):
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        [|SomeGoodPattern|];
+    end;
+}
+```
+
+### 3. Write the test class
+
+**MyNewRule.cs**:
+
+```csharp
+using RoslynTestKit;
+
+namespace ALCops.LinterCop.Test
+{
+    public class MyNewRule : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.MyNewRuleAnalyzer>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(MyNewRule)));
+        }
+
+        [Test]
+        [TestCase("ViolationCase1")]
+        [TestCase("ViolationCase2")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.MyNewRule);
+        }
+
+        [Test]
+        [TestCase("CorrectCase1")]
+        [TestCase("CorrectCase2")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.MyNewRule);
+        }
+    }
+}
+```
+
+### 4. Run and verify
+
+```bash
+dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~MyNewRule"
+```
+
+## Common Mistakes to Avoid
+
+- **Forgetting markers in NoDiagnostic files.** Both HasDiagnostic and NoDiagnostic .al files need `[|...|]` markers. The difference is whether a diagnostic is expected at those locations.
+- **Using `DiagnosticDescriptors` instead of `DiagnosticIds` for HasDiagnostic/NoDiagnostic.** `HasDiagnosticAtAllMarkers` and `NoDiagnosticAtAllMarkers` take a string diagnostic ID. `TestCodeFix` takes a `DiagnosticDescriptor` object.
+- **Mismatching TestCase name and .al filename.** The `[TestCase("Foo")]` value must exactly match `Foo.al` in the corresponding subdirectory.
+- **Missing supporting objects.** If your AL code references a table, enum, or other object, define it in the same .al file.
+- **Not using `async Task` for test methods.** All test methods must be `async Task`, not `void` or synchronous.
+- **Forgetting `.ConfigureAwait(false)`** on `ReadAllTextAsync` calls.

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/ExternalRecordMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/ExternalRecordMethodCall.al
@@ -1,0 +1,21 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth(var MyTableParam: Record MyTable)
+    begin
+    end;
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.DoSth([|MyTable|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/ExternalRecordMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/ExternalRecordMethodCall.al
@@ -5,17 +5,17 @@ table 50100 MyTable
         field(1; Name; Text[100]) { }
     }
 
-    procedure DoSth(var MyTableParam: Record MyTable)
+    procedure MyProcedure(var MyTableParam: Record MyTable)
     begin
     end;
 }
 
 codeunit 50100 MyCodeunit
 {
-    procedure MyProcedure()
+    procedure CallMyProcedure()
     var
         MyTable: Record MyTable;
     begin
-        MyTable.DoSth([|MyTable|]);
+        MyTable.MyProcedure([|MyTable|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageExtensionMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageExtensionMethodCall.al
@@ -25,12 +25,12 @@ page 50100 MyPage
 
 pageextension 50101 MyPageExt extends MyPage
 {
-    local procedure DoSth(var MyTableParam: Record MyTable)
+    local procedure MyProcedure(var MyTableParam: Record MyTable)
     begin
     end;
 
     trigger OnOpenPage()
     begin
-        DoSth([|Rec|]);
+        MyProcedure([|Rec|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageExtensionMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageExtensionMethodCall.al
@@ -1,0 +1,36 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+}
+
+pageextension 50101 MyPageExt extends MyPage
+{
+    local procedure DoSth(var MyTableParam: Record MyTable)
+    begin
+    end;
+
+    trigger OnOpenPage()
+    begin
+        DoSth([|Rec|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageMethodCall.al
@@ -22,12 +22,12 @@ page 50100 MyPage
         }
     }
 
-    local procedure DoSth(var MyTableParam: Record MyTable)
+    local procedure MyProcedure(var MyTableParam: Record MyTable)
     begin
     end;
 
     trigger OnOpenPage()
     begin
-        DoSth([|Rec|]);
+        MyProcedure([|Rec|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalPageMethodCall.al
@@ -1,0 +1,33 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+
+    local procedure DoSth(var MyTableParam: Record MyTable)
+    begin
+    end;
+
+    trigger OnOpenPage()
+    begin
+        DoSth([|Rec|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableExtensionMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableExtensionMethodCall.al
@@ -1,0 +1,19 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+tableextension 50100 MyTableExt extends MyTable
+{
+    procedure DoSth(var MyTableParam: Record MyTable)
+    begin
+    end;
+
+    procedure CallDoSth()
+    begin
+        DoSth([|Rec|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableExtensionMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableExtensionMethodCall.al
@@ -8,12 +8,12 @@ table 50100 MyTable
 
 tableextension 50100 MyTableExt extends MyTable
 {
-    procedure DoSth(var MyTableParam: Record MyTable)
+    procedure MyProcedure(var MyTableParam: Record MyTable)
     begin
     end;
 
-    procedure CallDoSth()
+    procedure CallMyProcedure()
     begin
-        DoSth([|Rec|]);
+        MyProcedure([|Rec|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableMethodCall.al
@@ -1,0 +1,12 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth(MyTable2: Record MyTable)
+    begin
+        DoSth([|Rec|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableMethodCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/InternalTableMethodCall.al
@@ -5,8 +5,8 @@ table 50100 MyTable
         field(1; Name; Text[100]) { }
     }
 
-    procedure DoSth(MyTable2: Record MyTable)
+    procedure MyProcedure(MyTable2: Record MyTable)
     begin
-        DoSth([|Rec|]);
+        MyProcedure([|Rec|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/MultipleArguments.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/MultipleArguments.al
@@ -1,0 +1,21 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth(OtherParam: Integer; var MyTableParam: Record MyTable)
+    begin
+    end;
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.DoSth(1, [|MyTable|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/MultipleArguments.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/HasDiagnostic/MultipleArguments.al
@@ -5,17 +5,17 @@ table 50100 MyTable
         field(1; Name; Text[100]) { }
     }
 
-    procedure DoSth(OtherParam: Integer; var MyTableParam: Record MyTable)
+    procedure MyProcedure(OtherParam: Integer; var MyTableParam: Record MyTable)
     begin
     end;
 }
 
 codeunit 50100 MyCodeunit
 {
-    procedure MyProcedure()
+    procedure CallMyProcedure()
     var
         MyTable: Record MyTable;
     begin
-        MyTable.DoSth(1, [|MyTable|]);
+        MyTable.MyProcedure(1, [|MyTable|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/BuiltInMethods.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/BuiltInMethods.al
@@ -1,0 +1,17 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|Clear(MyTable)|];
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DifferentParameter.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DifferentParameter.al
@@ -1,0 +1,22 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth(var MyTableParam: Record MyTable)
+    begin
+    end;
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyTable2: Record MyTable;
+    begin
+        MyTable.DoSth([|MyTable2|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DifferentParameter.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DifferentParameter.al
@@ -5,18 +5,18 @@ table 50100 MyTable
         field(1; Name; Text[100]) { }
     }
 
-    procedure DoSth(var MyTableParam: Record MyTable)
+    procedure MyProcedure(var MyTableParam: Record MyTable)
     begin
     end;
 }
 
 codeunit 50100 MyCodeunit
 {
-    procedure MyProcedure()
+    procedure CallMyProcedure()
     var
         MyTable: Record MyTable;
         MyTable2: Record MyTable;
     begin
-        MyTable.DoSth([|MyTable2|]);
+        MyTable.MyProcedure([|MyTable2|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/EventPublisher.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/EventPublisher.al
@@ -1,0 +1,19 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeDoSth(var MyTableParam: Record MyTable; var IsHandled: Boolean)
+    begin
+    end;
+
+    procedure DoSth()
+    var
+        IsHandled: Boolean;
+    begin
+        OnBeforeDoSth([|Rec|], IsHandled);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/EventPublisher.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/EventPublisher.al
@@ -6,14 +6,14 @@ table 50100 MyTable
     }
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeDoSth(var MyTableParam: Record MyTable; var IsHandled: Boolean)
+    local procedure OnBeforeMyProcedure(var MyTableParam: Record MyTable; var IsHandled: Boolean)
     begin
     end;
 
-    procedure DoSth()
+    procedure MyProcedure()
     var
         IsHandled: Boolean;
     begin
-        OnBeforeDoSth([|Rec|], IsHandled);
+        OnBeforeMyProcedure([|Rec|], IsHandled);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/FieldAccessExpression.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/FieldAccessExpression.al
@@ -1,0 +1,21 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth(MyParam: Text)
+    begin
+    end;
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.DoSth([|MyTable."Name"|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/FieldAccessExpression.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/FieldAccessExpression.al
@@ -5,17 +5,17 @@ table 50100 MyTable
         field(1; Name; Text[100]) { }
     }
 
-    procedure DoSth(MyParam: Text)
+    procedure MyProcedure(MyParam: Text)
     begin
     end;
 }
 
 codeunit 50100 MyCodeunit
 {
-    procedure MyProcedure()
+    procedure CallMyProcedure()
     var
         MyTable: Record MyTable;
     begin
-        MyTable.DoSth([|MyTable."Name"|]);
+        MyTable.MyProcedure([|MyTable."Name"|]);
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/PageRunModal.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/PageRunModal.al
@@ -1,0 +1,34 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|Page.RunModal(Page::MyPage, MyTable)|];
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/PublicPageMethodWithRec.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/PublicPageMethodWithRec.al
@@ -1,0 +1,33 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+}
+
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+
+    procedure CalculateInBackground(SalesHeader: Record MyTable)
+    begin
+    end;
+
+    trigger OnOpenPage()
+    begin
+        CalculateInBackground([|Rec|]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
@@ -29,6 +29,7 @@ namespace ALCops.LinterCop.Test
         {
             SkipTestIfVersionIsTooLow(
                 ["InternalPageExtensionMethodCall", "InternalTableExtensionMethodCall"],
+                testCase,
                 "13.0",
                 "No support for tableextensions when target itself is already declared in the same module");
 

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
@@ -27,6 +27,11 @@ namespace ALCops.LinterCop.Test
         [TestCase("MultipleArguments")]
         public async Task HasDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["InternalPageExtensionMethodCall", "InternalTableExtensionMethodCall"],
+                "13.0",
+                "No support for tableextensions when target itself is already declared in the same module");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
@@ -1,0 +1,51 @@
+using RoslynTestKit;
+
+namespace ALCops.LinterCop.Test
+{
+    public class UnnecessaryRecordParameterInMethodCall : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.UnnecessaryRecordParameterInMethodCall>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(UnnecessaryRecordParameterInMethodCall)));
+        }
+
+        [Test]
+        [TestCase("ExternalRecordMethodCall")]
+        [TestCase("InternalTableMethodCall")]
+        [TestCase("InternalPageMethodCall")]
+        [TestCase("InternalTableExtensionMethodCall")]
+        [TestCase("InternalPageExtensionMethodCall")]
+        [TestCase("MultipleArguments")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.UnnecessaryRecordParameterInMethodCall);
+        }
+
+        [Test]
+        [TestCase("DifferentParameter")]
+        [TestCase("EventPublisher")]
+        [TestCase("BuiltInMethods")]
+        [TestCase("PageRunModal")]
+        [TestCase("FieldAccessExpression")]
+        [TestCase("PublicPageMethodWithRec")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.UnnecessaryRecordParameterInMethodCall);
+        }
+    }
+}

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -393,6 +393,15 @@
   <data name="AllowInCustomizationsRedundancyCodeAction" xml:space="preserve">
     <value>ALCops: Remove redundant AllowInCustomizations</value>
   </data>
+  <data name="UnnecessaryRecordParameterInMethodCallTitle" xml:space="preserve">
+    <value>Unnecessary record parameter in method call</value>
+  </data>
+  <data name="UnnecessaryRecordParameterInMethodCallMessageFormat" xml:space="preserve">
+    <value>The record variable '{0}' is passed as an argument to a method that is already invoked on the same record. Remove the redundant parameter.</value>
+  </data>
+  <data name="UnnecessaryRecordParameterInMethodCallDescription" xml:space="preserve">
+    <value>When a method is invoked on a record variable using dot-notation (e.g. MyRecord.SomeProc()), the method already has access to the record through the implicit Rec variable. Passing the same record variable as an explicit parameter is redundant, obscures the real parameter list, and can mislead future readers about the method's intent. Similarly, when calling a sibling method inside a table or page, passing Rec explicitly is unnecessary because the callee already has access to it.</value>
+  </data>
   <data name="TranslatableTextShouldBeTranslatedTitle" xml:space="preserve">
     <value>Translatable text should be translated</value>
   </data>

--- a/src/ALCops.LinterCop/Analyzers/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop/Analyzers/UnnecessaryRecordParameterInMethodCall.cs
@@ -1,0 +1,163 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.LinterCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class UnnecessaryRecordParameterInMethodCall : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UnnecessaryRecordParameterInMethodCall);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterOperationAction(
+            AnalyzeInvocation,
+            EnumProvider.OperationKind.InvocationExpression);
+
+    private void AnalyzeInvocation(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
+            return;
+
+        if (invocation.Arguments.IsEmpty)
+            return;
+
+        if (invocation.TargetMethod.IsEvent)
+            return;
+
+        if (invocation.Instance is not null)
+        {
+            AnalyzeExternalCall(ctx, invocation);
+            return;
+        }
+
+        AnalyzeInternalCall(ctx, invocation);
+    }
+
+    /// <summary>
+    /// Handles the case where a method is called on a record variable using dot-notation:
+    /// <c>MyRecord.MyProcedure(MyRecord)</c>
+    /// </summary>
+    private static void AnalyzeExternalCall(OperationAnalysisContext ctx, IInvocationExpression invocation)
+    {
+        if (invocation.Instance!.Type?.NavTypeKind != EnumProvider.NavTypeKind.Record)
+            return;
+
+        if (!IsInCurrentModule(ctx, invocation.TargetMethod))
+            return;
+
+        if (invocation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
+            return;
+
+        var instanceSymbol = invocation.Instance.GetSymbol();
+        if (instanceSymbol is null)
+            return;
+
+        foreach (var argument in invocation.Arguments)
+        {
+            var argumentSymbol = ResolveArgumentSymbol(argument);
+
+            if (argumentSymbol is not null && instanceSymbol.Equals(argumentSymbol))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.UnnecessaryRecordParameterInMethodCall,
+                    argument.Syntax.GetLocation(),
+                    instanceSymbol.Name));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handles the case where a method is called inside a table, page, or their extensions
+    /// and the implicit <c>Rec</c> is passed as an argument:
+    /// <c>MyProcedure(Rec)</c>
+    /// For pages and page extensions, only local methods are flagged. Public/internal methods
+    /// that accept the source record are considered intentional API design for decoupling.
+    /// For tables and table extensions, all methods are flagged because the table IS the record.
+    /// </summary>
+    private static void AnalyzeInternalCall(OperationAnalysisContext ctx, IInvocationExpression invocation)
+    {
+        var containingObject = invocation.Syntax.GetContainingObjectSyntax();
+
+        if (!IsRecordOwningObject(containingObject))
+            return;
+
+        if (IsPageObject(containingObject) && !invocation.TargetMethod.IsLocal)
+            return;
+
+        if (!IsInCurrentModule(ctx, invocation.TargetMethod))
+            return;
+
+        if (invocation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
+            return;
+
+        foreach (var argument in invocation.Arguments)
+        {
+            var argumentSymbol = ResolveArgumentSymbol(argument);
+
+            if (argumentSymbol is not null
+                && argumentSymbol.Kind == EnumProvider.SymbolKind.GlobalVariable
+                && argumentSymbol.IsSynthesized
+                && SemanticFacts.IsSameName(argumentSymbol.Name, "Rec"))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.UnnecessaryRecordParameterInMethodCall,
+                    argument.Syntax.GetLocation(),
+                    argumentSymbol.Name));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the symbol from an argument value, unwrapping through
+    /// <c>IConversionExpression</c> when the SDK wraps the operand.
+    /// </summary>
+    private static ISymbol? ResolveArgumentSymbol(IArgument argument)
+    {
+        var symbol = argument.Value.GetSymbol();
+        if (symbol is not null)
+            return symbol;
+
+        if (argument.Value is IConversionExpression conversion)
+            return conversion.Operand.GetSymbol();
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks whether the syntax node is a table, page, or one of their extensions
+    /// (objects that have an implicit <c>Rec</c> variable).
+    /// </summary>
+    private static bool IsRecordOwningObject(SyntaxNode? containingObject) =>
+        containingObject is TableSyntax
+            or PageSyntax
+            or TableExtensionSyntax
+            or PageExtensionSyntax;
+
+    /// <summary>
+    /// Checks whether the syntax node is a page or page extension.
+    /// Used to apply the local-only restriction for page objects.
+    /// </summary>
+    private static bool IsPageObject(SyntaxNode? containingObject) =>
+        containingObject is PageSyntax or PageExtensionSyntax;
+
+    /// <summary>
+    /// Ensures the target method is defined in the current module (the developer's own app).
+    /// Methods from dependencies or the platform cannot be refactored, so flagging
+    /// calls to them is not actionable.
+    /// </summary>
+    private static bool IsInCurrentModule(OperationAnalysisContext ctx, IMethodSymbol targetMethod)
+    {
+        var currentModule = ctx.ContainingSymbol.ContainingModule;
+        var targetModule = targetMethod.ContainingModule;
+
+        if (currentModule is null || targetModule is null)
+            return false;
+
+        return currentModule == targetModule;
+    }
+}

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -294,6 +294,16 @@ public static class DiagnosticDescriptors
         description: LinterCopAnalyzers.UsePartialRecordsOnReadDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UsePartialRecordsOnRead));
 
+    public static readonly DiagnosticDescriptor UnnecessaryRecordParameterInMethodCall = new(
+        id: DiagnosticIds.UnnecessaryRecordParameterInMethodCall,
+        title: LinterCopAnalyzers.UnnecessaryRecordParameterInMethodCallTitle,
+        messageFormat: LinterCopAnalyzers.UnnecessaryRecordParameterInMethodCallMessageFormat,
+        category: Category.Usage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.UnnecessaryRecordParameterInMethodCallDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.UnnecessaryRecordParameterInMethodCall));
+
     public static readonly DiagnosticDescriptor UseSecretTextForSensitiveText = new(
         id: DiagnosticIds.UseSecretTextForSensitiveText,
         title: LinterCopAnalyzers.UseSecretTextForSensitiveTextTitle,

--- a/src/ALCops.LinterCop/DiagnosticIds.cs
+++ b/src/ALCops.LinterCop/DiagnosticIds.cs
@@ -31,4 +31,5 @@ public static class DiagnosticIds
     public static readonly string NamingPattern = "LC0092";
     public static readonly string AllowInCustomizationsRedundancy = "LC0094";
     public static readonly string UsePartialRecordsOnRead = "LC0095";
+    public static readonly string UnnecessaryRecordParameterInMethodCall = "LC0096";
 }


### PR DESCRIPTION
Detects redundant record parameters passed to methods where the same record is already the invocation instance or the implicit Rec variable.

Two analysis paths:
- External: MyRecord.MyProcedure(MyRecord) from any context
- Internal: MyProcedure(Rec) inside tables, pages, and extensions

Key design decisions:
- Pages: only flag local methods (public methods are intentional API)
- Tables: flag all methods (the table IS the record)
- Rec identification: IsSynthesized + SemanticFacts.IsSameName (no raw text)
- Module restriction via ContainingModule object equality
- Skip event publishers and built-in methods

Also updates analyzer-development.instructions.md with:
- Operation-level symbol resolution (IOperation.GetSymbol vs SemanticModel)
- IConversionExpression unwrapping pattern
- ContainingModule same-module check pattern
- Never compare raw syntax text pitfall

12 tests (6 HasDiagnostic, 6 NoDiagnostic), all passing.