### PR TITLE
feat: Add PC0029 UseSequentialGuid analyzer and CodeFix

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -87,3 +87,4 @@ These cover conventions for a category of files. Include:
 | `lc0096-unnecessary-record-parameter.instructions.md` | `'src/ALCops.LinterCop/**/UnnecessaryRecordParameterInMethodCall*'` | LC0096 rule details |
 | `lc0092-naming-pattern.instructions.md` | `'src/ALCops.LinterCop/**/NamingPattern*'` | LC0092 rule details |
 | `lc0091-translatable-text-should-be-translated.instructions.md` | `'src/ALCops.LinterCop/**/TranslatableTextShouldBeTranslated*'` | LC0091 rule details |
+| `pc0029-use-sequential-guid.instructions.md` | `'src/ALCops.PlatformCop/**/UseSequentialGuid*'` | PC0029 rule details |

--- a/.github/instructions/pc0029-use-sequential-guid.instructions.md
+++ b/.github/instructions/pc0029-use-sequential-guid.instructions.md
@@ -1,0 +1,200 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/UseSequentialGuid*'
+---
+
+# PC0029: UseSequentialGuid
+
+## Purpose
+
+Detects `CreateGuid()` calls whose result flows into a Guid field that is part of a table key, and suggests using `CreateSequentialGuid()` instead. Random GUIDs cause SQL index fragmentation; sequential GUIDs reduce it by 20-40%.
+
+**References:**
+- [MS Docs: Guid.CreateSequentialGuid](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/guid/guid-createsequentialguid-method)
+- [Demiliani: Use Sequential GUIDs](https://demiliani.com/2025/11/21/dynamics-365-business-central-use-sequential-guids-when-possible/)
+- [BC 2025 Wave 2 runtime 16.0](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-al-runtime)
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `PC0029` |
+| Category | Performance |
+| Severity | Info |
+| Enabled by default | true |
+| MessageFormat | `Use 'CreateSequentialGuid()' instead of '{0}'. {1}` |
+| Version gate | `Fall2025OrGreater` (runtime 16.0, currently commented out until SDK ships) |
+| netstandard2.1 | Full support (no net8.0-only APIs used) |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Cop | PlatformCop (PC0029) | Already has Guid rules (PC0015 GuidEmptyStringComparison), platform performance focus |
+| Default scope | Key fields only | Security trade-off: sequential GUIDs are predictable; non-key fields may use random GUIDs intentionally |
+| Configurable scope | `UseSequentialGuidScope` in alcops.json | Users can opt into `AllGuidFields` mode to flag all CreateGuid() calls |
+| Keys checked | All declared keys (primary + secondary + extension keys) | All keys benefit from sequential GUIDs for SQL index performance |
+| Temporary tables | Skip | No SQL backing, no index fragmentation benefit |
+| Events | Skip | Event parameters flow to external unanalyzable code; passing Rec to events is idiomatic |
+| Obsolete | Skip | Standard ALCops convention |
+| Cross-procedure tracing | Unlimited depth, cycle detection, intra-module only | Covers helper methods like `SetPrimaryKey(CreateGuid())` |
+| Cross-module procedures | Skip if no body (DeclaringSyntaxReference is null) | Symbol-only dependencies don't expose implementation |
+| Cross-module tables | Always check key membership | Table symbols always expose field/key metadata regardless of module |
+| Variable tracking | Yes | `v := CreateGuid(); Table.PK := v;` is a common pattern |
+| Diagnostic location | At the `CreateGuid()` call site | Where the developer needs to make the change |
+| CodeFix replacement | Always produce `Guid.CreateSequentialGuid()` | `CreateSequentialGuid()` requires the `Guid.` qualifier; bare `CreateGuid()` gets prefix added, `Guid.CreateGuid()` gets method name replaced |
+| Category | Performance | SQL index fragmentation is a database performance concern |
+| Severity | Info | Performance suggestion, not a correctness issue |
+| Registration | RegisterCodeBlockAction | Single-pass analysis of method/trigger bodies |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterCodeBlockAction` directly in `Initialize` to analyze entire method/trigger bodies in a single pass. Settings are loaded per code block from `ALCopsSettingsProvider`.
+
+### Analysis flow (KeyFieldsOnly mode, default)
+
+Single-pass `CreateGuidFlowWalker` (extends `OperationWalker`) visits the operation tree:
+
+1. **VisitAssignmentStatement**: If `assignment.Value` is `CreateGuid()`:
+   - If target is `IFieldAccess` -> `CheckFieldInKey()`
+   - If target is a local variable -> `TraceVariable()` to find downstream key field assignments
+
+2. **VisitInvocationExpression**: For each argument that is `CreateGuid()`:
+   - If the invocation is `Validate` and arg[1] is `CreateGuid()` -> `CheckValidateTarget()`
+   - If the invocation is a user procedure -> `TraceParameter()` with cycle detection
+
+### Analysis flow (AllGuidFields mode)
+
+Same walker reports every `CreateGuid()` call found in assignments or invocation arguments without flow analysis.
+
+### Critical SDK quirk: OperationWalker reference equality
+
+The BC SDK's `OperationWalker` does NOT preserve `IOperation` reference identity across separate walks of the same tree. A two-pass approach (collect nodes, then find parents) fails because `==` on `IOperation` returns false for logically identical nodes from different walks. The single-pass approach avoids this entirely by visiting parent structures (assignments, invocations) and checking their children inline.
+
+### Cross-procedure tracing
+
+`TraceParameter(method, paramIndex, visited)`:
+1. Check cycle detection (`visited` HashSet of `IMethodSymbol`)
+2. Get method body via `DeclaringSyntaxReference` (null for cross-module -> skip)
+3. Walk body with `SymbolFlowTracer` tracking the parameter symbol
+4. `SymbolFlowTracer` checks: direct field assignment, Validate call, nested procedure call (recursive)
+
+`TraceVariable(symbol, methodBody, ...)`:
+- Same `SymbolFlowTracer` but tracking a local variable instead of a parameter
+
+### Key field resolution
+
+`CheckFieldInKey(IFieldAccess)`:
+1. Get field symbol, verify it's Guid type
+2. Get record type from the instance, skip if Temporary
+3. Resolve to `ITableTypeSymbol`, skip if not Normal table type
+4. Iterate all keys (`.Keys` property), check if field is in any key by name comparison
+
+## Known issues and workarounds
+
+### IConversionExpression wrapping
+
+Arguments and assignment values may be wrapped in `IConversionExpression` by the SDK. The `UnwrapConversion()` helper strips this layer before checking for `CreateGuid()` or resolving symbols.
+
+### Fall2025OrGreater version gate
+
+The `SupportedVersions` override is commented out because the `Fall2025OrGreater` field doesn't exist in the current SDK's `VersionCompatibility` class. Reflection returns a "never supported" fallback, which prevents the analyzer from running entirely. Uncomment when the SDK ships runtime 16.0.
+
+### SymbolEqualityComparer
+
+Does NOT exist in the BC SDK (unlike Roslyn). Use plain `HashSet<IMethodSymbol>()` for cycle detection.
+
+### CreateSequentialGuid in test fixtures
+
+`CreateSequentialGuid()` doesn't exist in the current test SDK, so test fixtures cannot reference it in AL code that gets compiled. The `AlreadySequentialGuid` NoDiagnostic test case was removed for this reason.
+
+## Settings
+
+```json
+{
+  "UseSequentialGuidScope": "KeyFieldsOnly"
+}
+```
+
+| Value | Behavior |
+|---|---|
+| `"KeyFieldsOnly"` (default when null/unset) | Only flag `CreateGuid()` when value flows to a key field |
+| `"AllGuidFields"` | Flag all `CreateGuid()` calls regardless of context |
+
+Setting is defined as `public string? UseSequentialGuidScope` in `ALCopsSettings.cs`.
+
+## CodeFix: UseSequentialGuidCodeFixProvider
+
+### Purpose
+
+Provides a QuickFix "ALCops: Use CreateSequentialGuid()" that replaces `CreateGuid()` with `CreateSequentialGuid()`, preserving any `Guid.` prefix.
+
+### Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Prefix handling | Always output `Guid.CreateSequentialGuid()` | `CreateSequentialGuid()` requires the `Guid.` qualifier; detect `MemberAccessExpressionSyntax` to avoid `Guid.Guid.` duplication |
+| Replacement strategy | Replace method name for `Guid.` form, wrap bare form in `MemberAccessExpression` | Handles both syntax shapes correctly |
+| FixAll | Supported via `WellKnownFixAllProviders.BatchFixer` | Standard pattern |
+
+### Architecture
+
+1. Receive diagnostic span (the `CreateGuid()` invocation)
+2. Read `HasGuidPrefix` from diagnostic properties
+3. If `Guid.` prefix: find `MemberAccessExpressionSyntax`, build new one with `CreateSequentialGuid`
+4. If no prefix: find `IdentifierNameSyntax`, replace with `CreateSequentialGuid`
+5. Return document with updated syntax root
+
+## Differences from related rules
+
+| Aspect | PC0015 GuidEmptyStringComparison | PC0029 UseSequentialGuid |
+|---|---|---|
+| Focus | Guid comparison correctness | Guid creation performance |
+| Analysis | Single expression check | Flow analysis with cross-procedure tracing |
+| Severity | Warning | Info |
+| CodeFix | Replace comparison | Replace method name |
+
+## Test coverage
+
+### HasDiagnostic (9 cases)
+
+| Test case | Scenario |
+|---|---|
+| DirectAssignmentToPrimaryKey | `MyTable."Primary Key" := CreateGuid()` |
+| ValidatePrimaryKeyField | `MyTable.Validate("Primary Key", CreateGuid())` |
+| DirectAssignmentToSecondaryKeyField | Assignment to field in a secondary key |
+| VariableAssignedToKeyField | `MyGuid := CreateGuid(); MyTable."PK" := MyGuid;` |
+| CrossProcedureIntraModule | `SetPK(CreateGuid())` where SetPK assigns param to key field |
+| OnInsertTrigger | `Rec."Primary Key" := CreateGuid()` in table OnInsert trigger |
+| QualifiedCreateGuid | `MyTable."Primary Key" := Guid.CreateGuid()` |
+| MultiLevelTracing | `ProcA(CreateGuid())` -> ProcB(guid) -> key field assignment |
+| ValidateSecondaryKeyField | `MyTable.Validate("Index Field", CreateGuid())` for secondary key |
+
+### NoDiagnostic (5 cases)
+
+| Test case | Suppression reason |
+|---|---|
+| NonKeyGuidField | Field is not in any key |
+| TemporaryTable | Temporary table (no SQL backing) |
+| GuidVariableNotInKey | Variable used in Message(), not assigned to key field |
+| NonGuidKeyField | Table has non-Guid key field, no CreateGuid() for it |
+| AssignedToGuidVariableUsedElsewhere | Variable passed to unrelated procedure, not to key field |
+
+### HasFix (2 cases)
+
+| Test case | Scenario |
+|---|---|
+| SimpleCreateGuid | `CreateGuid()` -> `Guid.CreateSequentialGuid()` |
+| QualifiedCreateGuid | `Guid.CreateGuid()` -> `Guid.CreateSequentialGuid()` |
+
+## Phase 2 roadmap (not yet implemented)
+
+- **RecordRef support**: Detect `RecordRef.SetTable()` followed by field assignment
+- **Return value tracing**: Function returns CreateGuid(), caller assigns to key field
+- **Global variable tracking**: Track global variables across methods in the same object
+- **Parameter variable tracking**: Analyze calling context for parameters
+- **Cross-module setting**: Optional mode to also flag cross-module procedure calls
+- **AlreadySequentialGuid NoDiagnostic**: Add test when SDK ships CreateSequentialGuid
+- **Suppress for security**: Attribute or comment-based suppression for intentionally random GUIDs
+- **Event parameter tracing**: Optional mode to flag event arguments (currently skipped)

--- a/src/ALCops.Common/Reflection/VersionProvider.cs
+++ b/src/ALCops.Common/Reflection/VersionProvider.cs
@@ -70,6 +70,8 @@ public static class VersionProvider
             new(() => GetVersionCompatibility("Spring2024OrGreater"));
         private static readonly Lazy<NavCodeAnalysis.VersionCompatibility> _fall2024OrGreater =
             new(() => GetVersionCompatibility("Fall2024OrGreater"));
+        private static readonly Lazy<NavCodeAnalysis.VersionCompatibility> _fall2025OrGreater =
+            new(() => GetVersionCompatibility("Fall2025OrGreater"));
 
         public static NavCodeAnalysis.VersionCompatibility Fall2019OrGreater => _fall2019OrGreater.Value;
         public static NavCodeAnalysis.VersionCompatibility Spring2021OrGreater => _spring2021OrGreater.Value;
@@ -78,5 +80,6 @@ public static class VersionProvider
         public static NavCodeAnalysis.VersionCompatibility Fall2023OrGreater => _fall2023OrGreater.Value;
         public static NavCodeAnalysis.VersionCompatibility Spring2024OrGreater => _spring2024OrGreater.Value;
         public static NavCodeAnalysis.VersionCompatibility Fall2024OrGreater => _fall2024OrGreater.Value;
+        public static NavCodeAnalysis.VersionCompatibility Fall2025OrGreater => _fall2025OrGreater.Value;
     }
 }

--- a/src/ALCops.Common/Settings/ALCopsSettings.cs
+++ b/src/ALCops.Common/Settings/ALCopsSettings.cs
@@ -7,4 +7,5 @@ public sealed class ALCopsSettings
     public int MaintainabilityIndexThreshold { get; set; } = 20;
     public string[]? LanguagesToTranslate { get; set; }
     public Dictionary<string, NamingPattern>? NamingPatterns { get; set; }
+    public string? UseSequentialGuidScope { get; set; }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/CrossProcedureIntraModule.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/CrossProcedureIntraModule.al
@@ -1,0 +1,28 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        SetPrimaryKey([|CreateGuid()|]);
+    end;
+
+    local procedure SetPrimaryKey(MyGuid: Guid)
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := MyGuid;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DirectAssignmentToPrimaryKey.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DirectAssignmentToPrimaryKey.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := [|CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DirectAssignmentToSecondaryKeyField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DirectAssignmentToSecondaryKeyField.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Index Field" := [|CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; "Index Field"; Guid) { }
+        field(3; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+        key(SK; "Index Field") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/MultiLevelTracing.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/MultiLevelTracing.al
@@ -1,0 +1,33 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        ProcA([|CreateGuid()|]);
+    end;
+
+    local procedure ProcA(MyGuid: Guid)
+    begin
+        ProcB(MyGuid);
+    end;
+
+    local procedure ProcB(MyGuid: Guid)
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := MyGuid;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/OnInsertTrigger.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/OnInsertTrigger.al
@@ -1,0 +1,18 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+
+    trigger OnInsert()
+    begin
+        Rec."Primary Key" := [|CreateGuid()|];
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/QualifiedCreateGuid.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/QualifiedCreateGuid.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := [|Guid.CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/ValidatePrimaryKeyField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/ValidatePrimaryKeyField.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Validate("Primary Key", [|CreateGuid()|]);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/ValidateSecondaryKeyField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/ValidateSecondaryKeyField.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Validate("Index Field", [|CreateGuid()|]);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; "Index Field"; Guid) { }
+        field(3; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+        key(SK; "Index Field") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/VariableAssignedToKeyField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/VariableAssignedToKeyField.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyGuid: Guid;
+    begin
+        MyGuid := [|CreateGuid()|];
+        MyTable."Primary Key" := MyGuid;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/QualifiedCreateGuid/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/QualifiedCreateGuid/current.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := [|Guid.CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/QualifiedCreateGuid/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/QualifiedCreateGuid/expected.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := Guid.CreateSequentialGuid();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/SimpleCreateGuid/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/SimpleCreateGuid/current.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := [|CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/SimpleCreateGuid/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasFix/SimpleCreateGuid/expected.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := Guid.CreateSequentialGuid();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/AssignedToGuidVariableUsedElsewhere.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/AssignedToGuidVariableUsedElsewhere.al
@@ -1,0 +1,28 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyGuid: Guid;
+    begin
+        MyGuid := [|CreateGuid()|];
+        SomeUnrelatedUse(MyGuid);
+    end;
+
+    local procedure SomeUnrelatedUse(MyGuid: Guid)
+    begin
+        Message('%1', MyGuid);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/GuidVariableNotInKey.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/GuidVariableNotInKey.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyGuid: Guid;
+    begin
+        MyGuid := [|CreateGuid()|];
+        Message('%1', MyGuid);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/NonGuidKeyField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/NonGuidKeyField.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.MyField := [|CreateGuid()|];
+        MyTable.Validate(MyField, [|CreateGuid()|]);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/NonKeyGuidField.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/NonKeyGuidField.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.MyField := [|CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/TemporaryTable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/NoDiagnostic/TemporaryTable.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable."Primary Key" := [|CreateGuid()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; MyField; Guid) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
@@ -1,0 +1,75 @@
+using ALCops.PlatformCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test
+{
+    public class UseSequentialGuid : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.UseSequentialGuid _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.UseSequentialGuid>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(UseSequentialGuid)));
+        }
+
+        [Test]
+        [TestCase("DirectAssignmentToPrimaryKey")]
+        [TestCase("ValidatePrimaryKeyField")]
+        [TestCase("DirectAssignmentToSecondaryKeyField")]
+        [TestCase("VariableAssignedToKeyField")]
+        [TestCase("CrossProcedureIntraModule")]
+        [TestCase("OnInsertTrigger")]
+        [TestCase("QualifiedCreateGuid")]
+        [TestCase("MultiLevelTracing")]
+        [TestCase("ValidateSecondaryKeyField")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.UseSequentialGuid);
+        }
+
+        [Test]
+        [TestCase("NonKeyGuidField")]
+        [TestCase("TemporaryTable")]
+        [TestCase("GuidVariableNotInKey")]
+        [TestCase("NonGuidKeyField")]
+        [TestCase("AssignedToGuidVariableUsedElsewhere")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.UseSequentialGuid);
+        }
+
+        [Test]
+        [TestCase("SimpleCreateGuid")]
+        [TestCase("QualifiedCreateGuid")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<UseSequentialGuidCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.UseSequentialGuid);
+        }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
@@ -32,6 +32,9 @@ namespace ALCops.PlatformCop.Test
         [TestCase("ValidateSecondaryKeyField")]
         public async Task HasDiagnostic(string testCase)
         {
+            // https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/guid/guid-createsequentialguid-method
+            RequireMinimumVersion("16.0", "Available with runtime version 16.0.");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -399,4 +399,16 @@
   <data name="TransferFieldsTypeMismatchDescription" xml:space="preserve">
     <value>Tables coupled via TransferFields must define matching field types for the same field ID. A type mismatch will result in a runtime error when TransferFields is executed, as incompatible field types cannot be safely copied.</value>
   </data>
+  <data name="UseSequentialGuidTitle" xml:space="preserve">
+    <value>Use CreateSequentialGuid() instead of CreateGuid() for key fields</value>
+  </data>
+  <data name="UseSequentialGuidMessageFormat" xml:space="preserve">
+    <value>Use 'CreateSequentialGuid()' instead of '{0}'. {1}</value>
+  </data>
+  <data name="UseSequentialGuidDescription" xml:space="preserve">
+    <value>CreateGuid() generates random GUIDs that cause SQL index fragmentation when inserted into key fields. CreateSequentialGuid() produces partially-sequential GUIDs that reduce index fragmentation by 20-40%, improving insert, read, and update performance. Use CreateSequentialGuid() when the GUID is assigned to a field that is part of a table key.</value>
+  </data>
+  <data name="UseSequentialGuidCodeAction" xml:space="preserve">
+    <value>ALCops: Replace with CreateSequentialGuid()</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
@@ -1,0 +1,408 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using ALCops.Common.Settings;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class UseSequentialGuid : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UseSequentialGuid);
+
+    public override VersionCompatibility SupportedVersions =>
+        VersionProvider.VersionCompatibility.Fall2025OrGreater;
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterCodeBlockAction(AnalyzeCodeBlock);
+
+    private static void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
+    {
+        if (context.IsObsolete() ||
+            context.CodeBlock is not MethodOrTriggerDeclarationSyntax methodOrTrigger)
+            return;
+
+        var body = methodOrTrigger.Body;
+        if (body is null)
+            return;
+
+        var workspacePath = context.SemanticModel.Compilation.FileSystem?.GetDirectoryPath();
+        var settings = ALCopsSettingsProvider.GetSettings(workspacePath);
+        bool flagAllGuidFields = string.Equals(
+            settings.UseSequentialGuidScope, "AllGuidFields", StringComparison.OrdinalIgnoreCase);
+
+        var operation = context.SemanticModel.GetOperation(body, context.CancellationToken);
+        if (operation is null)
+            return;
+
+        var walker = new CreateGuidFlowWalker(
+            context, flagAllGuidFields, context.CancellationToken);
+        walker.Visit(operation);
+    }
+
+    private static void ReportDiagnostic(
+        CodeBlockAnalysisContext context, IInvocationExpression createGuidCall, string reason)
+    {
+        var syntax = createGuidCall.Syntax;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.UseSequentialGuid,
+            syntax.GetLocation(),
+            syntax.ToString(),
+            reason));
+    }
+
+    #region Data types
+
+#if NETSTANDARD2_1
+    private readonly struct KeyFieldResult
+    {
+        public string FieldName { get; }
+        public string TableName { get; }
+
+        public KeyFieldResult(string fieldName, string tableName)
+        {
+            FieldName = fieldName;
+            TableName = tableName;
+        }
+    }
+#else
+    private readonly record struct KeyFieldResult(string FieldName, string TableName);
+#endif
+
+    #endregion
+
+    #region Single-pass flow walker
+
+    /// <summary>
+    /// Single-pass walker that visits assignments and invocations, checking if their
+    /// value/argument is a CreateGuid() call that flows to a key field.
+    /// </summary>
+    private sealed class CreateGuidFlowWalker : OperationWalker
+    {
+        private readonly CodeBlockAnalysisContext _context;
+        private readonly bool _flagAllGuidFields;
+        private readonly CancellationToken _ct;
+
+        public CreateGuidFlowWalker(
+            CodeBlockAnalysisContext context, bool flagAllGuidFields,
+            CancellationToken ct)
+        {
+            _context = context;
+            _flagAllGuidFields = flagAllGuidFields;
+            _ct = ct;
+        }
+
+        public override void VisitAssignmentStatement(IAssignmentStatement operation)
+        {
+            _ct.ThrowIfCancellationRequested();
+
+            var value = UnwrapConversion(operation.Value);
+            if (IsCreateGuidCall(value, out var createGuidInvocation))
+            {
+                if (_flagAllGuidFields)
+                {
+                    ReportDiagnostic(_context, createGuidInvocation,
+                        "Sequential GUIDs improve index performance.");
+                }
+                else if (operation.Target is IFieldAccess fieldAccess)
+                {
+                    var result = CheckFieldInKey(fieldAccess);
+                    if (result is not null)
+                    {
+                        ReportDiagnostic(_context, createGuidInvocation,
+                            $"The value flows to key field '{result.Value.FieldName}' in table '{result.Value.TableName}'.");
+                    }
+                }
+                else
+                {
+                    // Variable assignment: v := CreateGuid()
+                    var targetSymbol = operation.Target?.GetSymbol();
+                    if (targetSymbol is not null && targetSymbol.Kind == EnumProvider.SymbolKind.LocalVariable)
+                    {
+                        var bodyOp = _context.SemanticModel.GetOperation(
+                            ((MethodOrTriggerDeclarationSyntax)_context.CodeBlock).Body!,
+                            _ct);
+                        if (bodyOp is not null)
+                        {
+                            var result = TraceVariable(
+                                targetSymbol, bodyOp, _context.SemanticModel.Compilation, _ct,
+                                new HashSet<IMethodSymbol>());
+                            if (result is not null)
+                            {
+                                ReportDiagnostic(_context, createGuidInvocation,
+                                    $"The value flows to key field '{result.Value.FieldName}' in table '{result.Value.TableName}'.");
+                            }
+                        }
+                    }
+                }
+            }
+
+            base.VisitAssignmentStatement(operation);
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            _ct.ThrowIfCancellationRequested();
+
+            for (int i = 0; i < operation.Arguments.Length; i++)
+            {
+                var argValue = UnwrapConversion(operation.Arguments[i].Value);
+                if (!IsCreateGuidCall(argValue, out var createGuidInvocation))
+                    continue;
+
+                if (_flagAllGuidFields)
+                {
+                    ReportDiagnostic(_context, createGuidInvocation,
+                        "Sequential GUIDs improve index performance.");
+                    continue;
+                }
+
+                // Validate(Field, CreateGuid())
+                if (IsValidateCall(operation) && i == 1 && operation.Arguments.Length >= 2)
+                {
+                    var result = CheckValidateTarget(operation);
+                    if (result is not null)
+                    {
+                        ReportDiagnostic(_context, createGuidInvocation,
+                            $"The value flows to key field '{result.Value.FieldName}' in table '{result.Value.TableName}'.");
+                    }
+                    continue;
+                }
+
+                // User procedure argument (skip events and built-in methods)
+                if (operation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod &&
+                    !operation.TargetMethod.IsEvent)
+                {
+                    var result = TraceParameter(
+                        operation.TargetMethod, i, _context.SemanticModel.Compilation, _ct,
+                        new HashSet<IMethodSymbol>());
+                    if (result is not null)
+                    {
+                        ReportDiagnostic(_context, createGuidInvocation,
+                            $"The value flows to key field '{result.Value.FieldName}' in table '{result.Value.TableName}'.");
+                    }
+                }
+            }
+
+            base.VisitInvocationExpression(operation);
+        }
+
+        private static bool IsCreateGuidCall(
+            IOperation operation, out IInvocationExpression invocation)
+        {
+            if (operation is IInvocationExpression inv &&
+                inv.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
+                string.Equals(inv.TargetMethod.Name, "CreateGuid", StringComparison.OrdinalIgnoreCase) &&
+                inv.Arguments.IsEmpty)
+            {
+                invocation = inv;
+                return true;
+            }
+
+            invocation = null!;
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region Cross-procedure tracing
+
+    private static KeyFieldResult? TraceVariable(
+        ISymbol variable, IOperation methodBody, Compilation compilation,
+        CancellationToken ct, HashSet<IMethodSymbol> visited)
+    {
+        var tracer = new SymbolFlowTracer(variable, compilation, ct, visited);
+        tracer.Visit(methodBody);
+        return tracer.Result;
+    }
+
+    private static KeyFieldResult? TraceParameter(
+        IMethodSymbol method, int paramIndex, Compilation compilation,
+        CancellationToken ct, HashSet<IMethodSymbol> visited)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (paramIndex >= method.Parameters.Length)
+            return null;
+
+        var syntaxRef = method.DeclaringSyntaxReference;
+        if (syntaxRef is null)
+            return null;
+
+        if (!visited.Add(method))
+            return null;
+
+        try
+        {
+            var syntax = syntaxRef.GetSyntax(ct);
+            if (syntax is not MethodOrTriggerDeclarationSyntax methodSyntax || methodSyntax.Body is null)
+                return null;
+
+            var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+            var bodyOp = semanticModel.GetOperation(methodSyntax.Body, ct);
+            if (bodyOp is null)
+                return null;
+
+            var parameter = method.Parameters[paramIndex];
+            var tracer = new SymbolFlowTracer(parameter, compilation, ct, visited);
+            tracer.Visit(bodyOp);
+            return tracer.Result;
+        }
+        finally
+        {
+            visited.Remove(method);
+        }
+    }
+
+    #endregion
+
+    #region SymbolFlowTracer
+
+    private sealed class SymbolFlowTracer : OperationWalker
+    {
+        private readonly ISymbol _tracked;
+        private readonly Compilation _compilation;
+        private readonly CancellationToken _ct;
+        private readonly HashSet<IMethodSymbol> _visited;
+
+        public KeyFieldResult? Result { get; private set; }
+
+        public SymbolFlowTracer(
+            ISymbol tracked, Compilation compilation,
+            CancellationToken ct, HashSet<IMethodSymbol> visited)
+        {
+            _tracked = tracked;
+            _compilation = compilation;
+            _ct = ct;
+            _visited = visited;
+        }
+
+        public override void VisitAssignmentStatement(IAssignmentStatement operation)
+        {
+            if (Result is not null) return;
+            _ct.ThrowIfCancellationRequested();
+
+            if (IsTrackedSymbol(operation.Value) && operation.Target is IFieldAccess fieldAccess)
+            {
+                Result = CheckFieldInKey(fieldAccess);
+                if (Result is not null) return;
+            }
+
+            base.VisitAssignmentStatement(operation);
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            if (Result is not null) return;
+            _ct.ThrowIfCancellationRequested();
+
+            if (IsValidateCall(operation) && operation.Arguments.Length >= 2 &&
+                IsTrackedSymbol(operation.Arguments[1].Value))
+            {
+                Result = CheckValidateTarget(operation);
+                if (Result is not null) return;
+            }
+
+            if (operation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod &&
+                !operation.TargetMethod.IsEvent)
+            {
+                for (int i = 0; i < operation.Arguments.Length; i++)
+                {
+                    if (IsTrackedSymbol(operation.Arguments[i].Value))
+                    {
+                        Result = TraceParameter(
+                            operation.TargetMethod, i, _compilation, _ct, _visited);
+                        if (Result is not null) return;
+                    }
+                }
+            }
+
+            base.VisitInvocationExpression(operation);
+        }
+
+        private bool IsTrackedSymbol(IOperation operation)
+        {
+            var op = UnwrapConversion(operation);
+            var symbol = op.GetSymbol();
+            return symbol is not null && symbol.Equals(_tracked);
+        }
+    }
+
+    #endregion
+
+    #region Shared helpers
+
+    private static bool IsValidateCall(IInvocationExpression invocation) =>
+        invocation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
+        string.Equals(invocation.TargetMethod.Name, "Validate", StringComparison.OrdinalIgnoreCase);
+
+    private static KeyFieldResult? CheckFieldInKey(IFieldAccess fieldAccess)
+    {
+        var fieldSymbol = fieldAccess.FieldSymbol;
+        if (fieldSymbol is null)
+            return null;
+
+        if (fieldSymbol.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Guid)
+            return null;
+
+        if (fieldAccess.Instance?.Type is not IRecordTypeSymbol recordType || recordType.Temporary)
+            return null;
+
+        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType ||
+            tableType.TableType != EnumProvider.TableTypeKind.Normal)
+            return null;
+
+        return IsFieldInAnyKey(fieldSymbol, tableType)
+            ? new KeyFieldResult(fieldSymbol.Name, tableType.Name)
+            : null;
+    }
+
+    private static KeyFieldResult? CheckValidateTarget(IInvocationExpression validateCall)
+    {
+        if (validateCall.Instance?.Type is not IRecordTypeSymbol recordType || recordType.Temporary)
+            return null;
+
+        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType ||
+            tableType.TableType != EnumProvider.TableTypeKind.Normal)
+            return null;
+
+        var firstArg = UnwrapConversion(validateCall.Arguments[0].Value);
+
+        if (firstArg.GetSymbol() is not IFieldSymbol fieldSymbol)
+            return null;
+
+        if (fieldSymbol.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Guid)
+            return null;
+
+        return IsFieldInAnyKey(fieldSymbol, tableType)
+            ? new KeyFieldResult(fieldSymbol.Name, tableType.Name)
+            : null;
+    }
+
+    private static bool IsFieldInAnyKey(IFieldSymbol field, ITableTypeSymbol table)
+    {
+        foreach (var key in table.Keys)
+        {
+            foreach (var keyField in key.Fields)
+            {
+                if (string.Equals(keyField.Name, field.Name, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IOperation UnwrapConversion(IOperation operation) =>
+        operation is IConversionExpression conv ? conv.Operand : operation;
+
+    #endregion
+}

--- a/src/ALCops.PlatformCop/CodeFixes/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSequentialGuid.cs
@@ -1,0 +1,109 @@
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.PlatformCop.CodeFixes;
+
+[CodeFixProvider(nameof(UseSequentialGuidCodeFixProvider))]
+public sealed class UseSequentialGuidCodeFixProvider : CodeFixProvider
+{
+    private class UseSequentialGuidCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public UseSequentialGuidCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.UseSequentialGuid.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(
+        CodeFixContext ctx, SyntaxNode syntaxRoot, TextSpan span, Document document)
+    {
+        SyntaxNode node = syntaxRoot.FindNode(span);
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(node, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static UseSequentialGuidCodeAction CreateCodeAction(
+        SyntaxNode node, Document document, bool generateFixAll)
+    {
+        return new UseSequentialGuidCodeAction(
+            PlatformCopAnalyzers.UseSequentialGuidCodeAction,
+            ct => ApplyFix(document, node, ct),
+            nameof(UseSequentialGuidCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(
+        Document document, SyntaxNode node, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        if (node is not InvocationExpressionSyntax invocation)
+            return document;
+
+        // Build the replacement invocation with CreateSequentialGuid
+        // Handle both forms: CreateGuid() and Guid.CreateGuid()
+        InvocationExpressionSyntax newInvocation;
+
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            // Guid.CreateGuid() → Guid.CreateSequentialGuid()
+            var newMemberAccess = SyntaxFactory.MemberAccessExpression(
+                memberAccess.Expression,
+                "CreateSequentialGuid");
+
+            newInvocation = SyntaxFactory.InvocationExpression(newMemberAccess)
+                .WithTriviaFrom(invocation);
+        }
+        else
+        {
+            // CreateGuid() → Guid.CreateSequentialGuid()
+            // CreateSequentialGuid requires the Guid. qualifier
+            var guidQualified = SyntaxFactory.MemberAccessExpression(
+                SyntaxFactory.IdentifierName("Guid"),
+                "CreateSequentialGuid");
+
+            newInvocation = SyntaxFactory.InvocationExpression(guidQualified)
+                .WithTriviaFrom(invocation);
+        }
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var newRoot = root.ReplaceNode(invocation, newInvocation);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -275,6 +275,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.TransferFieldsTypeMismatchDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.TransferFieldsTypeMismatch));
 
+    public static readonly DiagnosticDescriptor UseSequentialGuid = new(
+        id: DiagnosticIds.UseSequentialGuid,
+        title: PlatformCopAnalyzers.UseSequentialGuidTitle,
+        messageFormat: PlatformCopAnalyzers.UseSequentialGuidMessageFormat,
+        category: Category.Performance,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.UseSequentialGuidDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.UseSequentialGuid));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -29,4 +29,5 @@ public static class DiagnosticIds
     public static readonly string MandatoryFieldMissingOnApiPage = "PC0026";
     public static readonly string TemporaryRecordTriggerInvocation = "PC0027";
     public static readonly string TableRelationFieldLength = "PC0028";
+    public static readonly string UseSequentialGuid = "PC0029";
 }


### PR DESCRIPTION
Detect CreateGuid() calls whose result flows into table key fields and suggest Guid.CreateSequentialGuid() instead. Random GUIDs cause SQL index fragmentation; sequential GUIDs reduce page splits by 20-40%.

Analyzer features:
- Direct assignment and Validate() on key fields (primary + secondary)
- Variable tracking (v := CreateGuid(); Table.PK := v)
- Cross-procedure tracing with cycle detection (unlimited depth)
- Table trigger support (OnInsert, etc.)
- Configurable UseSequentialGuidScope setting (KeyFieldsOnly/AllGuidFields)
- Skips: temporary tables, events, obsolete, cross-module without source

CodeFix:
- Replaces CreateGuid() with Guid.CreateSequentialGuid()
- Handles both bare and Guid.-qualified forms

Tests: 9 HasDiagnostic, 5 NoDiagnostic, 2 HasFix (16 total)