### PR TITLE
fix(LC0095): flow-sensitive analysis for SetLoadFields, Clear/Reset, and control flow

### DIFF
--- a/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
@@ -104,6 +104,12 @@ Uses `RegisterCodeBlockAction` (not `RegisterOperationAction`) to analyze entire
 | `MyTable.Reset()` | Built-in instance method `Reset` on tracked variable | Reset all three boolean flags |
 | `MyTable.SetLoadFields()` | Built-in instance method `SetLoadFields` with 0 arguments | Reset `HasLoadFields` only |
 
+### Merge deduplication (prevents OOM on large codebases)
+
+Pre-fork reads are cloned into both branches during fork. Without deduplication, concatenating both branches at merge doubles the list size at each nesting level, causing exponential growth (2^K entries after K levels). With deeply nested if-statements and many tracked variables (common in large apps like the Base App), this caused `OutOfMemoryException` in `FlowFlags.Clone()`.
+
+Fix: deduplicate reads by `SourceSpan.Start` position (via `HashSet<int>`) at every merge point. List size is bounded by the number of unique read operations regardless of nesting depth.
+
 ### Key implementation detail: argument checking
 
 The walker checks ALL invocations (both built-in and user-defined) for tracked variables in arguments. This is necessary because built-in methods like `PAGE.Run(PageId, Record)` pass the record to a page that will access its fields. The `GetVariableNameFromArgument` method only matches direct variable identifiers (e.g., `Item` in `PAGE.Run(PAGE::"Item Card", Item)`), not field access expressions (e.g., `MyTable."No."` in `SetRange`), so this doesn't cause false positives on record method arguments.

--- a/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/lc0095-use-partial-records-on-read.instructions.md
@@ -41,6 +41,19 @@ These decisions were made during the initial design and should be preserved unle
 | RecordRef.SetTable(Record) | Link suppression to target Record | If target has write ops, passed to function, load fields, or is non-local/unresolvable: suppress RecordRef. Only simple overload (1 arg). |
 | RecordRef.SetTable(Record, Boolean) | Out of scope | ShareTable overload not handled; revisit if users report false positives |
 | RecordRef.GetTable | Out of scope | Reverse direction; only SetTable for now |
+| Flow-sensitive analysis | Forward dataflow with fork/merge at branches | Fixes false negatives where SetLoadFields after read, Clear between SetLoadFields and read, or SetLoadFields in one branch suppressed diagnostics elsewhere |
+| All three flags flow-aware | Yes (HasLoadFields, HasWriteOp, PassedToFunction) | Clear/Reset should reset all state; all flags have the same positional bug class |
+| HasLoadFields merge rule | AND (intersection) | If any code path lacks SetLoadFields, the read might execute without it |
+| HasWriteOp/PassedToFunction merge rule | OR (union) | Conservative: if any path writes/passes, suggesting SetLoadFields could interfere |
+| Clear(var) resets all flags | Yes | Clear completely reinitializes the variable, invalidating prior state |
+| Reset() resets all flags | Yes | Reset clears all filters and state on the record |
+| SetLoadFields() no args | Resets HasLoadFields only | Only affects the partial records state, not write/pass flags |
+| ClearAll() | Out of scope | Extremely rare, affects all variables, complex to handle |
+| while/for/foreach body | Merge pre-loop with post-body | Body might not execute |
+| repeat-until body | Use post-body state directly | Body always executes at least once |
+| Retroactive read clearing | Clear UncoveredReads when write/pass encountered | Handles `Get(); Modify()` pattern where write comes after read |
+| Loop analysis | Single pass, no fixed-point iteration | Acceptable approximation; fixed-point adds complexity for rare edge cases |
+| RecordRef flow analysis | Kept method-level (EverHad* flags) | RecordRef SetTable linkage is already complex; bug fixes focus on Record variables |
 
 ## Architecture
 
@@ -48,21 +61,74 @@ These decisions were made during the initial design and should be preserved unle
 
 Uses `RegisterCodeBlockAction` (not `RegisterOperationAction`) to analyze entire method/trigger bodies in a single pass. This avoids redundant walks when multiple read operations exist on the same variable.
 
-### Analysis flow
+### Analysis flow (flow-sensitive forward dataflow)
 
 1. Extract local variables of type `Record` (non-temp, Normal table) or `RecordRef` from `IMethodSymbol.LocalVariables`
 2. Get `IOperation` tree from the code block via `SemanticModel.GetOperation(body)`
-3. Walk with `SetLoadFieldsWalker` (extends `OperationWalker`), tracking per-variable:
-   - `ReadLocations`: Get, Find, FindFirst, FindLast, FindSet calls
-   - `HasLoadFieldsCall`: SetLoadFields, AddLoadFields, SetBaseLoadFields present
-   - `HasWriteOp`: Insert, Modify, ModifyAll, Delete, DeleteAll, Rename, TransferFields, Init, Copy
-   - `PassedToFunction`: Variable appears as argument to ANY invocation, or a non-built-in method is called ON the variable
-4. Report at each read location where none of the suppression conditions are met
-5. For RecordRef variables with `SetTable(TargetRecord)` calls: suppress if any target is unresolvable, non-local, or has a suppression condition (write op, passed to function, load fields)
+3. Walk with `SetLoadFieldsWalker` (extends `OperationWalker`), maintaining per-variable `FlowFlags`:
+   - `HasLoadFields`: bool, true when SetLoadFields/AddLoadFields/SetBaseLoadFields encountered on current path
+   - `HasWriteOp`: bool, true when Insert/Modify/ModifyAll/Delete/DeleteAll/Rename/TransferFields/Init/Copy encountered
+   - `PassedToFunction`: bool, true when variable passed as argument to any invocation or non-built-in method called on it
+   - `UncoveredReads`: List of read locations where none of the above flags were true at the time of the read
+4. **Read evaluation is immediate**: When a read (Get/Find/FindFirst/FindLast/FindSet) is encountered, the current flow state determines whether to flag it. If `!HasLoadFields && !HasWriteOp && !PassedToFunction`, the read is added to `UncoveredReads`.
+5. **Retroactive clearing**: When a write/pass operation is encountered, `UncoveredReads` is cleared (reads before the write are retroactively suppressed). This handles the pattern `Get(); Modify()` where the write comes after the read.
+6. **Control flow**: Override `VisitIfStatement`, `VisitCaseStatement`, and loop visit methods with fork/merge semantics.
+7. **Reset detection**: `Clear(var)`, `var.Reset()`, and `var.SetLoadFields()` with no arguments reset flow flags.
+8. Post-walk: `FinalizeResults()` deduplicates uncovered reads and copies them to `VariableState.UncoveredReadLocations`.
+9. For RecordRef variables with `SetTable(TargetRecord)` calls: suppress if any target is unresolvable, non-local, or has a suppression condition (uses method-level `EverHad*` flags).
+
+### Control flow fork/merge semantics
+
+| Construct | Fork | Merge |
+|---|---|---|
+| `if-then-else` | Clone pre-branch state for each branch | Merge both branches at join point |
+| `if-then` (no else) | Clone for the then-branch | Merge then-branch with pre-branch state (implicit empty else) |
+| `case` | Clone pre-case state for each case line and else | Merge all branches at join point |
+| `while`/`for`/`foreach` | Visit condition/init, clone for body | Merge post-body with pre-loop state (body might not execute) |
+| `repeat-until` | Visit body directly | Use post-body state (body always executes at least once) |
+
+### Merge rules
+
+| Flag | Merge rule | Rationale |
+|---|---|---|
+| `HasLoadFields` | AND (all branches must have it) | If any path lacks SetLoadFields, the read might execute without it |
+| `HasWriteOp` | OR (any branch having it) | If any path writes, suggesting SetLoadFields could interfere |
+| `PassedToFunction` | OR (any branch having it) | If any path passes the variable, callee might access any field |
+| `UncoveredReads` | Union (concat all branches) | A read uncovered in ANY branch should be reported |
+
+### Reset operations
+
+| Operation | Detection | Effect |
+|---|---|---|
+| `Clear(MyTable)` | Built-in invocation `Clear`, arg[0] is tracked variable | Reset all three boolean flags |
+| `MyTable.Reset()` | Built-in instance method `Reset` on tracked variable | Reset all three boolean flags |
+| `MyTable.SetLoadFields()` | Built-in instance method `SetLoadFields` with 0 arguments | Reset `HasLoadFields` only |
 
 ### Key implementation detail: argument checking
 
 The walker checks ALL invocations (both built-in and user-defined) for tracked variables in arguments. This is necessary because built-in methods like `PAGE.Run(PageId, Record)` pass the record to a page that will access its fields. The `GetVariableNameFromArgument` method only matches direct variable identifiers (e.g., `Item` in `PAGE.Run(PAGE::"Item Card", Item)`), not field access expressions (e.g., `MyTable."No."` in `SetRange`), so this doesn't cause false positives on record method arguments.
+
+### Dual-direction suppression
+
+Write/pass operations suppress reads in both directions:
+- **Forward**: Write/pass BEFORE a read causes the flag check at read time to suppress it
+- **Backward**: Write/pass AFTER a read retroactively clears `UncoveredReads` (handles `Get(); Modify()` pattern)
+
+### State architecture
+
+```
+FlowFlags (per-variable, forked/merged at branches):
+  - HasLoadFields: bool
+  - HasWriteOp: bool
+  - PassedToFunction: bool
+  - UncoveredReads: List<ReadInfo>
+
+VariableState (per-variable, method-level accumulated):
+  - UncoveredReadLocations: List<ReadInfo> (populated by FinalizeResults after walk)
+  - IsRecordRef: bool
+  - SetTableTargets: List<string?>
+  - EverHadLoadFields/EverHadWriteOp/EverPassedToFunction: bool (for RecordRef SetTable check)
+```
 
 ## Known issues and workarounds
 
@@ -85,6 +151,9 @@ This is an SDK bug. If a future SDK version fixes it, the type checks become har
 ### Write/mutation methods (suppress entire variable)
 `Insert`, `Modify`, `ModifyAll`, `Delete`, `DeleteAll`, `Rename`, `TransferFields`, `Init`, `Copy`
 
+### Reset methods (clear flow flags)
+`Clear(var)` (built-in), `Reset()` (instance method), `SetLoadFields()` with 0 arguments (resets HasLoadFields only)
+
 ## Relationship to AA0242
 
 AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** to LC0095:
@@ -102,9 +171,9 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 
 ## Test coverage
 
-40 test cases organized as:
+52 test cases organized as:
 
-### HasDiagnostic (7 cases)
+### HasDiagnostic (16 cases)
 | Test case | Scenario |
 |---|---|
 | LocalRecordGet | Basic Get() without SetLoadFields |
@@ -114,8 +183,17 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 | LocalRecordFind | Find() |
 | LocalRecordMultipleReads | Multiple read ops on same variable (both should report) |
 | LocalRecordRefFindFirst | RecordRef FindFirst() |
+| SetLoadFieldsAfterGet | SetLoadFields AFTER Get (Bug A: statement ordering) |
+| ClearBetweenSetLoadFieldsAndGet | Clear() invalidates SetLoadFields before Get (Bug B) |
+| ResetBetweenSetLoadFieldsAndGet | Reset() invalidates SetLoadFields before Get (Bug B) |
+| SetLoadFieldsNoArgsBetween | SetLoadFields() with 0 args resets partial records state (Bug B) |
+| CaseBranchWithoutSetLoadFields | SetLoadFields in one case branch, Get in other branches (Bug C) |
+| IfBranchWithoutSetLoadFields | SetLoadFields in if-true, Get in else branch (Bug C) |
+| ClearResetsWriteOp | Modify then Clear then Get (Clear resets write op flag) |
+| ClearResetsPassedToFunction | PassedToFunction then Clear then Get (Clear resets passed flag) |
+| LoopNoSetLoadFields | FindSet in while condition + Get in body, no SetLoadFields |
 
-### NoDiagnostic (23 cases)
+### NoDiagnostic (25 cases)
 | Test case | Suppression reason |
 |---|---|
 | HasSetLoadFields | SetLoadFields already present |
@@ -141,6 +219,8 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 | RecordRefSetTableWithModify | RecordRef.Get() + SetTable(MyTable) + MyTable.Modify() |
 | RecordRefSetTablePassedToFunction | RecordRef.Get() + SetTable(MyTable) + MyTable passed to function |
 | DatabaseObjectReference | DATABASE::MyTable as method argument (BoundObjectAccess) |
+| IfBothBranchesSetLoadFields | SetLoadFields in both if branches, Get after if (AND merge) |
+| LoopSetLoadFieldsBefore | SetLoadFields before while loop, Get inside loop body |
 
 ### HasFix (11 cases)
 | Test case | Scenario |

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using NavCodeAnalysis = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavCodeAnalysisSemantics = Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
 
 namespace ALCops.Common.Reflection;
 
@@ -287,6 +288,19 @@ public static class EnumProvider
         public static NavCodeAnalysis.FieldClassKind FlowField => _flowField.Value;
         public static NavCodeAnalysis.FieldClassKind FlowFilter => _flowFilter.Value;
         public static NavCodeAnalysis.FieldClassKind Normal => _normal.Value;
+    }
+    /// <summary>
+    /// LoopKind enum values (from Microsoft.Dynamics.Nav.CodeAnalysis.Semantics)
+    /// </summary>
+    public static class LoopKind
+    {
+        private static readonly Lazy<NavCodeAnalysisSemantics.LoopKind> _while =
+            new(() => ParseEnum<NavCodeAnalysisSemantics.LoopKind>(nameof(NavCodeAnalysisSemantics.LoopKind.While)));
+        private static readonly Lazy<NavCodeAnalysisSemantics.LoopKind> _repeat =
+            new(() => ParseEnum<NavCodeAnalysisSemantics.LoopKind>(nameof(NavCodeAnalysisSemantics.LoopKind.Repeat)));
+
+        public static NavCodeAnalysisSemantics.LoopKind While => _while.Value;
+        public static NavCodeAnalysisSemantics.LoopKind Repeat => _repeat.Value;
     }
     /// <summary>
     /// MethodKind enum values

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/CaseBranchWithoutSetLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/CaseBranchWithoutSetLoadFields.al
@@ -1,0 +1,39 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyEnum: Enum MyEnum;
+    begin
+        case MyEnum of
+            MyEnum::" ":
+                begin
+                    MyTable.SetLoadFields(MyTable.MyField);
+                    MyTable.Get();
+                end;
+            MyEnum::MyValue:
+                [|MyTable.Get()|];
+            else
+                [|MyTable.Get()|];
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}
+
+enum 50100 MyEnum
+{
+    value(0; " ") { }
+    value(1; MyValue) { }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearBetweenSetLoadFieldsAndGet.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearBetweenSetLoadFieldsAndGet.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        Clear(MyTable);
+        [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsPassedToFunction.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsPassedToFunction.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        ProcessRecord(MyTable);
+        Clear(MyTable);
+        [|MyTable.Get()|];
+    end;
+
+    local procedure ProcessRecord(MyRecord: Record MyTable)
+    begin
+        // do something
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsWriteOp.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsWriteOp.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Modify();
+        Clear(MyTable);
+        [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/IfBranchWithoutSetLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/IfBranchWithoutSetLoadFields.al
@@ -1,0 +1,27 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        Condition: Boolean;
+    begin
+        if Condition then begin
+            MyTable.SetLoadFields(MyTable.MyField);
+            MyTable.Get();
+        end else
+            [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LoopNoSetLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LoopNoSetLoadFields.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        while [|MyTable.FindSet()|] do
+            [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ResetBetweenSetLoadFieldsAndGet.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ResetBetweenSetLoadFieldsAndGet.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        MyTable.Reset();
+        [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsAfterGet.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsAfterGet.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        MyTable.SetLoadFields(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsNoArgsBetween.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsNoArgsBetween.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        MyTable.SetLoadFields();
+        [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/IfBothBranchesSetLoadFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/IfBothBranchesSetLoadFields.al
@@ -1,0 +1,27 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        Condition: Boolean;
+    begin
+        if Condition then
+            MyTable.SetLoadFields(MyTable.MyField)
+        else
+            MyTable.SetLoadFields(MyTable.MyField);
+        [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/LoopSetLoadFieldsBefore.al
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/LoopSetLoadFieldsBefore.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        Condition: Boolean;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        while Condition do
+            [|MyTable.Get()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -28,6 +28,15 @@ namespace ALCops.LinterCop.Test
         [TestCase("LocalRecordFind")]
         [TestCase("LocalRecordMultipleReads")]
         [TestCase("LocalRecordRefFindFirst")]
+        [TestCase("SetLoadFieldsAfterGet")]
+        [TestCase("ClearBetweenSetLoadFieldsAndGet")]
+        [TestCase("ResetBetweenSetLoadFieldsAndGet")]
+        [TestCase("SetLoadFieldsNoArgsBetween")]
+        [TestCase("CaseBranchWithoutSetLoadFields")]
+        [TestCase("IfBranchWithoutSetLoadFields")]
+        [TestCase("ClearResetsWriteOp")]
+        [TestCase("ClearResetsPassedToFunction")]
+        [TestCase("LoopNoSetLoadFields")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -60,6 +69,8 @@ namespace ALCops.LinterCop.Test
         [TestCase("RecordRefSetTableWithModify")]
         [TestCase("RecordRefSetTablePassedToFunction")]
         [TestCase("DatabaseObjectReference")]
+        [TestCase("IfBothBranchesSetLoadFields")]
+        [TestCase("LoopSetLoadFieldsBefore")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
@@ -3,6 +3,7 @@ using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 
@@ -62,21 +63,19 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
 
         var walker = new SetLoadFieldsWalker(trackedVariables, context.CancellationToken);
         walker.Visit(operation);
+        walker.FinalizeResults();
 
         foreach (var kvp in trackedVariables)
         {
             var state = kvp.Value;
 
-            if (state.ReadLocations.Count == 0 ||
-                state.HasLoadFieldsCall ||
-                state.HasWriteOp ||
-                state.PassedToFunction)
+            if (state.UncoveredReadLocations.Count == 0)
                 continue;
 
             if (state.IsRecordRef && ShouldSuppressViaSetTable(state, trackedVariables))
                 continue;
 
-            foreach (var readInfo in state.ReadLocations)
+            foreach (var readInfo in state.UncoveredReadLocations)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.UsePartialRecordsOnRead,
@@ -105,7 +104,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
     /// <summary>
     /// When a RecordRef calls SetTable(TargetRecord), the RecordRef's diagnostic is suppressed if:
     /// - Any target is unresolvable (null) or not a tracked local variable (conservative)
-    /// - Any tracked target has a suppression condition (write op, passed to function, has load fields call)
+    /// - Any tracked target ever had a suppression condition (write op, passed to function, load fields call)
     /// </summary>
     private static bool ShouldSuppressViaSetTable(VariableState state,
         Dictionary<string, VariableState> trackedVariables)
@@ -118,7 +117,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
             if (targetName is null || !trackedVariables.TryGetValue(targetName, out var targetState))
                 return true;
 
-            if (targetState.HasWriteOp || targetState.PassedToFunction || targetState.HasLoadFieldsCall)
+            if (targetState.EverHadWriteOp || targetState.EverPassedToFunction || targetState.EverHadLoadFields)
                 return true;
         }
 
@@ -148,12 +147,46 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
 
     private sealed class VariableState
     {
-        public List<ReadInfo> ReadLocations { get; } = new();
-        public bool HasLoadFieldsCall { get; set; }
-        public bool HasWriteOp { get; set; }
-        public bool PassedToFunction { get; set; }
+        public List<ReadInfo> UncoveredReadLocations { get; } = new();
         public bool IsRecordRef { get; set; }
         public List<string?> SetTableTargets { get; } = new();
+        // Method-level "ever" flags used only for RecordRef SetTable suppression check
+        public bool EverHadLoadFields { get; set; }
+        public bool EverHadWriteOp { get; set; }
+        public bool EverPassedToFunction { get; set; }
+    }
+
+    /// <summary>
+    /// Per-variable flow state tracked during the walk. Forked at branch points, merged at join points.
+    /// UncoveredReads accumulates reads not covered by SetLoadFields. Write/pass operations
+    /// retroactively clear this list (a write after a read means SetLoadFields could break the write).
+    /// At branch merge, uncovered reads from all branches are unioned.
+    /// </summary>
+    private sealed class FlowFlags
+    {
+        public bool HasLoadFields { get; set; }
+        public bool HasWriteOp { get; set; }
+        public bool PassedToFunction { get; set; }
+        public List<ReadInfo> UncoveredReads { get; private set; } = new();
+
+        public FlowFlags Clone() => new()
+        {
+            HasLoadFields = HasLoadFields,
+            HasWriteOp = HasWriteOp,
+            PassedToFunction = PassedToFunction,
+            UncoveredReads = new List<ReadInfo>(UncoveredReads)
+        };
+
+        /// <summary>
+        /// Resets boolean flow flags (used by Clear/Reset operations).
+        /// Does NOT clear UncoveredReads: reads before Clear are still genuinely uncovered.
+        /// </summary>
+        public void ResetFlags()
+        {
+            HasLoadFields = false;
+            HasWriteOp = false;
+            PassedToFunction = false;
+        }
     }
 
 #if NETSTANDARD2_1
@@ -175,6 +208,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
     private sealed class SetLoadFieldsWalker : OperationWalker
     {
         private readonly Dictionary<string, VariableState> _trackedVariables;
+        private readonly Dictionary<string, FlowFlags> _flowState;
         private readonly CancellationToken _cancellationToken;
 
         public SetLoadFieldsWalker(Dictionary<string, VariableState> trackedVariables,
@@ -182,6 +216,30 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
         {
             _trackedVariables = trackedVariables;
             _cancellationToken = cancellationToken;
+            _flowState = new Dictionary<string, FlowFlags>(StringComparer.OrdinalIgnoreCase);
+            foreach (var key in trackedVariables.Keys)
+                _flowState[key] = new FlowFlags();
+        }
+
+        /// <summary>
+        /// Copies final uncovered reads from flow state into VariableState for reporting.
+        /// Deduplicates by source span start position (reads before a branch fork appear
+        /// in both branch copies and get unioned at merge).
+        /// </summary>
+        public void FinalizeResults()
+        {
+            foreach (var kvp in _flowState)
+            {
+                if (!_trackedVariables.TryGetValue(kvp.Key, out var state))
+                    continue;
+
+                var seen = new HashSet<int>();
+                foreach (var read in kvp.Value.UncoveredReads)
+                {
+                    if (seen.Add(read.Location.SourceSpan.Start))
+                        state.UncoveredReadLocations.Add(read);
+                }
+            }
         }
 
         public override void VisitInvocationExpression(IInvocationExpression operation)
@@ -190,9 +248,10 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
             var instanceSymbol = operation.Instance?.GetSymbolSafe();
 
             if (instanceSymbol != null &&
-                _trackedVariables.TryGetValue(instanceSymbol.Name, out var state))
+                _trackedVariables.TryGetValue(instanceSymbol.Name, out var state) &&
+                _flowState.TryGetValue(instanceSymbol.Name, out var flowFlags))
             {
-                ClassifyInstanceMethodCall(operation, state);
+                ClassifyInstanceMethodCall(operation, state, flowFlags);
             }
 
             CheckArgumentsForTrackedVariables(operation);
@@ -200,18 +259,212 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
             base.VisitInvocationExpression(operation);
         }
 
-        private static void ClassifyInstanceMethodCall(IInvocationExpression operation, VariableState state)
+        #region Control flow overrides
+
+        public override void VisitIfStatement(IIfStatement operation)
+        {
+            Visit(operation.Condition);
+
+            var preBranchState = SaveFlowState();
+
+            Visit(operation.IfTrueStatement);
+            var trueBranchState = SaveFlowState();
+
+            RestoreFlowState(preBranchState);
+            Visit(operation.IfFalseStatement);
+            var falseBranchState = SaveFlowState();
+
+            MergeFlowStates(trueBranchState, falseBranchState);
+        }
+
+        public override void VisitCaseStatement(ICaseStatement operation)
+        {
+            Visit(operation.Value);
+
+            var preCaseState = SaveFlowState();
+            var branchStates = new List<Dictionary<string, FlowFlags>>();
+
+            foreach (var caseLine in operation.CaseLines)
+            {
+                RestoreFlowState(preCaseState);
+                Visit(caseLine);
+                branchStates.Add(SaveFlowState());
+            }
+
+            if (operation.ElseStatement != null)
+            {
+                RestoreFlowState(preCaseState);
+                Visit(operation.ElseStatement);
+                branchStates.Add(SaveFlowState());
+            }
+            else
+            {
+                // No else clause: implicit empty branch with pre-case state
+                branchStates.Add(CloneState(preCaseState));
+            }
+
+            MergeFlowStates(branchStates);
+        }
+
+        public override void VisitWhileRepeatLoopStatement(IWhileRepeatLoopStatement operation)
+        {
+            if (operation.LoopKind == EnumProvider.LoopKind.Repeat)
+            {
+                // repeat-until: body always executes at least once
+                Visit(operation.Body);
+                Visit(operation.Condition);
+            }
+            else
+            {
+                // while-do: body might not execute
+                Visit(operation.Condition);
+
+                var preLoopState = SaveFlowState();
+                Visit(operation.Body);
+                var postBodyState = SaveFlowState();
+
+                MergeFlowStates(preLoopState, postBodyState);
+            }
+        }
+
+        public override void VisitForLoopStatement(IForLoopStatement operation)
+        {
+            Visit(operation.InitialValue);
+            Visit(operation.EndValue);
+
+            var preLoopState = SaveFlowState();
+            Visit(operation.Body);
+            var postBodyState = SaveFlowState();
+
+            MergeFlowStates(preLoopState, postBodyState);
+        }
+
+        public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
+        {
+            Visit(operation.Expression);
+
+            var preLoopState = SaveFlowState();
+            Visit(operation.Body);
+            var postBodyState = SaveFlowState();
+
+            MergeFlowStates(preLoopState, postBodyState);
+        }
+
+        #endregion
+
+        #region Flow state management
+
+        private Dictionary<string, FlowFlags> SaveFlowState()
+        {
+            var saved = new Dictionary<string, FlowFlags>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in _flowState)
+                saved[kvp.Key] = kvp.Value.Clone();
+            return saved;
+        }
+
+        private void RestoreFlowState(Dictionary<string, FlowFlags> saved)
+        {
+            foreach (var kvp in saved)
+            {
+                if (_flowState.TryGetValue(kvp.Key, out var current))
+                {
+                    current.HasLoadFields = kvp.Value.HasLoadFields;
+                    current.HasWriteOp = kvp.Value.HasWriteOp;
+                    current.PassedToFunction = kvp.Value.PassedToFunction;
+                    current.UncoveredReads.Clear();
+                    current.UncoveredReads.AddRange(kvp.Value.UncoveredReads);
+                }
+            }
+        }
+
+        private static Dictionary<string, FlowFlags> CloneState(Dictionary<string, FlowFlags> source)
+        {
+            var clone = new Dictionary<string, FlowFlags>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in source)
+                clone[kvp.Key] = kvp.Value.Clone();
+            return clone;
+        }
+
+        private void MergeFlowStates(Dictionary<string, FlowFlags> stateA, Dictionary<string, FlowFlags> stateB)
+        {
+            foreach (var kvp in _flowState)
+            {
+                var a = stateA[kvp.Key];
+                var b = stateB[kvp.Key];
+
+                kvp.Value.HasLoadFields = a.HasLoadFields && b.HasLoadFields;
+                kvp.Value.HasWriteOp = a.HasWriteOp || b.HasWriteOp;
+                kvp.Value.PassedToFunction = a.PassedToFunction || b.PassedToFunction;
+
+                kvp.Value.UncoveredReads.Clear();
+                kvp.Value.UncoveredReads.AddRange(a.UncoveredReads);
+                kvp.Value.UncoveredReads.AddRange(b.UncoveredReads);
+            }
+        }
+
+        private void MergeFlowStates(List<Dictionary<string, FlowFlags>> branchStates)
+        {
+            if (branchStates.Count == 0)
+                return;
+
+            foreach (var kvp in _flowState)
+            {
+                kvp.Value.HasLoadFields = branchStates.All(bs => bs[kvp.Key].HasLoadFields);
+                kvp.Value.HasWriteOp = branchStates.Any(bs => bs[kvp.Key].HasWriteOp);
+                kvp.Value.PassedToFunction = branchStates.Any(bs => bs[kvp.Key].PassedToFunction);
+
+                kvp.Value.UncoveredReads.Clear();
+                foreach (var bs in branchStates)
+                    kvp.Value.UncoveredReads.AddRange(bs[kvp.Key].UncoveredReads);
+            }
+        }
+
+        #endregion
+
+        #region Method classification
+
+        private static void ClassifyInstanceMethodCall(IInvocationExpression operation,
+            VariableState state, FlowFlags flowFlags)
         {
             var methodName = operation.TargetMethod.Name;
 
             if (operation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
             {
                 if (ReadMethods.Contains(methodName))
-                    state.ReadLocations.Add(new ReadInfo(operation.Syntax.GetLocation(), methodName));
+                {
+                    // Check ALL flow flags: hasLoadFields (SetLoadFields before read),
+                    // hasWriteOp (write before read means SetLoadFields could break the write),
+                    // passedToFunction (callee might need all fields).
+                    // Write/pass AFTER read is handled by retroactive clearing of UncoveredReads.
+                    if (!flowFlags.HasLoadFields && !flowFlags.HasWriteOp && !flowFlags.PassedToFunction)
+                        flowFlags.UncoveredReads.Add(new ReadInfo(operation.Syntax.GetLocation(), methodName));
+                }
                 else if (LoadFieldsMethods.Contains(methodName))
-                    state.HasLoadFieldsCall = true;
+                {
+                    if (string.Equals(methodName, "SetLoadFields", StringComparison.OrdinalIgnoreCase)
+                        && operation.Arguments.IsEmpty)
+                    {
+                        // SetLoadFields() with no arguments resets partial records to "load all"
+                        flowFlags.HasLoadFields = false;
+                    }
+                    else
+                    {
+                        flowFlags.HasLoadFields = true;
+                        state.EverHadLoadFields = true;
+                    }
+                }
                 else if (WriteMethods.Contains(methodName))
-                    state.HasWriteOp = true;
+                {
+                    // Retroactively suppress uncovered reads: a write after a read means
+                    // adding SetLoadFields before the read could break the write operation
+                    flowFlags.UncoveredReads.Clear();
+                    flowFlags.HasWriteOp = true;
+                    state.EverHadWriteOp = true;
+                }
+                else if (string.Equals(methodName, "Reset", StringComparison.OrdinalIgnoreCase))
+                {
+                    flowFlags.ResetFlags();
+                }
                 else if (state.IsRecordRef
                     && string.Equals(methodName, "SetTable", StringComparison.OrdinalIgnoreCase)
                     && operation.Arguments.Length == 1)
@@ -219,20 +472,44 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
             }
             else
             {
-                // Non-built-in method called on the record variable (table-defined method)
-                state.PassedToFunction = true;
+                // Non-built-in method called on the record variable (table-defined method):
+                // retroactively suppress uncovered reads (callee might access any field)
+                flowFlags.UncoveredReads.Clear();
+                flowFlags.PassedToFunction = true;
+                state.EverPassedToFunction = true;
             }
         }
 
         private void CheckArgumentsForTrackedVariables(IInvocationExpression operation)
         {
+            // Clear(variable) resets flow state instead of marking passedToFunction
+            if (operation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod
+                && string.Equals(operation.TargetMethod.Name, "Clear", StringComparison.OrdinalIgnoreCase)
+                && operation.Arguments.Length >= 1)
+            {
+                var clearVarName = GetVariableNameFromArgument(operation.Arguments[0]);
+                if (clearVarName != null && _flowState.TryGetValue(clearVarName, out var clearFlags))
+                {
+                    clearFlags.ResetFlags();
+                    return;
+                }
+            }
+
             for (int i = 0; i < operation.Arguments.Length; i++)
             {
                 var varName = GetVariableNameFromArgument(operation.Arguments[i]);
-                if (varName != null && _trackedVariables.TryGetValue(varName, out var state))
-                    state.PassedToFunction = true;
+                if (varName != null && _flowState.TryGetValue(varName, out var flags))
+                {
+                    // Retroactively suppress uncovered reads: callee might access any field
+                    flags.UncoveredReads.Clear();
+                    flags.PassedToFunction = true;
+                    if (_trackedVariables.TryGetValue(varName, out var state))
+                        state.EverPassedToFunction = true;
+                }
             }
         }
+
+        #endregion
 
         private static string? GetVariableNameFromArgument(IArgument argument)
         {

--- a/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.LinterCop/Analyzers/UsePartialRecordsOnRead.cs
@@ -150,7 +150,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
         public List<ReadInfo> UncoveredReadLocations { get; } = new();
         public bool IsRecordRef { get; set; }
         public List<string?> SetTableTargets { get; } = new();
-        // Method-level "ever" flags used only for RecordRef SetTable suppression check
+
         public bool EverHadLoadFields { get; set; }
         public bool EverHadWriteOp { get; set; }
         public bool EverPassedToFunction { get; set; }
@@ -396,9 +396,7 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
                 kvp.Value.HasWriteOp = a.HasWriteOp || b.HasWriteOp;
                 kvp.Value.PassedToFunction = a.PassedToFunction || b.PassedToFunction;
 
-                kvp.Value.UncoveredReads.Clear();
-                kvp.Value.UncoveredReads.AddRange(a.UncoveredReads);
-                kvp.Value.UncoveredReads.AddRange(b.UncoveredReads);
+                MergeUncoveredReads(kvp.Value, a.UncoveredReads, b.UncoveredReads);
             }
         }
 
@@ -414,9 +412,32 @@ public sealed class UsePartialRecordsOnRead : DiagnosticAnalyzer
                 kvp.Value.PassedToFunction = branchStates.Any(bs => bs[kvp.Key].PassedToFunction);
 
                 kvp.Value.UncoveredReads.Clear();
+                var seen = new HashSet<int>();
                 foreach (var bs in branchStates)
-                    kvp.Value.UncoveredReads.AddRange(bs[kvp.Key].UncoveredReads);
+                    foreach (var read in bs[kvp.Key].UncoveredReads)
+                        if (seen.Add(read.Location.SourceSpan.Start))
+                            kvp.Value.UncoveredReads.Add(read);
             }
+        }
+
+        /// <summary>
+        /// Merges uncovered reads from two branches with deduplication by source position.
+        /// Pre-fork reads exist in both branches; without dedup, list size doubles at each
+        /// nesting level causing exponential growth and OOM on large codebases.
+        /// </summary>
+        private static void MergeUncoveredReads(FlowFlags target,
+            List<ReadInfo> readsA, List<ReadInfo> readsB)
+        {
+            target.UncoveredReads.Clear();
+
+            var seen = new HashSet<int>();
+            foreach (var read in readsA)
+                if (seen.Add(read.Location.SourceSpan.Start))
+                    target.UncoveredReads.Add(read);
+
+            foreach (var read in readsB)
+                if (seen.Add(read.Location.SourceSpan.Start))
+                    target.UncoveredReads.Add(read);
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Replaces method-level boolean flags in LC0095 (UsePartialRecordsOnRead) with forward dataflow analysis that tracks per-variable flow state through control flow constructs.

## Bugs Fixed

**Bug A - Statement ordering**: `SetLoadFields` appearing AFTER a read operation no longer incorrectly suppresses the diagnostic on that read.

**Bug B - Clear/Reset invalidation**: `Clear()`, `Reset()`, and `SetLoadFields()` with no arguments between a `SetLoadFields` and a read now correctly invalidate the suppression.

**Bug C - Control flow branches**: `SetLoadFields` in one branch of an if/case statement no longer suppresses diagnostics in other branches.

## Implementation

- `FlowFlags` per variable with fork/merge at if/case/loop constructs
- Merge rules: HasLoadFields=AND, HasWriteOp/PassedToFunction=OR
- UncoveredReads tracked per branch, union at merge points
- Retroactive clearing: write/pass after read clears prior uncovered reads
- Reset detection: `Clear()`, `Reset()`, `SetLoadFields()` with 0 args
- Loop handling: while/for/foreach merge with pre-loop; repeat uses post-body
- Added `LoopKind` to EnumProvider for while vs repeat distinction

## Tests

52 total (was 41): 16 HasDiagnostic (+9), 25 NoDiagnostic (+2), 11 HasFix (unchanged)

New HasDiagnostic cases: SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, LoopNoSetLoadFields

New NoDiagnostic cases: IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore