### PR TITLE
fix: make alcops.json lookup case-insensitive on all platforms

### DIFF
--- a/src/ALCops.Common/Settings/ALCopsSettingsProvider.cs
+++ b/src/ALCops.Common/Settings/ALCopsSettingsProvider.cs
@@ -108,7 +108,15 @@ public static class ALCopsSettingsProvider
             return null;
 
         var settingsFilePath = Path.Combine(directoryPath, SettingsFileName);
-        return File.Exists(settingsFilePath) ? settingsFilePath : null;
+        if (File.Exists(settingsFilePath))
+            return settingsFilePath;
+
+        if (!Directory.Exists(directoryPath))
+            return null;
+
+        return Directory.EnumerateFiles(directoryPath)
+            .FirstOrDefault(f => string.Equals(
+                Path.GetFileName(f), SettingsFileName, StringComparison.OrdinalIgnoreCase));
     }
 
 }


### PR DESCRIPTION
## Summary

`FindSettingsFileInDirectory` now performs a case-insensitive file lookup so that `ALCops.json`, `ALCOPS.JSON`, or any other casing is found on case-sensitive file systems (macOS, Linux).

## Changes

Single method change in `src/ALCops.Common/Settings/ALCopsSettingsProvider.cs`:

1. **Fast path**: Tries the exact canonical name `"alcops.json"` via `File.Exists` (zero overhead on Windows/case-insensitive FSes)
2. **Fallback**: Enumerates directory files and matches with `StringComparison.OrdinalIgnoreCase` (handles non-canonical casing on macOS/Linux)
3. **Guard**: Checks `Directory.Exists` before enumeration to avoid exceptions

## Testing

All 877 tests pass, 0 failures.