### PR TITLE
refactor: redesign release strategy with three-channel versioning

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -83,6 +83,7 @@ These cover conventions for a category of files. Include:
 | `testing.instructions.md` | `'src/*.Test/**'` | Test conventions and patterns |
 | `common-library.instructions.md` | `'src/ALCops.Common/**'` | Shared library guidelines |
 | `cicd.instructions.md` | `'.github/**'` | CI/CD workflows and scripts |
+| `release-strategy.instructions.md` | `'.github/**'` | Release channels, versioning, GitVersion config, cleanup |
 | `lc0095-use-partial-records-on-read.instructions.md` | `'src/ALCops.LinterCop/**/UsePartialRecordsOnRead*'` | LC0095 rule details |
 | `lc0096-unnecessary-record-parameter.instructions.md` | `'src/ALCops.LinterCop/**/UnnecessaryRecordParameterInMethodCall*'` | LC0096 rule details |
 | `lc0086-page-style-string-literal.instructions.md` | `'src/ALCops.LinterCop/**/PageStyleStringLiteral*'` | LC0086 rule details |

--- a/.github/instructions/project-overview.instructions.md
+++ b/.github/instructions/project-overview.instructions.md
@@ -136,9 +136,15 @@ The settings provider uses `Newtonsoft.Json` on `netstandard2.1` and `System.Tex
 
 ## Versioning
 
-GitVersion with `GitHubFlow/v1` workflow:
-- `main` branch: `alpha` label, `Patch` increment, tracks release branches
-- `release` branch: prevents increment when current commit is tagged (uses tag value)
+Three-channel release strategy using GitVersion with `GitHubFlow/v1` workflow:
+- **Alpha** (`main` branch): Auto-published on every push. Version: `X.Y.0-alpha.N` (Minor increment).
+- **Beta** (`release/vX.Y.Z` branch): Manual publish via workflow_dispatch. Version: `X.Y.0-beta.N` (ContinuousDelivery mode).
+- **Stable** (tag `vX.Y.Z`): Auto-published on tag push. Version from tag.
+
+`tracks-release-branches: true` on main means creating `release/v0.7.0` auto-bumps main to `0.8.0-alpha.1`.
+Override increment per commit with `+semver: major/minor/patch`.
+
+See `release-strategy.instructions.md` for full details.
 
 ## Branching policy
 
@@ -154,14 +160,16 @@ Branch naming conventions:
 - `fix/<description>` for bug fixes
 - `feat/<description>` for new features
 - `docs/<description>` for documentation-only changes
+- `release/vX.Y.Z` for release stabilization branches
 
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:
 - `build-test.yml` : Reusable workflow for build and test
 - `pull-request.yml` : Runs on PRs
-- `build-and-release.yml` : Build and release pipeline
-- `scheduled-build.yml` : Scheduled builds
+- `build-and-release.yml` : Build, test, pack, and publish (alpha/beta/stable channels)
+- `scheduled-build.yml` : Daily cache keepalive builds
+- `scheduled-cleanup.yml` : Weekly cleanup of old pre-release packages from NuGet.org and GitHub Packages
 
 ## Building locally
 

--- a/.github/instructions/release-strategy.instructions.md
+++ b/.github/instructions/release-strategy.instructions.md
@@ -1,0 +1,188 @@
+---
+applyTo: '.github/**'
+---
+
+# Release Strategy
+
+ALCops Analyzers uses a three-channel release strategy with GitVersion auto-computing all version numbers. NuGet packages are published to both NuGet.org and GitHub Packages.
+
+## Release channels
+
+| Channel | Source            | Trigger                    | Example                                |
+|---------|-------------------|----------------------------|----------------------------------------|
+| Alpha   | `main` branch     | Auto on every push         | `0.7.0-alpha.1`, `0.7.0-alpha.2`, ... |
+| Beta    | `release/vX.Y.Z`  | Manual (workflow_dispatch) | `0.7.0-beta.1`, `0.7.0-beta.2`, ...   |
+| Stable  | Tag `vX.Y.Z`      | Auto on tag push           | `0.7.0`                                |
+
+### Alpha releases
+
+Every push to `main` that passes CI automatically publishes an alpha package to NuGet.org and GitHub Packages. No GitHub Release is created. A weekly cleanup job unlists old alphas from NuGet.org (keeping the last 3) to prevent clutter.
+
+### Beta releases
+
+Created manually by running the CI/CD workflow via `workflow_dispatch` on a release branch (e.g., `release/v0.7.0`). The person running the workflow selects the release branch in the GitHub Actions UI. The workflow auto-creates a git tag (e.g., `v0.7.0-beta.1`) so that GitVersion's `ManualDeployment` mode increments `.N` sequentially per published beta, not per commit. Packages are published to NuGet.org and GitHub Packages. No GitHub Release is created.
+
+### Stable releases
+
+Triggered automatically when a tag matching `v*` is pushed (e.g., `v0.7.0`). Stable releases get a GitHub Release with an auto-generated changelog and the `.nupkg` attached. Packages are also published to NuGet.org and GitHub Packages. After a stable release, the weekly cleanup job unlists all superseded pre-releases.
+
+## Version computation (GitVersion)
+
+GitVersion with `GitHubFlow/v1` workflow auto-computes versions based on tags, branch names, and commit count.
+
+### Configuration (`GitVersion.yml`)
+
+```yaml
+workflow: GitHubFlow/v1
+branches:
+  main:
+    label: alpha
+    increment: Minor
+    tracks-release-branches: true
+  release:
+    mode: ManualDeployment
+    label: beta
+    prevent-increment:
+      when-current-commit-tagged: true
+```
+
+### How versions are computed
+
+- **Main branch** (`ContinuousDeployment`, GitHubFlow default): Takes the latest tag, bumps the minor version, appends `-alpha.N` where N is the commit count since the last version-relevant event. Every push gets a unique version. `tracks-release-branches: true` means creating a release branch causes main to auto-bump to the next minor.
+- **Release branch** (`ManualDeployment`): Extracts the version from the branch name (e.g., `release/v0.7.0` produces `0.7.0-beta.N`). The `.N` only increments when a new tag exists. The CI/CD workflow auto-creates tags on each beta publish, producing sequential numbering (beta.1, beta.2, ...) with no gaps.
+- **Tagged commit**: Uses the tag value directly (e.g., tag `v0.7.0` produces version `0.7.0`).
+
+### Version progression example
+
+```
+v0.6.1 (current latest stable)
+  |
+  v (merges to main, auto-published)
+  0.7.0-alpha.1 -> 0.7.0-alpha.2 -> ... -> 0.7.0-alpha.N
+  |
+  v (create release/v0.7.0 branch)
+  main auto-bumps to: 0.8.0-alpha.1, 0.8.0-alpha.2, ...
+  release branch (workflow_dispatch publishes + auto-tags):
+    commit 1 -> publish -> tag v0.7.0-beta.1
+    commit 2, 3 (not published, no tag, no version bump)
+    commit 4 -> publish -> tag v0.7.0-beta.2  (sequential, no gaps)
+  |
+  v (tag v0.7.0 on release branch)
+  0.7.0 (stable release, auto-published)
+  cleanup unlists: all 0.7.0-alpha.*, all 0.7.0-beta.*
+```
+
+### Alpha vs beta numbering
+
+- **Alpha** (`ContinuousDeployment`): Every push to main gets a unique `.N` based on commit count. Since every push auto-publishes, there are no gaps. Gaps could appear if commits only change non-source files (path-filtered), but this is acceptable.
+- **Beta** (`ManualDeployment`): The `.N` only increments when the workflow auto-creates a tag. Between tags, GitVersion produces the same version with different build metadata (stripped by NuGet). This guarantees sequential `beta.1`, `beta.2`, ... with no gaps on NuGet.
+
+### Overriding the increment
+
+By default, main increments the Minor version. Override per commit message:
+- `+semver: patch` (bump patch instead of minor)
+- `+semver: major` (bump major, e.g., for v1.0.0)
+- `+semver: minor` (explicit minor, same as default)
+
+## Branch naming conventions
+
+| Branch pattern    | Purpose                                   |
+|-------------------|-------------------------------------------|
+| `main`            | Development trunk, produces alpha releases |
+| `release/vX.Y.Z`  | Release stabilization, produces betas     |
+| `fix/<desc>`      | Bug fix branches (PR to main)             |
+| `feat/<desc>`     | Feature branches (PR to main)             |
+| `docs/<desc>`     | Documentation branches (PR to main)       |
+
+## How to create a release
+
+### 1. Create the release branch
+
+```bash
+git checkout main
+git pull
+git checkout -b release/v0.7.0
+git push -u origin release/v0.7.0
+```
+
+This automatically bumps main to the next minor (e.g., `0.8.0-alpha.1`).
+
+### 2. Stabilize on the release branch
+
+Fix bugs by creating PRs to the release branch. Each merge can be published as a beta via workflow_dispatch.
+
+### 3. Publish beta releases
+
+1. Go to GitHub Actions > CI/CD workflow
+2. Click "Run workflow"
+3. Select the release branch (e.g., `release/v0.7.0`)
+4. Click "Run workflow"
+
+### 4. Create the stable release
+
+```bash
+git checkout release/v0.7.0
+git tag v0.7.0
+git push origin v0.7.0
+```
+
+The tag push automatically triggers CI/CD, which builds, tests, publishes to NuGet, creates a GitHub Release with changelog, and deletes the beta tags (e.g., `v0.7.0-beta.1`, `v0.7.0-beta.2`) from the repo.
+
+### 5. Merge back to main
+
+```bash
+git checkout main
+git merge release/v0.7.0
+git push
+```
+
+The pull-request workflow skips CI for release-to-main merges (housekeeping, not feature work).
+
+## Cleanup job
+
+A weekly scheduled workflow (`scheduled-cleanup.yml`) runs every Sunday at 06:00 UTC. It can also be triggered manually.
+
+### What it does
+
+1. **Superseded pre-releases**: Unlists from NuGet.org and deletes from GitHub Packages all pre-release versions whose base version is at or below the latest stable (e.g., all `0.7.0-alpha.*` and `0.7.0-beta.*` after `0.7.0` is released)
+2. **Old current alphas**: For pre-releases above the latest stable, keeps the last 3 and unlists/deletes the rest
+
+### NuGet.org vs GitHub Packages cleanup
+
+- **NuGet.org**: Unlists packages. Unlisted packages are hidden from search but remain downloadable by exact version pin. This is safe for users who have pinned a specific version.
+- **GitHub Packages**: Permanently deletes old versions. Accepted trade-off for pre-releases.
+
+## SemVer ordering
+
+The `.N` suffix pattern (`alpha.1`, `alpha.2`, `beta.1`) was chosen over a patch-increment scheme (`v1.0.0-alpha`, `v1.0.1-alpha`, `v1.0.2-alpha`) for SemVer correctness.
+
+With patch-increment pre-releases, `1.0.1-beta > 1.0.0` (stable), meaning a beta would sort higher than the stable release it precedes. The `.N` suffix keeps all pre-releases below their target stable version: `1.0.0-beta.99 < 1.0.0`.
+
+## CI/CD workflows
+
+| Workflow               | Trigger                          | Purpose                                |
+|------------------------|----------------------------------|----------------------------------------|
+| `build-test.yml`       | Reusable (called by others)      | Build and test all projects            |
+| `pull-request.yml`     | Pull requests to main/release    | PR validation                          |
+| `build-and-release.yml`| Push to main, tags, workflow_dispatch | Build, test, pack, publish      |
+| `scheduled-build.yml`  | Daily cron                       | Cache keepalive                        |
+| `scheduled-cleanup.yml`| Weekly cron, workflow_dispatch   | Unlist/delete old pre-releases         |
+
+### build-and-release.yml release conditions
+
+The release job runs when:
+- `refs/heads/main` -> publish alpha packages
+- `refs/heads/release/*` + workflow_dispatch -> publish beta packages
+- `refs/tags/v*` -> publish stable packages + create GitHub Release with changelog
+
+Push to a release branch without workflow_dispatch runs build-and-test only (no publish). This gives CI feedback on commits without publishing every change.
+
+GitHub Releases are only created for stable versions (tag pushes). Alpha and beta versions are NuGet-only.
+
+## What external contributors should expect
+
+- PRs are validated by `pull-request.yml` (build + test)
+- PRs do not produce any release or package
+- Once merged to main, the change appears in the next alpha automatically
+- The maintainers decide when to cut a release branch and tag a stable version
+- Pre-release versions may be unlisted from NuGet.org after a stable release, but remain downloadable by exact version

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,5 +1,10 @@
 name: CI/CD
 
+# Release channels:
+#   Alpha  - auto on every push to main            (1.0.0-alpha.1, 1.0.0-alpha.2, ...)
+#   Beta   - manual workflow_dispatch on release/* (1.0.0-beta.1, 1.0.0-beta.2, ...)
+#   Stable - auto on tag push v*                   (1.0.0)
+
 on:
   push:
     branches:
@@ -22,6 +27,7 @@ on:
       - "!**/*.md"
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -43,7 +49,13 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     name: Release
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    if: >-
+      github.ref == 'refs/heads/main'
+      || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/'))
+      || startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/checkout@v6
@@ -69,7 +81,7 @@ jobs:
           version-number: ${{ needs.build-and-test.outputs.tfm-net80-version-lowest }}
           target-path: Microsoft.Dynamics.BusinessCentral.Development.Tools/net8.0
 
-      # Git Version
+      # GitVersion
       - name: GitVersion - Setup
         uses: gittools/actions/gitversion/setup@v4.5.0
         with:
@@ -79,7 +91,26 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v4.5.0
 
-      # Pack and publish
+      - name: Display version
+        run: echo "SemVer:${{ steps.gitversion.outputs.SemVer }}"
+
+      # Tag beta releases for sequential numbering (beta.1, beta.2, ...)
+      # ManualDeployment mode increments .N based on tags, not commits.
+      - name: Tag beta release
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          TAG="v${{ steps.gitversion.outputs.SemVer }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists (re-run), skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created tag $TAG"
+          fi
+
+      # Pack
       - name: Pack
         run: >
           dotnet pack ./src/ALCops.Analyzers/ALCops.Analyzers.csproj
@@ -95,26 +126,27 @@ jobs:
           /p:FileVersion=${{ steps.gitversion.outputs.AssemblySemFileVer }}
           /p:InformationalVersion="${{ steps.gitversion.outputs.InformationalVersion }}"
 
+      # GitHub Release (stable only, triggered by tag push)
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v6
         if: startsWith(github.ref, 'refs/tags/v')
+        uses: mikepenz/release-changelog-builder-action@v6
         with:
-          ignorePreReleases: ${{ steps.gitversion.outputs.PreReleaseTag == '' }}
+          ignorePreReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.gitversion.outputs.SemVer }}
           name: v${{ steps.gitversion.outputs.SemVer }}
           body: ${{ steps.build_changelog.outputs.changelog }}
-          prerelease: ${{ steps.gitversion.outputs.PreReleaseTag != '' }}
           files: |
             ./artifacts/*.nupkg
 
+      # Publish packages (all channels)
       - name: Publish to GitHub Packages
         run: >
           dotnet nuget push "./artifacts/*.nupkg"
@@ -134,3 +166,13 @@ jobs:
             --api-key "$NUGET_API_KEY" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+
+      # Clean up beta tags after stable release
+      - name: Delete beta tags
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${{ steps.gitversion.outputs.MajorMinorPatch }}"
+          echo "Cleaning up beta tags for v${VERSION}"
+          for TAG in $(git tag -l "v${VERSION}-beta.*"); do
+            git push origin --delete "$TAG" && echo "Deleted $TAG" || echo "Failed to delete $TAG"
+          done

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -1,0 +1,227 @@
+name: Cleanup Pre-release Packages
+
+# Unlist old pre-release versions from NuGet.org and delete from GitHub Packages.
+# Runs weekly and can be triggered manually after a stable release.
+#
+# Logic:
+#   1. Superseded pre-releases (base version <= latest stable): unlist/delete ALL
+#   2. Current pre-releases (base version > latest stable): keep last 3, unlist/delete the rest
+#
+# NuGet.org: unlists packages (still downloadable by exact version pin)
+# GitHub Packages: permanently deletes old versions
+
+on:
+  schedule:
+    - cron: "0 6 * * 0" # Every Sunday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+env:
+  PACKAGE_NAME: ALCops.Analyzers
+  PACKAGE_NAME_LOWER: alcops.analyzers
+  KEEP_LAST_N: 3
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Cleanup old pre-releases
+    steps:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Cleanup NuGet.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "::warning::NUGET_API_KEY not configured, skipping NuGet.org cleanup"
+            exit 0
+          fi
+
+          echo "Fetching all versions from NuGet.org flat container..."
+          ALL_VERSIONS=$(curl -sf "https://api.nuget.org/v3-flatcontainer/${PACKAGE_NAME_LOWER}/index.json" \
+            | jq -r '.versions[]') || { echo "::warning::Failed to fetch versions"; exit 0; }
+
+          if [ -z "$ALL_VERSIONS" ]; then
+            echo "No versions found"
+            exit 0
+          fi
+
+          # Separate stable and pre-release
+          STABLE=()
+          PRERELEASE=()
+          while IFS= read -r v; do
+            if [[ "$v" == *-* ]]; then
+              PRERELEASE+=("$v")
+            else
+              STABLE+=("$v")
+            fi
+          done <<< "$ALL_VERSIONS"
+
+          echo "Found ${#STABLE[@]} stable and ${#PRERELEASE[@]} pre-release versions"
+
+          if [ ${#PRERELEASE[@]} -eq 0 ]; then
+            echo "No pre-release versions to clean up"
+            exit 0
+          fi
+
+          # Find latest stable
+          LATEST_STABLE=""
+          if [ ${#STABLE[@]} -gt 0 ]; then
+            LATEST_STABLE=$(printf '%s\n' "${STABLE[@]}" | sort -V | tail -n1)
+            echo "Latest stable: $LATEST_STABLE"
+          else
+            echo "No stable versions found, will only trim current alphas"
+          fi
+
+          # Categorize pre-releases into superseded vs current
+          SUPERSEDED=()
+          CURRENT=()
+          for v in "${PRERELEASE[@]}"; do
+            base="${v%%-*}"
+            if [ -n "$LATEST_STABLE" ]; then
+              higher=$(printf '%s\n%s' "$base" "$LATEST_STABLE" | sort -V | tail -n1)
+              if [ "$higher" = "$LATEST_STABLE" ] || [ "$base" = "$LATEST_STABLE" ]; then
+                SUPERSEDED+=("$v")
+              else
+                CURRENT+=("$v")
+              fi
+            else
+              CURRENT+=("$v")
+            fi
+          done
+
+          echo "Superseded pre-releases: ${#SUPERSEDED[@]}"
+          echo "Current pre-releases: ${#CURRENT[@]}"
+
+          # Build unlist list
+          TO_UNLIST=()
+
+          # All superseded pre-releases
+          for v in "${SUPERSEDED[@]}"; do
+            TO_UNLIST+=("$v")
+          done
+
+          # Current pre-releases: keep last N (by SemVer sort)
+          if [ ${#CURRENT[@]} -gt "$KEEP_LAST_N" ]; then
+            mapfile -t SORTED_CURRENT < <(printf '%s\n' "${CURRENT[@]}" | sort -V)
+            REMOVE_COUNT=$(( ${#SORTED_CURRENT[@]} - KEEP_LAST_N ))
+            for ((i=0; i<REMOVE_COUNT; i++)); do
+              TO_UNLIST+=("${SORTED_CURRENT[$i]}")
+            done
+          fi
+
+          echo ""
+          echo "=== NuGet.org: unlisting ${#TO_UNLIST[@]} versions ==="
+          for v in "${TO_UNLIST[@]}"; do
+            echo "  Unlisting: $v"
+            dotnet nuget delete "$PACKAGE_NAME" "$v" \
+              --source https://api.nuget.org/v3/index.json \
+              --api-key "$NUGET_API_KEY" \
+              --non-interactive 2>&1 || echo "  (already unlisted or failed)"
+            sleep 1
+          done
+          echo "NuGet.org cleanup complete"
+
+      - name: Cleanup GitHub Packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          OWNER="${{ github.repository_owner }}"
+
+          echo "Fetching GitHub Packages versions..."
+          GH_VERSIONS=$(gh api "/orgs/${OWNER}/packages/nuget/${PACKAGE_NAME}/versions" \
+            --paginate --jq '.[] | "\(.id)|\(.name)"' 2>/dev/null) \
+            || GH_VERSIONS=$(gh api "/users/${OWNER}/packages/nuget/${PACKAGE_NAME}/versions" \
+              --paginate --jq '.[] | "\(.id)|\(.name)"' 2>/dev/null) \
+            || { echo "::warning::Failed to list GitHub Packages versions"; exit 0; }
+
+          if [ -z "$GH_VERSIONS" ]; then
+            echo "No GitHub Packages versions found"
+            exit 0
+          fi
+
+          # Build lookup: version -> id
+          declare -A VERSION_IDS
+          while IFS='|' read -r id name; do
+            VERSION_IDS["$name"]="$id"
+          done <<< "$GH_VERSIONS"
+
+          echo "Found ${#VERSION_IDS[@]} versions on GitHub Packages"
+
+          # Separate stable and pre-release
+          STABLE=()
+          PRERELEASE=()
+          for v in "${!VERSION_IDS[@]}"; do
+            if [[ "$v" == *-* ]]; then
+              PRERELEASE+=("$v")
+            else
+              STABLE+=("$v")
+            fi
+          done
+
+          # Find latest stable
+          LATEST_STABLE=""
+          if [ ${#STABLE[@]} -gt 0 ]; then
+            LATEST_STABLE=$(printf '%s\n' "${STABLE[@]}" | sort -V | tail -n1)
+          fi
+
+          # Categorize
+          SUPERSEDED=()
+          CURRENT=()
+          for v in "${PRERELEASE[@]}"; do
+            base="${v%%-*}"
+            if [ -n "$LATEST_STABLE" ]; then
+              higher=$(printf '%s\n%s' "$base" "$LATEST_STABLE" | sort -V | tail -n1)
+              if [ "$higher" = "$LATEST_STABLE" ] || [ "$base" = "$LATEST_STABLE" ]; then
+                SUPERSEDED+=("$v")
+              else
+                CURRENT+=("$v")
+              fi
+            else
+              CURRENT+=("$v")
+            fi
+          done
+
+          # Build delete list
+          TO_DELETE=()
+          for v in "${SUPERSEDED[@]}"; do
+            TO_DELETE+=("$v")
+          done
+
+          if [ ${#CURRENT[@]} -gt "$KEEP_LAST_N" ]; then
+            mapfile -t SORTED_CURRENT < <(printf '%s\n' "${CURRENT[@]}" | sort -V)
+            REMOVE_COUNT=$(( ${#SORTED_CURRENT[@]} - KEEP_LAST_N ))
+            for ((i=0; i<REMOVE_COUNT; i++)); do
+              TO_DELETE+=("${SORTED_CURRENT[$i]}")
+            done
+          fi
+
+          echo ""
+          echo "=== GitHub Packages: deleting ${#TO_DELETE[@]} versions ==="
+
+          # Determine API path (org vs user)
+          API_BASE="/orgs/${OWNER}/packages/nuget/${PACKAGE_NAME}/versions"
+          gh api "$API_BASE" --silent 2>/dev/null \
+            || API_BASE="/users/${OWNER}/packages/nuget/${PACKAGE_NAME}/versions"
+
+          for v in "${TO_DELETE[@]}"; do
+            VID="${VERSION_IDS[$v]:-}"
+            if [ -z "$VID" ]; then
+              echo "  Skipping $v (version ID not found)"
+              continue
+            fi
+            echo "  Deleting: $v (id: $VID)"
+            gh api -X DELETE "${API_BASE%/versions}/${VID}" 2>&1 \
+              || echo "  (already deleted or failed)"
+            sleep 1
+          done
+          echo "GitHub Packages cleanup complete"


### PR DESCRIPTION
Implement alpha/beta/stable release channels with GitVersion:
- Alpha: auto-publish on every push to main (ContinuousDeployment)
- Beta: manual workflow_dispatch on release branches (ManualDeployment)
- Stable: auto-publish on tag push with GitHub Release

Key changes:
- Add workflow_dispatch trigger and concurrency group to build-and-release
- Auto-tag beta releases for sequential numbering (no version gaps)
- Clean up beta tags when stable is released
- Add weekly scheduled-cleanup job for old pre-release packages
- Create release-strategy instruction file
- Update project-overview and instruction-maintenance docs