### PR TITLE
Add GitHub issue templates and fix TestCop naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Report a bug, false positive, false negative, or crash in an ALCops analyzer
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        Before you create a new issue, please:
+        🔎 **Search [existing issues](https://github.com/ALCops/Analyzers/issues)** to avoid duplicates.
+        ✅ **Try reproducing on the [latest version](https://www.nuget.org/packages/ALCops.Analyzers)** of ALCops Analyzers.
+        💡 **Want to suggest a new rule?** Please open a [Discussion](https://github.com/ALCops/Analyzers/discussions) instead.
+
+  - type: dropdown
+    id: cop
+    attributes:
+      label: Analyzer
+      description: Which analyzer (cop) is this about?
+      options:
+        - ApplicationCop
+        - DocumentationCop
+        - FormattingCop
+        - LinterCop
+        - PlatformCop
+        - TestAutomationCop
+        - General
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      description: What kind of issue are you reporting?
+      options:
+        - False positive (diagnostic fires when it shouldn't)
+        - False negative (diagnostic doesn't fire when it should)
+        - Crash / exception
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: rule-id
+    attributes:
+      label: Rule ID
+      description: The diagnostic rule ID, if applicable.
+      placeholder: e.g., LC0086
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the issue.
+      placeholder: Describe the issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: al-code
+    attributes:
+      label: AL code to reproduce
+      description: A minimal AL code snippet that reproduces the issue.
+      value: |
+        ```al
+
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any additional information that might help, such as screenshots, stack traces, or logs.
+      placeholder: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💡 Suggest a new rule
+    url: https://github.com/ALCops/Analyzers/discussions
+    about: Have an idea for a new analyzer rule? Open a discussion so we can shape it together with the community.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A collection of custom code analyzers for the AL programming language of Microso
 | [FormattingCop](https://alcops.dev/docs/analyzers/formattingcop/) | Covers stylistic and syntactic consistency rules. Ensures clean, uniform, readable code without influencing behavior or semantics. |
 | [LinterCop](https://alcops.dev/docs/analyzers/lintercop/) | Identifies non-breaking code smells and suggests better implementation patterns. Focuses on maintainability, clarity, and recommended practices where multiple valid options exist. |
 | [PlatformCop](https://alcops.dev/docs/analyzers/platformcop/) | Validates AL language and runtime semantic correctness, preventing patterns that always fail or behave unpredictably. These rules apply universally, independent of the Business Central domain model. |
-| [TestCop](https://alcops.dev/docs/analyzers/testcop/) | Ensures correctness and structure of test codeunits and related test procedures. Applies exclusively to test logic, not production code. |
+| [TestAutomationCop](https://alcops.dev/docs/analyzers/testcop/) | Ensures correctness and structure of test codeunits and related test procedures. Applies exclusively to test logic, not production code. |
 
 Browse the complete rules reference at [alcops.dev/docs/analyzers](https://alcops.dev/docs/analyzers/).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A collection of custom code analyzers for the AL programming language of Microso
 | [FormattingCop](https://alcops.dev/docs/analyzers/formattingcop/) | Covers stylistic and syntactic consistency rules. Ensures clean, uniform, readable code without influencing behavior or semantics. |
 | [LinterCop](https://alcops.dev/docs/analyzers/lintercop/) | Identifies non-breaking code smells and suggests better implementation patterns. Focuses on maintainability, clarity, and recommended practices where multiple valid options exist. |
 | [PlatformCop](https://alcops.dev/docs/analyzers/platformcop/) | Validates AL language and runtime semantic correctness, preventing patterns that always fail or behave unpredictably. These rules apply universally, independent of the Business Central domain model. |
-| [TestAutomationCop](https://alcops.dev/docs/analyzers/testcop/) | Ensures correctness and structure of test codeunits and related test procedures. Applies exclusively to test logic, not production code. |
+| [TestAutomationCop](https://alcops.dev/docs/analyzers/testautomationcop/) | Ensures correctness and structure of test codeunits and related test procedures. Applies exclusively to test logic, not production code. |
 
 Browse the complete rules reference at [alcops.dev/docs/analyzers](https://alcops.dev/docs/analyzers/).
 


### PR DESCRIPTION
## Summary

Adds structured GitHub issue templates to improve bug report quality and redirect rule suggestions to Discussions. Fixes TestCop naming inconsistency in README.

Ref #151

## Changes

### New: Bug report issue form (`.github/ISSUE_TEMPLATE/bug_report.yml`)

YAML-based issue form with structured fields:

| Field | Type | Required |
|-------|------|----------|
| Analyzer (cop) | Dropdown (7 options incl. General) | ✅ |
| Issue type | Dropdown (false positive, false negative, crash, other) | ✅ |
| Rule ID | Text input | ❌ |
| Description | Textarea | ✅ |
| AL code to reproduce | Textarea (pre-populated with AL code block) | ❌ |
| Additional context | Textarea | ❌ |

Includes a markdown preamble with guidelines: search existing issues, try the latest version, use Discussions for new rule suggestions.

### New: Issue template config (`.github/ISSUE_TEMPLATE/config.yml`)

- Blank issues remain enabled
- Adds a "Suggest a new rule" link redirecting to GitHub Discussions

### Fix: README.md

Renamed "TestCop" to "TestAutomationCop" to match the actual project name (`ALCops.TestAutomationCop`, prefix `TA`).