### PR TITLE
fix: correct GitHub Packages delete URL and skip already-unlisted NuGet packages

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: Buld and Release
 
 # Release channels:
 #   Alpha  - auto on every push to main            (1.0.0-alpha.1, 1.0.0-alpha.2, ...)

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -220,7 +220,7 @@ jobs:
               continue
             fi
             echo "  Deleting: $v (id: $VID)"
-            gh api -X DELETE "${API_BASE%/versions}/${VID}" 2>&1 \
+            gh api -X DELETE "${API_BASE}/${VID}" 2>&1 \
               || echo "  (already deleted or failed)"
             sleep 1
           done

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -44,12 +44,43 @@ jobs:
             exit 0
           fi
 
-          echo "Fetching all versions from NuGet.org flat container..."
-          ALL_VERSIONS=$(curl -sf "https://api.nuget.org/v3-flatcontainer/${PACKAGE_NAME_LOWER}/index.json" \
-            | jq -r '.versions[]') || { echo "::warning::Failed to fetch versions"; exit 0; }
+          echo "Fetching version metadata from NuGet.org registration API..."
+          REGISTRATION_JSON=$(curl -sf --compressed \
+            "https://api.nuget.org/v3/registration5-gz-semver2/${PACKAGE_NAME_LOWER}/index.json") \
+            || { echo "::warning::Failed to fetch registration index"; exit 0; }
+
+          # Extract listed versions from registration pages.
+          # Pages may have inlined items or require fetching by URL (@id).
+          ALL_VERSIONS=$(echo "$REGISTRATION_JSON" | jq -r '
+            [.items[] |
+              if .items then
+                .items[]
+              else
+                empty
+              end
+            | select(.catalogEntry.listed == true)
+            | .catalogEntry.version
+            ] | .[]') || { echo "::warning::Failed to parse registration data"; exit 0; }
+
+          # Handle non-inlined pages: fetch each page URL if items were not inlined
+          PAGE_URLS=$(echo "$REGISTRATION_JSON" | jq -r '
+            [.items[] | select(.items == null) | .["@id"]] | .[]' 2>/dev/null)
+          if [ -n "$PAGE_URLS" ]; then
+            while IFS= read -r page_url; do
+              PAGE_VERSIONS=$(curl -sf --compressed "$page_url" | jq -r '
+                [.items[] | select(.catalogEntry.listed == true) | .catalogEntry.version] | .[]' 2>/dev/null)
+              if [ -n "$PAGE_VERSIONS" ]; then
+                ALL_VERSIONS=$(printf '%s\n%s' "$ALL_VERSIONS" "$PAGE_VERSIONS")
+              fi
+            done <<< "$PAGE_URLS"
+          fi
+
+          TOTAL_COUNT=$(echo "$REGISTRATION_JSON" | jq '[.items[].items // [] | length] | add // 0')
+          LISTED_COUNT=$(echo "$ALL_VERSIONS" | grep -c . || true)
+          echo "Found ${LISTED_COUNT} listed versions out of ${TOTAL_COUNT} total on NuGet.org"
 
           if [ -z "$ALL_VERSIONS" ]; then
-            echo "No versions found"
+            echo "No listed versions found"
             exit 0
           fi
 


### PR DESCRIPTION
## Problems

Two bugs in `scheduled-cleanup.yml` ([failing run](https://github.com/ALCops/Analyzers/actions/runs/24770745604/job/72476256590)):

### 1. GitHub Packages: 404 on every delete

The delete URL was constructed with `${API_BASE%/versions}/${VID}` which strips `/versions` from the path, producing an invalid endpoint. All 45 delete attempts fail with HTTP 404.

**Fix**: Remove the `%/versions` suffix stripping. `API_BASE` already ends with `/versions`, so `${API_BASE}/${VID}` produces the correct path.

### 2. NuGet.org: re-unlisting already-unlisted packages every run

The flat container API (`/v3-flatcontainer/.../index.json`) returns all 61 versions (listed + unlisted) with no listing status metadata. Every weekly run tries to unlist the same ~49 already-unlisted packages.

**Fix**: Switch to the NuGet Registration API (`registration5-gz-semver2`), which exposes `catalogEntry.listed` per version. Only listed versions (currently 12 out of 61) are fed into the categorization and unlist logic.

Also handles non-inlined registration pages for robustness when version count exceeds the inlining threshold (~128 versions).