### PR TITLE
perf: AC0026 and AC0013 CompilationStart + lazy field resolution

### DIFF
--- a/.github/instructions/ac0013-field-groups-required.instructions.md
+++ b/.github/instructions/ac0013-field-groups-required.instructions.md
@@ -1,0 +1,73 @@
+---
+applyTo: 'src/ALCops.ApplicationCop/**/FieldGroupsRequired*'
+---
+
+# AC0013: FieldGroupsRequired
+
+## Purpose
+
+Checks that tables used by pages define both `Brick` and `DropDown` field groups. These field groups control how records are displayed in list views and lookup dropdowns in Business Central.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `AC0013` |
+| Category | Design |
+| Severity | Info |
+| Enabled by default | false |
+| MessageFormat | `Table '{0}' does not have a '{1}' field group.` |
+| Version gate | None |
+| netstandard2.1 | Full support (no net8.0-only APIs used) |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Architecture | CompilationStart with pre-computed table set | Cross-object analysis (which tables have pages) must be done once, not per-table. |
+| Page discovery | `GetDeclaredApplicationObjectSymbols()` filtered for pages | Original syntax tree walk created 7938 semantic models (one per file). Symbol-based query is O(S) with a single call. |
+| Setup tables | Excluded | Tables with a single Code PK field named "Primary Key" are setup tables; field groups are not useful. |
+| Temporary tables | Conditional | Only flagged if referenced by a page (temporary tables without pages are skipped). |
+| Both field groups checked | Brick and DropDown | Both serve different purposes; missing either is a separate diagnostic. |
+| Enabled by default | false | Opt-in rule; not all teams enforce field group conventions. |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterCompilationStartAction` to discover which tables are referenced by pages, then `RegisterSymbolAction` on `Table` symbols.
+
+### Performance-critical design
+
+**Problem:** The original `BuildTablesReferencedByPages()` iterated ALL syntax trees (7938 on the Base App), calling `tree.GetRoot()`, `ctx.Compilation.GetSemanticModel(tree)`, and walking descendants for `PageSyntax`. Creating 7938 semantic models was the dominant cost (4.3s).
+
+**Solution:** Single `GetDeclaredApplicationObjectSymbols()` call filtered for `IPageTypeSymbol` with `NavTypeKind.Page`. Reads `RelatedTable` directly from the page symbol. No syntax tree parsing or semantic model creation needed.
+
+### Analysis flow
+
+1. **CompilationStart**: `BuildTablesReferencedByPages()` builds `HashSet<ITableTypeSymbol>` of all tables that have at least one page
+2. **PerSymbol (Table)**:
+   - Skip obsolete, skip setup tables
+   - Skip temporary tables not referenced by pages
+   - Check for `Brick` field group (non-empty)
+   - Check for `DropDown` field group (non-empty)
+   - Report diagnostic for each missing field group
+
+## Test coverage
+
+### HasDiagnostic (commented out)
+
+Tests are commented out with a TODO about `WithRuleSetPath` in RoslynTestKit. The rule is `isEnabledByDefault: false`, so test fixtures don't trigger it without explicit enablement.
+
+| Test case | Scenario |
+|---|---|
+| BrickIsMissing | Table without Brick field group |
+| DropDownIsMissing | Table without DropDown field group |
+| TemporaryTable | Temporary table referenced by a page |
+
+### NoDiagnostic (2 cases)
+
+| Test case | Suppression reason |
+|---|---|
+| HasBrickAndDropDown | Table has both field groups defined |
+| TemporaryTable | Temporary table not referenced by any page |

--- a/.github/instructions/ac0026-allow-in-customizations-for-omitted-fields.instructions.md
+++ b/.github/instructions/ac0026-allow-in-customizations-for-omitted-fields.instructions.md
@@ -24,8 +24,8 @@ Detects table/table extension fields that are not placed on any page and do not 
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Architecture | CompilationStart with pre-computed lookups | Cross-object analysis (table-to-page) must be done once, not per-table. Original per-table `GetDeclaredApplicationObjectSymbols()` was O(T x S) on the Base App. |
-| Data structure | `HashSet<ITableTypeSymbol>` + `Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>` | Two lookups: (1) does this table have any page, (2) which fields are on pages. Both read-only after construction, safe for concurrent SymbolAction callbacks. |
+| Architecture | CompilationStart with lightweight index + lazy field resolution | Cross-object analysis split into two levels: (1) cheap table-to-page index at CompilationStart, (2) per-table field resolution deferred to AnalyzeSymbol via `ConcurrentDictionary<ITableTypeSymbol, Lazy<HashSet<IFieldSymbol>>>`. Tables that exit early never trigger expensive FlattenedControls materialization. |
+| Data structure | `HashSet<ITableTypeSymbol>` + `Dictionary<..., List<IPageTypeSymbol>>` + `Dictionary<..., List<IPageExtensionTypeSymbol>>` + `ConcurrentDictionary<..., Lazy<HashSet<IFieldSymbol>>>` | Level 1: which tables have pages and which pages/extensions reference them (read-only after construction). Level 2: lazy per-table field cache, computed at most once per table on-demand. |
 | Page extensions | Resolve via `ext.Target.GetTypeSymbol()` to `IPageTypeSymbol` | Extension's `.Target` is the extended page object; its `RelatedTable` gives the source table. |
 | API pages | Excluded | API pages don't use AllowInCustomizations. |
 | Table extensions with no page | Check `BaseTableHasLookupOrDrillDown` | Table extensions should still flag if the base table has LookupPageId or DrillDownPageId (implicit page usage). |
@@ -42,29 +42,43 @@ Uses `RegisterCompilationStartAction` to build page lookups once per compilation
 
 ### Performance-critical design
 
-**Problem:** The original implementation called `compilation.GetDeclaredApplicationObjectSymbols()` per table (~1500 times on the Base App). Internally, `GetDeclaredApplicationObjectSymbols()` materializes a new `ImmutableArray` via LINQ each call: `CompiledModule.GetDeclaredObjectSymbols().OfType<IApplicationObjectTypeSymbol>().ToImmutableArray()`. This was O(T x S) where T=tables, S=all symbols, taking 8.6s on the Base App.
+**Problem:** The original implementation called `compilation.GetDeclaredApplicationObjectSymbols()` per table (~1500 times on the Base App), taking 8.6s. Phase 1 moved to a single call in CompilationStart but eagerly materialized `FlattenedControls` for all 2591 pages and iterated ~75k controls, costing 2.9s.
 
-**Solution:** Single `GetDeclaredApplicationObjectSymbols()` call in `BuildPageLookups()` builds two structures:
-1. `tablesWithPages`: `HashSet<ITableTypeSymbol>` of all tables that have at least one page
-2. `tableToReferencedFields`: `Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>` mapping each table to fields referenced on any of its pages
+**Solution (two-level lazy architecture):**
 
-Both are closure-captured as read-only data by the SymbolAction callback, which does O(1) lookups.
+**Level 1 — `BuildTableToPageIndex()` (CompilationStart, sequential):**
+- Single `GetDeclaredApplicationObjectSymbols()` call
+- For each page: record `table → List<IPageTypeSymbol>` and add table to `tablesWithPages`
+- For each page extension: record `table → List<IPageExtensionTypeSymbol>`
+- Does NOT access `FlattenedControls` or `AddedControlsFlattened` (deferred)
+- Cost: ~500ms (just symbol iteration + `RelatedTable` resolution)
+
+**Level 2 — `ResolveFieldsOnPages()` (AnalyzeSymbol, concurrent, lazy):**
+- `ConcurrentDictionary<ITableTypeSymbol, Lazy<HashSet<IFieldSymbol>>>` caches per-table results
+- Factory: iterates `tableToPages[table]` → `FlattenedControls` + `tableToPageExtensions[table]` → `AddedControlsFlattened`
+- Computed at most once per table (thread-safe via `Lazy<T>` default mode)
+- Parallelized across AnalyzeSymbol threads (4+ cores → ~125ms wall-clock)
+- Tables that exit early (obsolete, no candidates, AllowInCustomizations set, etc.) never trigger computation
 
 ### Analysis flow
 
-1. **CompilationStart**: `BuildPageLookups()` iterates declared symbols once, processing pages and page extensions
+1. **CompilationStart**: `BuildTableToPageIndex()` builds lightweight index (no control iteration)
 2. **PerSymbol (Table/TableExtension)**:
    - Version gate check, obsolete check, AllowInCustomizations on object check
    - Resolve to `ITableTypeSymbol` via `TryGetTableOrTargetTable()`
    - Get candidate fields via `GetCandidateFields()`
    - Check if table has pages (HashSet lookup)
    - For table extensions without pages, check `BaseTableHasLookupOrDrillDown()`
+   - **Lazy resolve:** `fieldRefCache.GetOrAdd(table, Lazy<...>).Value` triggers field resolution only if needed
    - For each candidate field, check if it's referenced on any page (HashSet lookup)
    - Report diagnostic for unreferenced fields
 
 ### Concurrency safety
 
-`CompilationStart` runs once before any `SymbolAction` callbacks. The closure-captured `HashSet` and `Dictionary` are construction-complete and never modified after. `Dictionary` and `HashSet` are safe for concurrent reads.
+- `BuildTableToPageIndex` runs once before any `SymbolAction` callbacks. The `tableToPages` and `tableToPageExtensions` dictionaries are construction-complete and never modified after, safe for concurrent reads.
+- `ConcurrentDictionary.GetOrAdd(key, valueFactory)` with `Lazy<T>` ensures single computation per table key.
+- `Lazy<T>` with default `ExecutionAndPublication` mode ensures thread safety.
+- `FlattenedControls` and `AddedControlsFlattened` are SDK `Lazy<ImmutableArray>` properties, safe for concurrent access.
 
 ## Test coverage
 

--- a/.github/instructions/ac0026-allow-in-customizations-for-omitted-fields.instructions.md
+++ b/.github/instructions/ac0026-allow-in-customizations-for-omitted-fields.instructions.md
@@ -1,0 +1,100 @@
+---
+applyTo: 'src/ALCops.ApplicationCop/**/AllowInCustomizationsForOmittedFields*'
+---
+
+# AC0026: AllowInCustomizationsForOmittedFields
+
+## Purpose
+
+Detects table/table extension fields that are not placed on any page and do not have `AllowInCustomizations` explicitly set. Fields omitted from pages should declare `AllowInCustomizations = Always` (or `Never`) so page customizers know whether the field is intentionally hidden.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `AC0026` |
+| Category | Design |
+| Severity | Info |
+| Enabled by default | true |
+| MessageFormat | `Field '{0}' is not added to any page and does not have the AllowInCustomizations property set.` |
+| Version gate | `AddPageControlInPageCustomization` feature |
+| netstandard2.1 | Full support (no net8.0-only APIs used) |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Architecture | CompilationStart with pre-computed lookups | Cross-object analysis (table-to-page) must be done once, not per-table. Original per-table `GetDeclaredApplicationObjectSymbols()` was O(T x S) on the Base App. |
+| Data structure | `HashSet<ITableTypeSymbol>` + `Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>` | Two lookups: (1) does this table have any page, (2) which fields are on pages. Both read-only after construction, safe for concurrent SymbolAction callbacks. |
+| Page extensions | Resolve via `ext.Target.GetTypeSymbol()` to `IPageTypeSymbol` | Extension's `.Target` is the extended page object; its `RelatedTable` gives the source table. |
+| API pages | Excluded | API pages don't use AllowInCustomizations. |
+| Table extensions with no page | Check `BaseTableHasLookupOrDrillDown` | Table extensions should still flag if the base table has LookupPageId or DrillDownPageId (implicit page usage). |
+| Field filtering | User ID range, non-local/protected, non-FlowFilter, enabled, non-obsolete, supported types | Standard field filtering; unsupported types (Blob, Media, MediaSet, RecordId, TableFilter) are excluded. |
+| OriginalDefinition for field comparison | `field.OriginalDefinition` cast to `IFieldSymbol` | Page controls reference field original definitions, not the field instances from table extensions. |
+| Symbol equality | Default (reference) equality for `ITableTypeSymbol` keys | SDK uses reference equality within the same compilation's symbol set. |
+| Skip obsolete | Yes | Standard ALCops convention. |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterCompilationStartAction` to build page lookups once per compilation, then `RegisterSymbolAction` for `Table` and `TableExtension` symbols.
+
+### Performance-critical design
+
+**Problem:** The original implementation called `compilation.GetDeclaredApplicationObjectSymbols()` per table (~1500 times on the Base App). Internally, `GetDeclaredApplicationObjectSymbols()` materializes a new `ImmutableArray` via LINQ each call: `CompiledModule.GetDeclaredObjectSymbols().OfType<IApplicationObjectTypeSymbol>().ToImmutableArray()`. This was O(T x S) where T=tables, S=all symbols, taking 8.6s on the Base App.
+
+**Solution:** Single `GetDeclaredApplicationObjectSymbols()` call in `BuildPageLookups()` builds two structures:
+1. `tablesWithPages`: `HashSet<ITableTypeSymbol>` of all tables that have at least one page
+2. `tableToReferencedFields`: `Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>` mapping each table to fields referenced on any of its pages
+
+Both are closure-captured as read-only data by the SymbolAction callback, which does O(1) lookups.
+
+### Analysis flow
+
+1. **CompilationStart**: `BuildPageLookups()` iterates declared symbols once, processing pages and page extensions
+2. **PerSymbol (Table/TableExtension)**:
+   - Version gate check, obsolete check, AllowInCustomizations on object check
+   - Resolve to `ITableTypeSymbol` via `TryGetTableOrTargetTable()`
+   - Get candidate fields via `GetCandidateFields()`
+   - Check if table has pages (HashSet lookup)
+   - For table extensions without pages, check `BaseTableHasLookupOrDrillDown()`
+   - For each candidate field, check if it's referenced on any page (HashSet lookup)
+   - Report diagnostic for unreferenced fields
+
+### Concurrency safety
+
+`CompilationStart` runs once before any `SymbolAction` callbacks. The closure-captured `HashSet` and `Dictionary` are construction-complete and never modified after. `Dictionary` and `HashSet` are safe for concurrent reads.
+
+## Test coverage
+
+### HasDiagnostic (6 cases)
+
+| Test case | Scenario |
+|---|---|
+| FieldOmittedPage | Field not on any page |
+| ObsoleteStateNo | Non-obsolete field (ObsoleteState = No) flags |
+| TableExtension | Field in table extension not on page |
+| TableExtensionBaseDrillDownPageId | Table extension where base has DrillDownPageId |
+| TableExtensionBaseLookupPageId | Table extension where base has LookupPageId |
+| TableExtensionBaseTableHasAllowInCustomizations | Table extension where base has AllowInCustomizations |
+
+### NoDiagnostic (11 cases)
+
+| Test case | Suppression reason |
+|---|---|
+| AllowInCustomizationsIsSet | AllowInCustomizations already set on field |
+| AllowInCustomizationsOnField | AllowInCustomizations set at field level |
+| AllowInCustomizationsOnTable | AllowInCustomizations set at table level |
+| AllowInCustomizationsOnTableExtension | AllowInCustomizations set at table extension level |
+| DisabledField | Field has Enabled = false |
+| FieldOnPage | Field is placed on a page |
+| FieldTypeNotSupported | Field type is Blob/Media/etc. |
+| FlowFilterField | FlowFilter field class |
+| ObsoleteStatePending | Obsolete field (pending) |
+| ObsoleteStateRemoved | Obsolete field (removed) |
+| TableExtension | Table extension field that is on a page |
+
+## Relationship to Microsoft's AS0138
+
+Microsoft's `RuleUseAllowInCustomizationsProperty` (AS0138 in AppSourceCop) is simpler: it only checks if AllowInCustomizations is set on fields, without the page-reference cross-check. AC0026 is more sophisticated, only flagging fields that are NOT on any page.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -89,3 +89,5 @@ These cover conventions for a category of files. Include:
 | `lc0092-naming-pattern.instructions.md` | `'src/ALCops.LinterCop/**/NamingPattern*'` | LC0092 rule details |
 | `lc0091-translatable-text-should-be-translated.instructions.md` | `'src/ALCops.LinterCop/**/TranslatableTextShouldBeTranslated*'` | LC0091 rule details |
 | `pc0029-use-sequential-guid.instructions.md` | `'src/ALCops.PlatformCop/**/UseSequentialGuid*'` | PC0029 rule details |
+| `ac0026-allow-in-customizations-for-omitted-fields.instructions.md` | `'src/ALCops.ApplicationCop/**/AllowInCustomizationsForOmittedFields*'` | AC0026 rule details |
+| `ac0013-field-groups-required.instructions.md` | `'src/ALCops.ApplicationCop/**/FieldGroupsRequired*'` | AC0013 rule details |

--- a/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
@@ -21,10 +22,14 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
 
     private static void OnCompilationStart(CompilationStartAnalysisContext compilationCtx)
     {
-        var (tablesWithPages, tableToReferencedFields) = BuildPageLookups(compilationCtx.Compilation);
+        var (tablesWithPages, tableToPages, tableToPageExtensions) =
+            BuildTableToPageIndex(compilationCtx.Compilation);
+
+        var fieldRefCache = new ConcurrentDictionary<ITableTypeSymbol, Lazy<HashSet<IFieldSymbol>>>();
 
         compilationCtx.RegisterSymbolAction(
-            symbolCtx => AnalyzeSymbol(symbolCtx, tablesWithPages, tableToReferencedFields),
+            symbolCtx => AnalyzeSymbol(
+                symbolCtx, tablesWithPages, tableToPages, tableToPageExtensions, fieldRefCache),
             EnumProvider.SymbolKind.Table,
             EnumProvider.SymbolKind.TableExtension);
     }
@@ -32,7 +37,9 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
     private static void AnalyzeSymbol(
         SymbolAnalysisContext ctx,
         HashSet<ITableTypeSymbol> tablesWithPages,
-        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+        Dictionary<ITableTypeSymbol, List<IPageTypeSymbol>> tableToPages,
+        Dictionary<ITableTypeSymbol, List<IPageExtensionTypeSymbol>> tableToPageExtensions,
+        ConcurrentDictionary<ITableTypeSymbol, Lazy<HashSet<IFieldSymbol>>> fieldRefCache)
     {
         if (!VersionChecker.IsSupported(ctx.Symbol, EnumProvider.Feature.AddPageControlInPageCustomization))
             return;
@@ -59,14 +66,17 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
                 return;
         }
 
-        tableToReferencedFields.TryGetValue(table, out var referencedOnPages);
+        var referencedOnPages = fieldRefCache.GetOrAdd(
+            table,
+            t => new Lazy<HashSet<IFieldSymbol>>(
+                () => ResolveFieldsOnPages(t, tableToPages, tableToPageExtensions))).Value;
 
         foreach (var field in candidateFields)
         {
             if (field.OriginalDefinition is not IFieldSymbol fieldKey)
                 continue;
 
-            if (referencedOnPages is not null && referencedOnPages.Contains(fieldKey))
+            if (referencedOnPages.Contains(fieldKey))
                 continue;
 
             var location =
@@ -84,11 +94,19 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
         }
     }
 
-    private static (HashSet<ITableTypeSymbol> tablesWithPages, Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
-        BuildPageLookups(Compilation compilation)
+    /// <summary>
+    /// Builds a lightweight index of which tables have pages and which pages/extensions reference each table.
+    /// Does NOT access FlattenedControls or iterate controls (deferred to lazy resolution).
+    /// </summary>
+    private static (
+        HashSet<ITableTypeSymbol> tablesWithPages,
+        Dictionary<ITableTypeSymbol, List<IPageTypeSymbol>> tableToPages,
+        Dictionary<ITableTypeSymbol, List<IPageExtensionTypeSymbol>> tableToPageExtensions)
+        BuildTableToPageIndex(Compilation compilation)
     {
         var tablesWithPages = new HashSet<ITableTypeSymbol>();
-        var tableToReferencedFields = new Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>();
+        var tableToPages = new Dictionary<ITableTypeSymbol, List<IPageTypeSymbol>>();
+        var tableToPageExtensions = new Dictionary<ITableTypeSymbol, List<IPageExtensionTypeSymbol>>();
 
         var declared = compilation.GetDeclaredApplicationObjectSymbols();
 
@@ -99,21 +117,21 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
 
             if (navKind == EnumProvider.NavTypeKind.Page)
             {
-                ProcessPage(symbol, tablesWithPages, tableToReferencedFields);
+                IndexPage(symbol, tablesWithPages, tableToPages);
             }
             else if (navKind == EnumProvider.NavTypeKind.PageExtension)
             {
-                ProcessPageExtension(symbol, tablesWithPages, tableToReferencedFields);
+                IndexPageExtension(symbol, tablesWithPages, tableToPageExtensions);
             }
         }
 
-        return (tablesWithPages, tableToReferencedFields);
+        return (tablesWithPages, tableToPages, tableToPageExtensions);
     }
 
-    private static void ProcessPage(
+    private static void IndexPage(
         IApplicationObjectTypeSymbol symbol,
         HashSet<ITableTypeSymbol> tablesWithPages,
-        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+        Dictionary<ITableTypeSymbol, List<IPageTypeSymbol>> tableToPages)
     {
         if (symbol is not IPageTypeSymbol page)
             return;
@@ -126,19 +144,19 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
 
         tablesWithPages.Add(table);
 
-        if (!tableToReferencedFields.TryGetValue(table, out var fieldSet))
+        if (!tableToPages.TryGetValue(table, out var pages))
         {
-            fieldSet = new HashSet<IFieldSymbol>();
-            tableToReferencedFields[table] = fieldSet;
+            pages = new List<IPageTypeSymbol>();
+            tableToPages[table] = pages;
         }
 
-        AddFieldControls(fieldSet, page.FlattenedControls);
+        pages.Add(page);
     }
 
-    private static void ProcessPageExtension(
+    private static void IndexPageExtension(
         IApplicationObjectTypeSymbol symbol,
         HashSet<ITableTypeSymbol> tablesWithPages,
-        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+        Dictionary<ITableTypeSymbol, List<IPageExtensionTypeSymbol>> tableToPageExtensions)
     {
         if (symbol is not IApplicationObjectExtensionTypeSymbol ext || ext.Target is null)
             return;
@@ -151,14 +169,42 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
 
         tablesWithPages.Add(table);
 
-        if (!tableToReferencedFields.TryGetValue(table, out var fieldSet))
+        if (symbol is not IPageExtensionTypeSymbol pageExt)
+            return;
+
+        if (!tableToPageExtensions.TryGetValue(table, out var extensions))
         {
-            fieldSet = new HashSet<IFieldSymbol>();
-            tableToReferencedFields[table] = fieldSet;
+            extensions = new List<IPageExtensionTypeSymbol>();
+            tableToPageExtensions[table] = extensions;
         }
 
-        if (symbol is IPageExtensionTypeSymbol pageExt)
-            AddFieldControls(fieldSet, pageExt.AddedControlsFlattened);
+        extensions.Add(pageExt);
+    }
+
+    /// <summary>
+    /// Resolves all field symbols referenced on pages/page extensions for a given table.
+    /// Called lazily per-table, at most once (cached via ConcurrentDictionary + Lazy).
+    /// </summary>
+    private static HashSet<IFieldSymbol> ResolveFieldsOnPages(
+        ITableTypeSymbol table,
+        Dictionary<ITableTypeSymbol, List<IPageTypeSymbol>> tableToPages,
+        Dictionary<ITableTypeSymbol, List<IPageExtensionTypeSymbol>> tableToPageExtensions)
+    {
+        var fieldSet = new HashSet<IFieldSymbol>();
+
+        if (tableToPages.TryGetValue(table, out var pages))
+        {
+            foreach (var page in pages)
+                AddFieldControls(fieldSet, page.FlattenedControls);
+        }
+
+        if (tableToPageExtensions.TryGetValue(table, out var extensions))
+        {
+            foreach (var ext in extensions)
+                AddFieldControls(fieldSet, ext.AddedControlsFlattened);
+        }
+
+        return fieldSet;
     }
 
     private static bool TryGetTableOrTargetTable(ISymbol symbol, out ITableTypeSymbol table, out bool isTableExtension)

--- a/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/AllowInCustomizationsForOmittedFields.cs
@@ -17,12 +17,22 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
         ImmutableArray.Create(DiagnosticDescriptors.AllowInCustomizationsForOmittedFields);
 
     public override void Initialize(AnalysisContext context) =>
-        context.RegisterSymbolAction(
-            AnalyzeSymbol,
+        context.RegisterCompilationStartAction(OnCompilationStart);
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext compilationCtx)
+    {
+        var (tablesWithPages, tableToReferencedFields) = BuildPageLookups(compilationCtx.Compilation);
+
+        compilationCtx.RegisterSymbolAction(
+            symbolCtx => AnalyzeSymbol(symbolCtx, tablesWithPages, tableToReferencedFields),
             EnumProvider.SymbolKind.Table,
             EnumProvider.SymbolKind.TableExtension);
+    }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext ctx)
+    private static void AnalyzeSymbol(
+        SymbolAnalysisContext ctx,
+        HashSet<ITableTypeSymbol> tablesWithPages,
+        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
     {
         if (!VersionChecker.IsSupported(ctx.Symbol, EnumProvider.Feature.AddPageControlInPageCustomization))
             return;
@@ -40,10 +50,7 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
         if (candidateFields.Count == 0)
             return;
 
-        var relatedPages = GetRelatedPages(ctx.Compilation, table);
-
-        // Allow diagnostic if base table has Lookup/DrillDown page set even if no related pages exist directly
-        if (!relatedPages.Any())
+        if (!tablesWithPages.Contains(table))
         {
             if (!isTableExtension)
                 return;
@@ -52,14 +59,14 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
                 return;
         }
 
-        var referencedOnPages = GetReferencedPageFields(relatedPages);
+        tableToReferencedFields.TryGetValue(table, out var referencedOnPages);
 
         foreach (var field in candidateFields)
         {
             if (field.OriginalDefinition is not IFieldSymbol fieldKey)
                 continue;
 
-            if (referencedOnPages.Contains(fieldKey))
+            if (referencedOnPages is not null && referencedOnPages.Contains(fieldKey))
                 continue;
 
             var location =
@@ -77,20 +84,95 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
         }
     }
 
+    private static (HashSet<ITableTypeSymbol> tablesWithPages, Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+        BuildPageLookups(Compilation compilation)
+    {
+        var tablesWithPages = new HashSet<ITableTypeSymbol>();
+        var tableToReferencedFields = new Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>>();
+
+        var declared = compilation.GetDeclaredApplicationObjectSymbols();
+
+        for (int i = 0; i < declared.Length; i++)
+        {
+            var symbol = declared[i];
+            var navKind = symbol.GetNavTypeKindSafe();
+
+            if (navKind == EnumProvider.NavTypeKind.Page)
+            {
+                ProcessPage(symbol, tablesWithPages, tableToReferencedFields);
+            }
+            else if (navKind == EnumProvider.NavTypeKind.PageExtension)
+            {
+                ProcessPageExtension(symbol, tablesWithPages, tableToReferencedFields);
+            }
+        }
+
+        return (tablesWithPages, tableToReferencedFields);
+    }
+
+    private static void ProcessPage(
+        IApplicationObjectTypeSymbol symbol,
+        HashSet<ITableTypeSymbol> tablesWithPages,
+        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+    {
+        if (symbol is not IPageTypeSymbol page)
+            return;
+
+        if (page.PageType == PageTypeKind.API)
+            return;
+
+        if (page.RelatedTable is not ITableTypeSymbol table)
+            return;
+
+        tablesWithPages.Add(table);
+
+        if (!tableToReferencedFields.TryGetValue(table, out var fieldSet))
+        {
+            fieldSet = new HashSet<IFieldSymbol>();
+            tableToReferencedFields[table] = fieldSet;
+        }
+
+        AddFieldControls(fieldSet, page.FlattenedControls);
+    }
+
+    private static void ProcessPageExtension(
+        IApplicationObjectTypeSymbol symbol,
+        HashSet<ITableTypeSymbol> tablesWithPages,
+        Dictionary<ITableTypeSymbol, HashSet<IFieldSymbol>> tableToReferencedFields)
+    {
+        if (symbol is not IApplicationObjectExtensionTypeSymbol ext || ext.Target is null)
+            return;
+
+        if (ext.Target.GetTypeSymbol() is not IPageTypeSymbol targetPage)
+            return;
+
+        if (targetPage.RelatedTable is not ITableTypeSymbol table)
+            return;
+
+        tablesWithPages.Add(table);
+
+        if (!tableToReferencedFields.TryGetValue(table, out var fieldSet))
+        {
+            fieldSet = new HashSet<IFieldSymbol>();
+            tableToReferencedFields[table] = fieldSet;
+        }
+
+        if (symbol is IPageExtensionTypeSymbol pageExt)
+            AddFieldControls(fieldSet, pageExt.AddedControlsFlattened);
+    }
+
     private static bool TryGetTableOrTargetTable(ISymbol symbol, out ITableTypeSymbol table, out bool isTableExtension)
     {
         table = null!;
         isTableExtension = false;
 
-        var navKind = symbol.GetContainingObjectTypeSymbol().GetNavTypeKindSafe();
-
-        if (navKind == EnumProvider.NavTypeKind.Record && symbol is ITableTypeSymbol t)
+        if (symbol is ITableTypeSymbol t)
         {
             table = t;
             return true;
         }
 
-        if (navKind == EnumProvider.NavTypeKind.TableExtension && symbol is IApplicationObjectExtensionTypeSymbol ext)
+        if (symbol is IApplicationObjectExtensionTypeSymbol ext)
         {
             isTableExtension = true;
 
@@ -108,7 +190,15 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
 
     private static List<IFieldSymbol> GetCandidateFields(ISymbol symbol)
     {
-        var fields = GetDeclaredTableFields(symbol);
+        ICollection<IFieldSymbol> fields;
+
+        if (symbol is ITableTypeSymbol table)
+            fields = table.Fields;
+        else if (symbol is ITableExtensionTypeSymbol tableExt)
+            fields = tableExt.AddedFields;
+        else
+            return new List<IFieldSymbol>(0);
+
         if (fields.Count == 0)
             return new List<IFieldSymbol>(0);
 
@@ -143,72 +233,6 @@ public sealed class AllowInCustomizationsForOmittedFields : DiagnosticAnalyzer
         }
 
         return result;
-    }
-
-    private static ICollection<IFieldSymbol> GetDeclaredTableFields(ISymbol symbol)
-    {
-        var navKind = symbol.GetContainingObjectTypeSymbol().GetNavTypeKindSafe();
-
-        if (navKind == EnumProvider.NavTypeKind.Record && symbol is ITableTypeSymbol table)
-            return table.Fields;
-
-        if (navKind == EnumProvider.NavTypeKind.TableExtension && symbol is ITableExtensionTypeSymbol tableExt)
-            return tableExt.AddedFields;
-
-        return Array.Empty<IFieldSymbol>();
-    }
-
-    private static IReadOnlyList<IApplicationObjectTypeSymbol> GetRelatedPages(Compilation compilation, ITableTypeSymbol table)
-    {
-        // Materialize once, then filter. Avoid repeated enumeration of declared symbols.
-        var declared = compilation.GetDeclaredApplicationObjectSymbols().ToList();
-
-        var pages =
-            declared.Where(x => x.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Page)
-                    .Select(x => (IApplicationObjectTypeSymbol)x)
-                    .Where(x =>
-                    {
-                        var page = (IPageTypeSymbol)x.GetTypeSymbol();
-                        return page.PageType != PageTypeKind.API && page.RelatedTable == table;
-                    });
-
-        var pageExtensions =
-            declared.Where(x => x.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.PageExtension)
-                    .Select(x => (IApplicationObjectTypeSymbol)x)
-                    .Where(x =>
-                    {
-                        if (x is not IApplicationObjectExtensionTypeSymbol ext || ext.Target is null)
-                            return false;
-
-                        var targetPage = (IPageTypeSymbol)ext.Target.GetTypeSymbol();
-                        return targetPage.RelatedTable == table;
-                    });
-
-        return pages.Concat(pageExtensions).ToList();
-    }
-
-    private static HashSet<IFieldSymbol> GetReferencedPageFields(IEnumerable<IApplicationObjectTypeSymbol> relatedPages)
-    {
-        var set = new HashSet<IFieldSymbol>();
-
-        foreach (var pageLike in relatedPages)
-        {
-            var navKind = pageLike.GetNavTypeKindSafe();
-
-            if (navKind == EnumProvider.NavTypeKind.Page && pageLike is IPageTypeSymbol page)
-            {
-                AddFieldControls(set, page.FlattenedControls);
-                continue;
-            }
-
-            if (navKind == EnumProvider.NavTypeKind.PageExtension && pageLike is IPageExtensionTypeSymbol pageExt)
-            {
-                AddFieldControls(set, pageExt.AddedControlsFlattened);
-                continue;
-            }
-        }
-
-        return set;
     }
 
     private static void AddFieldControls(HashSet<IFieldSymbol> set, ImmutableArray<IControlSymbol> controls)

--- a/src/ALCops.ApplicationCop/Analyzers/FieldGroupsRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/FieldGroupsRequired.cs
@@ -4,7 +4,6 @@ using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 
 namespace ALCops.ApplicationCop.Analyzers;
@@ -79,20 +78,17 @@ public sealed class FieldGroupsRequired : DiagnosticAnalyzer
     private static HashSet<ITableTypeSymbol> BuildTablesReferencedByPages(CompilationStartAnalysisContext ctx)
     {
         var result = new HashSet<ITableTypeSymbol>();
+        var declared = ctx.Compilation.GetDeclaredApplicationObjectSymbols();
 
-        foreach (var tree in ctx.Compilation.SyntaxTrees)
+        for (int i = 0; i < declared.Length; i++)
         {
-            var root = tree.GetRoot(ctx.CancellationToken);
-            var semanticModel = ctx.Compilation.GetSemanticModel(tree);
+            var symbol = declared[i];
 
-            foreach (var pageDeclaration in root.DescendantNodes().OfType<PageSyntax>())
-            {
-                if (semanticModel.GetDeclaredSymbol(pageDeclaration, ctx.CancellationToken) is not IPageTypeSymbol pageSymbol)
-                    continue;
+            if (symbol.GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Page)
+                continue;
 
-                if (pageSymbol.RelatedTable is ITableTypeSymbol table)
-                    result.Add(table);
-            }
+            if (symbol is IPageTypeSymbol page && page.RelatedTable is ITableTypeSymbol table)
+                result.Add(table);
         }
 
         return result;


### PR DESCRIPTION
## Performance optimization for AC0026 and AC0013

### Problem

On the Base App (7938 files), two ApplicationCop rules dominated processing time:
- **AC0026** (AllowInCustomizationsForOmittedFields): **8.6s** — called `GetDeclaredApplicationObjectSymbols()` per table (~1500 times), each materializing a new `ImmutableArray`
- **AC0013** (FieldGroupsRequired): **4.3s** — walked all 7938 syntax trees creating semantic models to find pages

### Solution

**AC0013**: Replaced syntax-tree walk with single `GetDeclaredApplicationObjectSymbols()` call filtered for pages.
- Result: **4.3s → 0.03s** (143× faster)

**AC0026 Phase 1**: Moved to `CompilationStart` pattern with pre-computed page lookups.
- Result: **8.6s → 3.1s** (2.8× faster)

**AC0026 Phase 2**: Two-level lazy architecture:
- **Level 1** (`BuildTableToPageIndex`, CompilationStart): Lightweight table-to-page index without materializing `FlattenedControls`
- **Level 2** (`ConcurrentDictionary + Lazy`, AnalyzeSymbol): Per-table field resolution on-demand, parallelized across threads. Tables exiting early never trigger expensive control iteration.
- Result: **3.1s → target <1s**

### Overall impact

| Rule | Before | After |
|---|---|---|
| AC0013 | 4.3s | 0.03s |
| AC0026 | 8.6s | ~0.5-1s (estimated) |
| ApplicationCop total | 16.4s | ~4s (estimated) |

### Testing

All 854 tests pass across all 6 test projects.