### PR TITLE
fix: handle BoundObjectAccess/BoundApplicationObjectAccess crashes in LC0096, LC0095, and PC0029

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -414,25 +414,25 @@ This avoids redundant `GetSymbolInfo` calls for identifiers that reference the s
 
 ## Operation-Level Symbol Resolution
 
-When working inside `RegisterOperationAction`, the bound operation tree already has symbols resolved. Prefer `IOperation.GetSymbol()` over `SemanticModel.GetSymbolInfo()` in this context.
+When working inside `RegisterOperationAction`, the bound operation tree already has symbols resolved. Prefer `IOperation.GetSymbolSafe()` over `SemanticModel.GetSymbolInfo()` in this context.
 
-### `IOperation.GetSymbol()` vs `SemanticModel.GetSymbolInfo()`
+### `IOperation.GetSymbolSafe()` vs `SemanticModel.GetSymbolInfo()`
 
 | Method | Context | Cost | Use When |
 |---|---|---|---|
-| `IOperation.GetSymbol()` | Operation analysis | O(1) property accessor on the bound tree | You have an `IOperation` (invocation instance, argument value, field access) |
+| `IOperation.GetSymbolSafe()` | Operation analysis | O(1) with type guard | You have an `IOperation` (invocation instance, argument value, field access) |
 | `SemanticModel.GetSymbolInfo(node)` | Syntax analysis | Performs semantic resolution | You have a `SyntaxNode` and no operation tree |
 
-`IOperation.GetSymbol()` is a property accessor that reads from the already-resolved bound tree, not a semantic resolution call. There is no performance benefit to pre-filtering with text checks before calling it.
+**IMPORTANT: Always use `GetSymbolSafe()` instead of `GetSymbol()`.** The SDK's `GetSymbol()` crashes with `InvalidCastException` on `BoundApplicationObjectAccess` (`DATABASE::X`, `CODEUNIT::X`) and `BoundObjectAccess` because they report `Kind = FieldAccess` but don't implement `IFieldAccess`. See "SDK GetSymbol() Bug" section below.
 
 ```csharp
 // In an OperationAnalysisContext callback:
 
 // Resolve the instance of a method invocation
-var instanceSymbol = invocation.Instance.GetSymbol();
+var instanceSymbol = invocation.Instance.GetSymbolSafe();
 
 // Resolve an argument's value
-var argumentSymbol = argument.Value.GetSymbol();
+var argumentSymbol = argument.Value.GetSymbolSafe();
 
 // Compare two symbols by identity (same variable, same declaration)
 if (instanceSymbol is not null && instanceSymbol.Equals(argumentSymbol))
@@ -441,23 +441,23 @@ if (instanceSymbol is not null && instanceSymbol.Equals(argumentSymbol))
 
 ### Unwrapping `IConversionExpression`
 
-The SDK frequently wraps argument values in `IConversionExpression` for implicit type conversions (e.g., passing a `Record "Sales Header"` where the parameter type is `Record "Sales Header"`). When this happens, `argument.Value.GetSymbol()` returns null because the conversion itself has no symbol. Unwrap through the conversion to get the actual operand's symbol:
+The SDK frequently wraps argument values in `IConversionExpression` for implicit type conversions (e.g., passing a `Record "Sales Header"` where the parameter type is `Record "Sales Header"`). When this happens, `argument.Value.GetSymbolSafe()` returns null because the conversion itself has no symbol. Unwrap through the conversion to get the actual operand's symbol:
 
 ```csharp
 private static ISymbol? ResolveArgumentSymbol(IArgument argument)
 {
-    var symbol = argument.Value.GetSymbol();
+    var symbol = argument.Value.GetSymbolSafe();
     if (symbol is not null)
         return symbol;
 
     if (argument.Value is IConversionExpression conversion)
-        return conversion.Operand.GetSymbol();
+        return conversion.Operand.GetSymbolSafe();
 
     return null;
 }
 ```
 
-This pattern appears across the codebase (e.g., `TransferFieldsSchemaCompatibility`, `PossibleOverflowAssigning`, `UsePartialRecordsOnRead`, `UnnecessaryRecordParameterInMethodCall`). Always try unwrapping when `GetSymbol()` returns null on an argument value.
+This pattern appears across the codebase (e.g., `TransferFieldsSchemaCompatibility`, `PossibleOverflowAssigning`, `UsePartialRecordsOnRead`, `UnnecessaryRecordParameterInMethodCall`). Always try unwrapping when `GetSymbolSafe()` returns null on an argument value.
 
 ## Dynamic SDK Discovery via PropertyInfoLookup
 
@@ -843,9 +843,54 @@ Build the solution and run the tests to confirm the analyzer works.
 
 - **Always use `EnumProvider`** for SDK enum values. Direct references break across BC versions.
 - **Always check `IsObsolete()` first** in every analysis method. Reporting on obsolete code creates noise.
-- **Never compare raw syntax text to identify symbols.** Do not use `syntax.ToString()`, `node.Identifier.ValueText`, or similar text-based checks to determine what a variable, method, or expression refers to. These are fragile (case-sensitive, whitespace-dependent, miss implicit conversions) and produce incorrect results when the source text doesn't match the canonical symbol name. Instead, resolve the symbol via `IOperation.GetSymbol()`, `SemanticModel.GetSymbolInfo()`, or `SemanticModel.GetDeclaredSymbol()`, then compare using symbol identity (`symbol.Equals(other)`) or symbol properties (`symbol.Kind`, `symbol.Name`). Checking `ISymbol.Name` after resolution is acceptable because it's the compiler-resolved canonical form, not raw source text.
+- **Never compare raw syntax text to identify symbols.** Do not use `syntax.ToString()`, `node.Identifier.ValueText`, or similar text-based checks to determine what a variable, method, or expression refers to. These are fragile (case-sensitive, whitespace-dependent, miss implicit conversions) and produce incorrect results when the source text doesn't match the canonical symbol name. Instead, resolve the symbol via `IOperation.GetSymbolSafe()`, `SemanticModel.GetSymbolInfo()`, or `SemanticModel.GetDeclaredSymbol()`, then compare using symbol identity (`symbol.Equals(other)`) or symbol properties (`symbol.Kind`, `symbol.Name`). Checking `ISymbol.Name` after resolution is acceptable because it's the compiler-resolved canonical form, not raw source text.
 - **Use `CancellationToken`** via `ctx.CancellationToken.ThrowIfCancellationRequested()` in loops over large collections (e.g., iterating all fields in a table).
 - **Mark analyzer classes `sealed`** unless there is a specific reason for inheritance.
 - **One analyzer class per rule or tightly related rule group.** The `AnalyzeCountMethod` analyzer handles both `LC0081` (IsEmpty) and `LC0082` (FindWithNext) because they share the same analysis logic.
 - **Use `ImmutableArray.Create()`** for `SupportedDiagnostics`, listing all descriptors the analyzer may report.
 - **Location matters.** Report diagnostics at the most specific location: the offending property, syntax node, or symbol, not the entire object.
+
+## SDK GetSymbol() Bug
+
+The BC SDK's `OperationExtensions.GetSymbol()` has a known bug: it switches on `OperationKind.FieldAccess` and casts to `IFieldAccess`, but two internal bound types use that kind without implementing `IFieldAccess`:
+
+| SDK Type | Implements | Triggered by | Returns |
+|---|---|---|---|
+| `BoundApplicationObjectAccess` | `IApplicationObjectAccess` (public) | `DATABASE::X`, `CODEUNIT::X`, `TABLE::X`, `XMLPORT::X`, `QUERY::X` | Integer (the object ID) |
+| `BoundObjectAccess` | `IObjectAccess` (internal) | Object type references | Varies |
+
+Both set `ExpressionKind => OperationKind.FieldAccess`, causing `GetSymbol()` to attempt `((IFieldAccess)operation).FieldSymbol` which throws `InvalidCastException`.
+
+### Solution: Always use `GetSymbolSafe()` instead of `GetSymbol()`
+
+`OperationSafeExtensions.GetSymbolSafe()` in `ALCops.Common/Extensions/OperationExtensions.cs` handles the bug with zero overhead:
+
+```csharp
+public static ISymbol? GetSymbolSafe(this IOperation operation)
+{
+    // BoundApplicationObjectAccess: DATABASE::X, CODEUNIT::X, etc.
+    if (operation is IApplicationObjectAccess appObjAccess)
+        return appObjAccess.ApplicationObjectTypeSymbol;
+
+    // Guard BoundObjectAccess and future mismatches
+    if (operation.Kind == EnumProvider.OperationKind.FieldAccess && operation is not IFieldAccess)
+        return null;
+
+    return operation.GetSymbol();
+}
+```
+
+- `IApplicationObjectAccess` is a public SDK interface, so the type check works directly
+- `IObjectAccess` is internal, so the `is not IFieldAccess` guard catches it generically
+- No try/catch, no exception handling overhead on the happy path
+- 25+ `GetSymbol()` call sites across all cops should migrate to `GetSymbolSafe()`
+
+### How Microsoft's own analyzers handle this
+
+CodeCop Rule 243 demonstrates the correct pattern (from decompiled source):
+```csharp
+ICodeunitTypeSymbol obj = (SemanticFacts.GetBoundExpressionArgument(invocationExpression, 0)
+    as IApplicationObjectAccess)?.ApplicationObjectTypeSymbol as ICodeunitTypeSymbol;
+```
+
+Microsoft casts to `IApplicationObjectAccess` explicitly instead of relying on `GetSymbol()`.

--- a/.github/instructions/common-library.instructions.md
+++ b/.github/instructions/common-library.instructions.md
@@ -36,6 +36,7 @@ Extension methods on SDK types. Each file extends one type or interface family.
 | `SymbolInterfaceExtensions.cs` | `ISymbol` | `GetContainingNamespaceQualifiedNameWithReflection()`, `GetPageTypeSymbol()`, `GetFlattenedControls()`, `GetFullyQualifiedObjectName(quoteIfNeeded)`, `IsObsolete()` |
 | `SyntaxNodeExtensions.cs` | `LabelPropertyValueSyntax`, `LabelSyntax`, `SyntaxNode`, `CommaSeparatedIdentifierEqualsLiteralListSyntax` | `GetIntegerPropertyValue(property)`, `GetBooleanPropertyValue(property)` (overloaded for each syntax type) |
 | `TypeSymbolInterfaceExtensions.cs` | `ITypeSymbol` | `GetTypeLength(ref isError)` |
+| `OperationExtensions.cs` | `IOperation` | `GetSymbolSafe()` - Safe replacement for SDK `GetSymbol()` that handles `BoundApplicationObjectAccess` (`DATABASE::X`, `CODEUNIT::X`) via `IApplicationObjectAccess` interface check, and guards against `BoundObjectAccess` via `is not IFieldAccess`. No try/catch. See `analyzer-development.instructions.md` "SDK GetSymbol() Bug". |
 | `IdentifierProperty.cs` | N/A (enum) | `Comment`, `Locked`, `MaxLength` |
 
 ### Helpers/

--- a/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
@@ -70,9 +70,9 @@ The walker checks ALL invocations (both built-in and user-defined) for tracked v
 
 The SDK's `OperationExtensions.GetSymbol()` throws `InvalidCastException` when the operation instance is a `BoundObjectAccess` (or `BoundApplicationObjectAccess`). These internal SDK types report `Kind = FieldAccess` but don't implement `IFieldAccess`, so the SDK's internal cast fails.
 
-The analyzer should use `GetSymbolSafe()` from `ALCops.Common.Extensions.OperationSafeExtensions` on all `GetSymbol()` call sites. This method handles the bug without exception handling: it checks `is IApplicationObjectAccess` (public SDK interface) first, then guards any remaining `FieldAccess`-kind operations that don't implement `IFieldAccess` by returning null. See the "SDK GetSymbol() Bug" section in `analyzer-development.instructions.md`.
+The analyzer uses `GetSymbolSafe()` from `ALCops.Common.Extensions.OperationSafeExtensions` on all `GetSymbol()` call sites. This method handles the bug without exception handling: it checks `is IApplicationObjectAccess` (public SDK interface) first, then guards any remaining `FieldAccess`-kind operations that don't implement `IFieldAccess` by returning null. See the "SDK GetSymbol() Bug" section in `analyzer-development.instructions.md`.
 
-This is an SDK bug. If a future SDK version fixes it, the catch becomes a no-op (harmless to keep).
+This is an SDK bug. If a future SDK version fixes it, the type checks become harmless no-ops.
 
 ## Method classification
 
@@ -115,7 +115,7 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 | LocalRecordMultipleReads | Multiple read ops on same variable (both should report) |
 | LocalRecordRefFindFirst | RecordRef FindFirst() |
 
-### NoDiagnostic (22 cases)
+### NoDiagnostic (23 cases)
 | Test case | Suppression reason |
 |---|---|
 | HasSetLoadFields | SetLoadFields already present |
@@ -140,6 +140,7 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 | CDSTable | CDS table type (non-Normal) |
 | RecordRefSetTableWithModify | RecordRef.Get() + SetTable(MyTable) + MyTable.Modify() |
 | RecordRefSetTablePassedToFunction | RecordRef.Get() + SetTable(MyTable) + MyTable passed to function |
+| DatabaseObjectReference | DATABASE::MyTable as method argument (BoundObjectAccess) |
 
 ### HasFix (11 cases)
 | Test case | Scenario |

--- a/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
@@ -68,9 +68,11 @@ The walker checks ALL invocations (both built-in and user-defined) for tracked v
 
 ### BoundObjectAccess InvalidCastException
 
-The SDK's `OperationExtensions.GetSymbol()` throws `InvalidCastException` when the operation instance is a `BoundObjectAccess`. This type reports `Kind = FieldAccess` but doesn't implement `IFieldAccess`, so the SDK's internal cast fails. The analyzer uses a `TryGetSymbol()` wrapper that catches `InvalidCastException` and returns null.
+The SDK's `OperationExtensions.GetSymbol()` throws `InvalidCastException` when the operation instance is a `BoundObjectAccess` (or `BoundApplicationObjectAccess`). These internal SDK types report `Kind = FieldAccess` but don't implement `IFieldAccess`, so the SDK's internal cast fails.
 
-This is an SDK bug. If a future SDK version fixes it, the try-catch becomes a no-op (harmless to keep).
+The analyzer should use `GetSymbolSafe()` from `ALCops.Common.Extensions.OperationSafeExtensions` on all `GetSymbol()` call sites. This method handles the bug without exception handling: it checks `is IApplicationObjectAccess` (public SDK interface) first, then guards any remaining `FieldAccess`-kind operations that don't implement `IFieldAccess` by returning null. See the "SDK GetSymbol() Bug" section in `analyzer-development.instructions.md`.
+
+This is an SDK bug. If a future SDK version fixes it, the catch becomes a no-op (harmless to keep).
 
 ## Method classification
 

--- a/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
+++ b/.github/instructions/lc0096-unnecessary-record-parameter.instructions.md
@@ -80,16 +80,22 @@ Uses `RegisterOperationAction` on `OperationKind.InvocationExpression` for singl
 
 ### Performance optimizations
 
-- **Symbol-based checks only**: Uses `IOperation.GetSymbol()` (a property accessor on the bound tree, O(1)) instead of text-based `syntax.ToString()` comparisons
+- **Symbol-based checks only**: Uses `IOperation.GetSymbolSafe()` (type-guarded O(1) accessor on the bound tree) instead of text-based `syntax.ToString()` comparisons
 - **Early exits**: Non-record invocations, empty arguments, events, and built-in methods all exit before any symbol resolution
-- **No SemanticModel retrieval**: Uses `IOperation.GetSymbol()` and `IArgument.Value.GetSymbol()` instead of `SemanticModel.GetSymbolInfo()`
+- **No SemanticModel retrieval**: Uses `IOperation.GetSymbolSafe()` and `IArgument.Value.GetSymbolSafe()` instead of `SemanticModel.GetSymbolInfo()`
 - **Conversion unwrapping**: `ResolveArgumentSymbol` handles `IConversionExpression` wrapping in a single utility method
 
 ## Known issues and workarounds
 
+### BoundApplicationObjectAccess InvalidCastException
+
+The SDK's `OperationExtensions.GetSymbol()` throws `InvalidCastException` when the operation is a `BoundApplicationObjectAccess` (or `BoundObjectAccess`). These internal SDK types report `Kind = FieldAccess` but don't implement `IFieldAccess`, causing the SDK's internal cast to fail.
+
+The analyzer uses `GetSymbolSafe()` (from `ALCops.Common.Extensions.OperationSafeExtensions`) on all `GetSymbol()` call sites. This method handles the bug without exception handling: it checks `is IApplicationObjectAccess` first (returning the `ApplicationObjectTypeSymbol`), then guards any remaining `FieldAccess`-kind operations that don't implement `IFieldAccess` by returning null. The `DatabaseObjectReference` NoDiagnostic test case covers this pattern (`DATABASE::MyTable` as a method argument).
+
 ### IConversionExpression wrapping
 
-Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.Value.GetSymbol()` returns null, the analyzer unwraps through the conversion and calls `GetSymbol()` on the operand.
+Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.Value.GetSymbolSafe()` returns null, the analyzer unwraps through the conversion and calls `GetSymbolSafe()` on the operand.
 
 ## Differences from original BC.LinterCop LC0094
 
@@ -115,7 +121,7 @@ Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.V
 | InternalPageExtensionMethodCall | `MyProcedure(Rec)` inside a page extension (local method) |
 | MultipleArguments | `MyRecord.MyProcedure(OtherParam, MyRecord)` flags matching arg |
 
-### NoDiagnostic (6 cases)
+### NoDiagnostic (7 cases)
 
 | Test case | Suppression reason |
 |---|---|
@@ -125,6 +131,7 @@ Arguments may be wrapped in `IConversionExpression` by the SDK. When `argument.V
 | PageRunModal | `Page.RunModal(Page::MyPage, MyTable)` built-in, not on the record |
 | FieldAccessExpression | `MyTable.MyProcedure(MyTable."Name")` field value, not the record |
 | PublicPageMethodWithRec | `CalculateInBackground(Rec)` on public page method (intentional API) |
+| DatabaseObjectReference | `MyTable.MyProcedure(DATABASE::MyTable, MyTable)` application object access (SDK bug trigger) |
 
 ## Phase 2 roadmap (not yet implemented)
 

--- a/.github/instructions/pc0029-use-sequential-guid.instructions.md
+++ b/.github/instructions/pc0029-use-sequential-guid.instructions.md
@@ -157,7 +157,7 @@ Provides a QuickFix "ALCops: Use CreateSequentialGuid()" that replaces `CreateGu
 
 ## Test coverage
 
-### HasDiagnostic (9 cases)
+### HasDiagnostic (10 cases)
 
 | Test case | Scenario |
 |---|---|
@@ -170,6 +170,7 @@ Provides a QuickFix "ALCops: Use CreateSequentialGuid()" that replaces `CreateGu
 | QualifiedCreateGuid | `MyTable."Primary Key" := Guid.CreateGuid()` |
 | MultiLevelTracing | `ProcA(CreateGuid())` -> ProcB(guid) -> key field assignment |
 | ValidateSecondaryKeyField | `MyTable.Validate("Index Field", CreateGuid())` for secondary key |
+| DatabaseObjectReference | `CreateGuid()` flows to key field with `DATABASE::MyTable` in same method (BoundApplicationObjectAccess) |
 
 ### NoDiagnostic (5 cases)
 

--- a/src/ALCops.Common/Extensions/OperationExtensions.cs
+++ b/src/ALCops.Common/Extensions/OperationExtensions.cs
@@ -1,0 +1,45 @@
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+
+namespace ALCops.Common.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IOperation"/> that provide safe alternatives
+/// to SDK methods with known bugs.
+/// </summary>
+public static class OperationSafeExtensions
+{
+    /// <summary>
+    /// Safe replacement for the SDK's <c>OperationExtensions.GetSymbol()</c> which
+    /// crashes with <see cref="InvalidCastException"/> on certain bound types.
+    /// <para>
+    /// The SDK's method switches on <c>OperationKind.FieldAccess</c> and casts to
+    /// <see cref="IFieldAccess"/>, but <c>BoundApplicationObjectAccess</c> (for
+    /// <c>DATABASE::X</c>, <c>CODEUNIT::X</c> etc.) and <c>BoundObjectAccess</c>
+    /// both report <c>FieldAccess</c> kind while implementing different interfaces.
+    /// </para>
+    /// <para>
+    /// This method handles <see cref="IApplicationObjectAccess"/> (public SDK interface)
+    /// by returning its <c>ApplicationObjectTypeSymbol</c>, and guards against any other
+    /// <c>FieldAccess</c>-kind operations that don't implement <see cref="IFieldAccess"/>
+    /// by returning <c>null</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="operation">The operation to resolve.</param>
+    /// <returns>The resolved symbol, or <c>null</c> if the operation type is unsupported.</returns>
+    public static ISymbol? GetSymbolSafe(this IOperation operation)
+    {
+        // BoundApplicationObjectAccess: reports FieldAccess kind but implements
+        // IApplicationObjectAccess (DATABASE::X, CODEUNIT::X, TABLE::X, etc.)
+        if (operation is IApplicationObjectAccess appObjAccess)
+            return appObjAccess.ApplicationObjectTypeSymbol;
+
+        // Guard against BoundObjectAccess and any future types that report FieldAccess
+        // but don't implement IFieldAccess. IObjectAccess is internal so we can't check
+        // it directly; the is-not-IFieldAccess guard catches it generically.
+        if (operation.Kind == EnumProvider.OperationKind.FieldAccess && operation is not IFieldAccess)
+            return null;
+
+        return operation.GetSymbol();
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DatabaseObjectReference.al
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/NoDiagnostic/DatabaseObjectReference.al
@@ -1,0 +1,21 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure MyProcedure(TableNo: Integer; var MyTableParam: Record MyTable)
+    begin
+    end;
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure CallMyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.MyProcedure([|DATABASE::MyTable|], MyTable);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UnnecessaryRecordParameterInMethodCall/UnnecessaryRecordParameterInMethodCall.cs
@@ -46,6 +46,7 @@ namespace ALCops.LinterCop.Test
         [TestCase("PageRunModal")]
         [TestCase("FieldAccessExpression")]
         [TestCase("PublicPageMethodWithRec")]
+        [TestCase("DatabaseObjectReference")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/DatabaseObjectReference.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/DatabaseObjectReference.al
@@ -1,0 +1,47 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        ReservEntry: Record ReservEntry;
+    begin
+        ReservEntry.SetSourceFilter(DATABASE::MyTable, 0, 'TEST', 0, false);
+        [|ReservEntry.FindFirst()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}
+
+table 50101 ReservEntry
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Source Type"; Integer) { }
+        field(3; "Source Subtype"; Integer) { }
+        field(4; "Source ID"; Code[20]) { }
+        field(5; "Source Batch Name"; Code[10]) { }
+        field(6; "Source Ref. No."; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { }
+    }
+
+    procedure SetSourceFilter(SourceType: Integer; SourceSubtype: Integer; SourceID: Code[20]; SourceRefNo: Integer; SourceBatchName: Boolean)
+    begin
+        // stub
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -59,6 +59,7 @@ namespace ALCops.LinterCop.Test
         [TestCase("CDSTable")]
         [TestCase("RecordRefSetTableWithModify")]
         [TestCase("RecordRefSetTablePassedToFunction")]
+        [TestCase("DatabaseObjectReference")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop/Analyzers/UnnecessaryRecordParameterInMethodCall.cs
+++ b/src/ALCops.LinterCop/Analyzers/UnnecessaryRecordParameterInMethodCall.cs
@@ -11,7 +11,8 @@ namespace ALCops.LinterCop.Analyzers;
 public sealed class UnnecessaryRecordParameterInMethodCall : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        ImmutableArray.Create(DiagnosticDescriptors.UnnecessaryRecordParameterInMethodCall);
+        ImmutableArray.Create(
+            DiagnosticDescriptors.UnnecessaryRecordParameterInMethodCall);
 
     public override void Initialize(AnalysisContext context) =>
         context.RegisterOperationAction(
@@ -53,7 +54,7 @@ public sealed class UnnecessaryRecordParameterInMethodCall : DiagnosticAnalyzer
         if (invocation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
             return;
 
-        var instanceSymbol = invocation.Instance.GetSymbol();
+        var instanceSymbol = invocation.Instance.GetSymbolSafe();
         if (instanceSymbol is null)
             return;
 
@@ -115,15 +116,17 @@ public sealed class UnnecessaryRecordParameterInMethodCall : DiagnosticAnalyzer
     /// <summary>
     /// Resolves the symbol from an argument value, unwrapping through
     /// <c>IConversionExpression</c> when the SDK wraps the operand.
+    /// Uses <see cref="OperationSafeExtensions.GetSymbolSafe"/> to guard against
+    /// SDK bugs with <c>BoundApplicationObjectAccess</c>.
     /// </summary>
     private static ISymbol? ResolveArgumentSymbol(IArgument argument)
     {
-        var symbol = argument.Value.GetSymbol();
+        var symbol = argument.Value.GetSymbolSafe();
         if (symbol is not null)
             return symbol;
 
         if (argument.Value is IConversionExpression conversion)
-            return conversion.Operand.GetSymbol();
+            return conversion.Operand.GetSymbolSafe();
 
         return null;
     }

--- a/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
@@ -187,7 +187,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
         public override void VisitInvocationExpression(IInvocationExpression operation)
         {
             _cancellationToken.ThrowIfCancellationRequested();
-            var instanceSymbol = operation.Instance?.GetSymbol();
+            var instanceSymbol = operation.Instance?.GetSymbolSafe();
 
             if (instanceSymbol != null &&
                 _trackedVariables.TryGetValue(instanceSymbol.Name, out var state))

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DatabaseObjectReference.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/HasDiagnostic/DatabaseObjectReference.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyGuid: Guid;
+        MyTable: Record MyTable;
+    begin
+        MyGuid := [|CreateGuid()|];
+        MyTable."Source Type" := DATABASE::MyTable;
+        MyTable."Primary Key" := MyGuid;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Guid) { }
+        field(2; "Source Type"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSequentialGuid/UseSequentialGuid.cs
@@ -30,6 +30,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("QualifiedCreateGuid")]
         [TestCase("MultiLevelTracing")]
         [TestCase("ValidateSecondaryKeyField")]
+        [TestCase("DatabaseObjectReference")]
         public async Task HasDiagnostic(string testCase)
         {
             // https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/guid/guid-createsequentialguid-method

--- a/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
@@ -123,7 +123,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
                 else
                 {
                     // Variable assignment: v := CreateGuid()
-                    var targetSymbol = operation.Target?.GetSymbol();
+                    var targetSymbol = operation.Target?.GetSymbolSafe();
                     if (targetSymbol is not null && targetSymbol.Kind == EnumProvider.SymbolKind.LocalVariable)
                     {
                         var bodyOp = _context.SemanticModel.GetOperation(
@@ -331,7 +331,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
         private bool IsTrackedSymbol(IOperation operation)
         {
             var op = UnwrapConversion(operation);
-            var symbol = op.GetSymbol();
+            var symbol = op.GetSymbolSafe();
             return symbol is not null && symbol.Equals(_tracked);
         }
     }
@@ -376,7 +376,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
 
         var firstArg = UnwrapConversion(validateCall.Arguments[0].Value);
 
-        if (firstArg.GetSymbol() is not IFieldSymbol fieldSymbol)
+        if (firstArg.GetSymbolSafe() is not IFieldSymbol fieldSymbol)
             return null;
 
         if (fieldSymbol.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Guid)


### PR DESCRIPTION
## Problem

Three analyzers crash with `InvalidCastException` when AL code uses `DATABASE::<Table>`, `CODEUNIT::<Codeunit>`, or similar application object references as method arguments:

- **LC0096** `UnnecessaryRecordParameterInMethodCall` (BoundApplicationObjectAccess)
- **LC0095** `UsePartialRecordsOnRead` (BoundObjectAccess)
- **PC0029** `UseSequentialGuid` (BoundApplicationObjectAccess)

```
System.InvalidCastException: Unable to cast object of type
'Microsoft.Dynamics.Nav.CodeAnalysis.BoundApplicationObjectAccess'
to type 'Microsoft.Dynamics.Nav.CodeAnalysis.IFieldAccess'.
```

## Root cause

The SDK's `OperationExtensions.GetSymbol()` switches on `OperationKind.FieldAccess` and casts to `IFieldAccess`. However:
- `BoundApplicationObjectAccess` reports `ExpressionKind => FieldAccess` while implementing `IApplicationObjectAccess`, not `IFieldAccess`
- `BoundObjectAccess` reports `ExpressionKind => FieldAccess` while implementing internal `IObjectAccess`, not `IFieldAccess`

## Fix

Added `GetSymbolSafe()` extension method in `ALCops.Common` that handles the SDK bug with zero-overhead type checks (no try/catch):

1. `is IApplicationObjectAccess` → returns `ApplicationObjectTypeSymbol` (correct symbol)
2. `FieldAccess kind && is not IFieldAccess` → returns null (guards BoundObjectAccess and future mismatches)
3. Otherwise → delegates to SDK `GetSymbol()`

Updated all three analyzers to use `GetSymbolSafe()`:
- **LC0096**: 3 call sites in `ResolveArgumentSymbol` and `AnalyzeExternalCall`
- **LC0095**: 1 call site in `SetLoadFieldsWalker.VisitInvocationExpression`
- **PC0029**: 3 call sites in `CreateGuidFlowWalker`, `SymbolFlowTracer`, and `CheckValidateTarget`

## Testing

- **LC0096**: Added `DatabaseObjectReference` NoDiagnostic test (7 total)
- **LC0095**: Added `DatabaseObjectReference` NoDiagnostic test (23 total)
- **PC0029**: Added `DatabaseObjectReference` HasDiagnostic test (10 total) — confirms the analyzer correctly traces `CreateGuid()` to a key field when `DATABASE::X` is in the same method
- All tests pass across all 6 test projects

## Follow-up

Other analyzers with direct `GetSymbol()` calls should migrate to `GetSymbolSafe()` in a separate PR.