### PR TITLE
feat: add PC0033 DuplicateODataEntityName analyzer

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -839,6 +839,73 @@ Write the test class following the pattern above, using `RoslynFixtureFactory.Cr
 
 Build the solution and run the tests to confirm the analyzer works.
 
+## Gathering All Extensions of a Kind (ConditionalWeakTable Cache Pattern)
+
+When an analyzer needs to find all extension objects (page extensions, table extensions) targeting a specific base object, use a `ConditionalWeakTable<Compilation, CacheEntry>` to lazily cache the full set once per compilation. This avoids repeated expensive `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection()` calls.
+
+### Pattern
+
+```csharp
+// Cache all extensions per Compilation (lazy, thread-safe, GC-friendly)
+private static ImmutableArray<IPageExtensionBaseTypeSymbol> GetCachedPageExtensions(Compilation compilation)
+    => PageExtensionsCache.GetValue(compilation, static c => new PageExtensionsCacheEntry(c)).Value.Value;
+private static readonly ConditionalWeakTable<Compilation, PageExtensionsCacheEntry> PageExtensionsCache = new();
+private sealed class PageExtensionsCacheEntry(Compilation compilation)
+{
+    public Lazy<ImmutableArray<IPageExtensionBaseTypeSymbol>> Value { get; } =
+        new Lazy<ImmutableArray<IPageExtensionBaseTypeSymbol>>(
+            () => compilation
+                .GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection(EnumProvider.SymbolKind.PageExtension)
+                .OfType<IPageExtensionBaseTypeSymbol>()
+                .ToImmutableArray(),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+}
+```
+
+### Matching extensions to base objects
+
+Use `SameApplicationObject()` to compare extension targets with the base object. This handles cross-module symbols where reference equality fails:
+
+```csharp
+private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
+{
+    if (source is null || target is null)
+        return false;
+
+    source = source.OriginalDefinition;
+    target = target.OriginalDefinition;
+
+    if (ReferenceEquals(source, target))
+        return true;
+
+    if (source is ISymbolWithId lId && target is ISymbolWithId rId)
+        return lId.Id == rId.Id && source.Kind == target.Kind;
+
+    return source.Equals(target);
+}
+```
+
+### When to use
+
+- Analyzing page extensions that need controls from sibling extensions targeting the same page (e.g., `DuplicateODataEntityName` for OData name collision)
+- Analyzing table extensions that need fields from sibling extensions targeting the same table (e.g., `TransferFieldsSchemaCompatibility` for field schema comparison)
+- Any cross-object analysis where you need to enumerate all extensions of a given `SymbolKind`
+
+### Key points
+
+- `ConditionalWeakTable` uses the `Compilation` as key, so the cache is GC'd when the compilation is released
+- The inner `Lazy<T>` with `ExecutionAndPublication` ensures single computation per compilation, even under concurrent `RegisterSymbolAction` callbacks
+- `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection` retrieves symbols from all referenced modules, not just the current one
+- Always use `OriginalDefinition` when comparing symbols from different contexts (extension target vs base object)
+- Requires `using System.Runtime.CompilerServices;` for `ConditionalWeakTable`
+
+### Existing implementations
+
+| File | Extension kind | Purpose |
+|---|---|---|
+| `TransferFieldsSchemaCompatibility.cs` | `TableExtension` | Gathers table extension fields for schema comparison |
+| `DuplicateODataEntityName.cs` | `PageExtension` | Gathers sibling page extension controls for OData name collision detection |
+
 ## Common Pitfalls
 
 - **Always use `EnumProvider`** for SDK enum values. Direct references break across BC versions.

--- a/.github/instructions/common-library.instructions.md
+++ b/.github/instructions/common-library.instructions.md
@@ -46,6 +46,7 @@ Higher-level utilities that wrap SDK functionality.
 |------|---------|
 | `AppSourceCopConfigurationProvider.cs` | Adapter wrapping `Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration`. Exposes `MandatoryAffixes`, `MandatorySuffix`, `MandatoryPrefix`. Uses init-only setters on net8.0, regular setters on netstandard2.1. |
 | `ManifestHelper.cs` | `GetManifest(Compilation)` returning `NavAppManifest?`. On net8.0 delegates directly; on netstandard2.1 uses reflection to create a typed delegate, trying two different type paths for AL version compatibility. **Throws `FileNotFoundException` in test contexts** because `Microsoft.Dynamics.Nav.Analyzers.Common` assembly isn't available. Analyzers must catch this and treat as null manifest. |
+| `ODataNameHelper.cs` | `MangleIntoValidXmlIdentifier(string name)` returning `string?`. Accesses `NameTransformations.MangleIntoValidXmlIdentifier` in `Microsoft.Dynamics.Nav.AL.Common` via `Type.GetType()` + `GetMethod()` + `CreateDelegate()`. Returns null if the SDK method is unavailable (older SDK versions). Callers should check `IsAvailable` property to exit early. Used by PC0033 (DuplicateODataEntityName). |
 
 ### Reflection/
 Runtime access to internal/version-dependent SDK types. This is the most sensitive area of Common.

--- a/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
+++ b/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
@@ -40,7 +40,9 @@ Detects page controls that produce duplicate OData EntityNames after the EDMX na
 | Query objects | Not checked | Query objects restrict special characters already |
 | OData name comparison | Case-insensitive | OData property names are case-insensitive per OData spec |
 | Control filtering | `ControlKind.Field` only | Only Field controls produce OData properties; Group/Area/Part are structural |
-| Registration | `RegisterSymbolAction` on Page + PageExtension | Single-pass per symbol, no compilation-wide analysis needed |
+| Registration | `RegisterSymbolAction` on Page + PageExtension | Single-pass per symbol; sibling extension lookup via `ConditionalWeakTable` cache |
+| Sibling extension detection | `ConditionalWeakTable<Compilation, Lazy<ImmutableArray<IPageExtensionBaseTypeSymbol>>>` | Lazily caches all page extensions per compilation; same pattern as `TransferFieldsSchemaCompatibility` for table extensions |
+| Extension target matching | `SameApplicationObject()` via `OriginalDefinition` + ID comparison | Handles cross-module symbols where reference equality fails |
 | CodeFix | None for v1 | Auto-renaming controls is complex and could break existing integrations |
 | Skip obsolete | Yes | Standard ALCops convention |
 | OData transformation location | Static method in analyzer class | Only used by this rule; move to Common if reuse emerges |
@@ -71,7 +73,7 @@ So `"PTE No."` has MetadataName `PTE_Noa46` (unique from `"PTE No"` = `PTE_No`),
 
 ### Registration strategy
 
-Uses `RegisterSymbolAction` on `Page` and `PageExtension` symbol kinds.
+Uses `RegisterSymbolAction` on `Page` and `PageExtension` symbol kinds. Page extension analysis uses a `ConditionalWeakTable`-based cache to lazily gather all page extensions per compilation, enabling sibling extension collision detection.
 
 ### Analysis flow
 
@@ -89,8 +91,16 @@ Uses `RegisterSymbolAction` on `Page` and `PageExtension` symbol kinds.
 3. Collect extension's own controls from `AddedControlsFlattened`
 4. Collect base page controls from `FlattenedControls`
 5. Collect PK fields from target page's `RelatedTable`
-6. Combined duplicate check across all entries
-7. Only report diagnostics on extension-added controls (filter via `extensionControlSet`)
+6. Collect controls from sibling page extensions (other extensions targeting the same base page) via `ConditionalWeakTable` cache
+7. Combined duplicate check across all entries
+8. Only report diagnostics on extension-added controls (filter via `extensionControlSet`)
+
+### Sibling extension detection
+
+Uses the `ConditionalWeakTable<Compilation, PageExtensionsCacheEntry>` pattern (same as `TransferFieldsSchemaCompatibility` for table extensions):
+1. `GetCachedPageExtensions(compilation)` lazily loads all `IPageExtensionBaseTypeSymbol` via `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection`
+2. Filters to siblings targeting the same base page using `SameApplicationObject()` (ID + Kind comparison via `OriginalDefinition`)
+3. Sibling controls are added with `Control = null` so they are not reportable (only the current extension's controls are reported)
 
 ### Key SDK interfaces
 
@@ -127,7 +137,7 @@ These transformations differ from the SDK's MetadataName mangling, so the compil
 
 ## Test coverage
 
-### HasDiagnostic (7 cases)
+### HasDiagnostic (8 cases)
 
 | Test case | Scenario |
 |---|---|
@@ -138,6 +148,7 @@ These transformations differ from the SDK's MetadataName mangling, so the compil
 | PageExtensionCollision | Extension control `"Item No"` collides with base page `"Item No."` |
 | PrimaryKeyCollision | Control `Primary_Key` collides with PK field `"Primary Key"` |
 | ThreeWayCollision | Three controls with dots in different positions all producing `Amt` |
+| MultiplePageExtensionCollision | Two page extensions each adding a control that collides (`"PTE No"` and `"PTE No."` both → `PTE_No`) |
 
 ### NoDiagnostic (5 cases)
 
@@ -154,5 +165,4 @@ These transformations differ from the SDK's MetadataName mangling, so the compil
 - **AllowInCustomizations**: Check table fields with `AllowInCustomizations = Always` for potential collisions with page controls
 - **CodeFix**: Suggest renaming controls to avoid collision
 - **Query objects**: Evaluate if needed despite restricted characters
-- **Cross-extension collision**: Detect when two page extensions for the same base page collide with each other
 - **Apostrophe test case**: Add test for `'` → `_x0027_` transformation

--- a/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
+++ b/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
@@ -24,6 +24,7 @@ Detects page controls that produce duplicate OData EntityNames after the EDMX na
 | MessageFormat | `Control '{0}' has a duplicate OData EntityName '{1}'. This will cause a runtime error when using 'Edit in Excel'.` |
 | Version gate | None |
 | netstandard2.1 | Full support (no net8.0-only APIs used) |
+| OData transformation | Via SDK's `MangleIntoValidXmlIdentifier` accessed through reflection (`ODataNameHelper` in ALCops.Common) |
 
 ## Design decisions
 
@@ -45,20 +46,35 @@ Detects page controls that produce duplicate OData EntityNames after the EDMX na
 | Extension target matching | `SameApplicationObject()` via `OriginalDefinition` + ID comparison | Handles cross-module symbols where reference equality fails |
 | CodeFix | None for v1 | Auto-renaming controls is complex and could break existing integrations |
 | Skip obsolete | Yes | Standard ALCops convention |
-| OData transformation location | Static method in analyzer class | Only used by this rule; move to Common if reuse emerges |
+| OData transformation location | `ODataNameHelper` in `ALCops.Common/Helpers/` via reflection to SDK's `MangleIntoValidXmlIdentifier` | Authoritative SDK method eliminates maintenance burden; graceful fallback if SDK method unavailable (older versions) |
+| SDK method unavailable | Analyzer exits early (no diagnostics) | Older SDKs without `MangleIntoValidXmlIdentifier` silently skip; no errors |
 
 ## OData/EDMX Name Transformation
 
-The EDMX specification defines how AL control names are transformed to OData property names:
+The OData property name transformation is performed by the SDK's `NameTransformations.MangleIntoValidXmlIdentifier()` method in `Microsoft.Dynamics.Nav.AL.Common`. The analyzer accesses this method via reflection through `ODataNameHelper` in `ALCops.Common/Helpers/`.
+
+### Transformation rules (from SDK)
 
 | Character | Transformation | Example |
 |---|---|---|
 | Space (` `) | `_` (underscore) | `"PTE No"` → `PTE_No` |
-| Dot (`.`) | Removed | `"No."` → `No` |
-| Parentheses `()` | Removed | `"Balance (LCY)"` → `Balance_LCY` |
+| Dot (`.`) | `_` (underscore) | `"No."` → `No_` → `No` (trailing trim) |
+| Parentheses `()` | `_` (underscore) | `"Balance (LCY)"` → `Balance__LCY_` → `Balance_LCY` (dedup + trim) |
 | Slash (`/`) | `_` (underscore) | `"Country/Region"` → `Country_Region` |
-| Apostrophe (`'`) | `_x0027_` | `"O'Brien"` → `O_x0027_Brien` |
+| Hyphen (`-`) | `_` (underscore) | `"Line-No"` → `Line_No` |
+| Colon (`:`) | `_` (underscore) | `"Type:Code"` → `Type_Code` |
+| At (`@`) | `_` (underscore) | `"Email@Work"` → `Email_Work` |
+| Backslash (`\`) | `_` (underscore) | `"Path\Name"` → `Path_Name` |
+| Double quote (`"`) | `_` (underscore) | Quotes in name → underscore |
 | Percent (`%`) | `Percent` | `"Tax%"` → `TaxPercent` |
+| Consecutive `_` | Deduplicated | `"A__B"` → `A_B` |
+| Trailing `_` | Trimmed | `"Name_"` → `Name` |
+| "Subform" suffix | Replaced with "Line" | `"SalesSubform"` → `"SalesLine"` |
+| Other special chars | Via `XmlConvert.EncodeName` | `"O'Brien"` → `O_x0027_Brien` |
+
+### Why we use SDK reflection (not custom implementation)
+
+The transformation has many edge cases (consecutive underscore deduplication, trailing trim, Subform replacement, XmlConvert encoding). Maintaining a custom reimplementation is fragile and error-prone. The SDK's method is the authoritative source that matches what the BC platform actually does at runtime.
 
 ### SDK MetadataName vs OData (critical difference)
 
@@ -78,12 +94,13 @@ Uses `RegisterSymbolAction` on `Page` and `PageExtension` symbol kinds. Page ext
 ### Analysis flow
 
 **For Pages (`IPageBaseTypeSymbol`):**
-1. Skip obsolete symbols
-2. Check `PageType` against `RelevantPageTypes` set
-3. Collect field controls from `FlattenedControls` (filter to `ControlKind.Field`)
-4. Collect PK fields from `RelatedTable.PrimaryKey.Fields`
-5. Transform all names via `ToODataEntityName()`
-6. Group by OData name (case-insensitive), report all members of groups with count > 1
+1. Skip if `ODataNameHelper.IsAvailable` is false (SDK method unavailable)
+2. Skip obsolete symbols
+3. Check `PageType` against `RelevantPageTypes` set
+4. Collect field controls from `FlattenedControls` (filter to `ControlKind.Field`)
+5. Collect PK fields from `RelatedTable.PrimaryKey.Fields`
+6. Transform all names via `ODataNameHelper.MangleIntoValidXmlIdentifier()`
+7. Group by OData name (case-insensitive), report all members of groups with count > 1
 
 **For PageExtensions (`IPageExtensionBaseTypeSymbol`):**
 1. Skip obsolete symbols
@@ -127,13 +144,16 @@ The SDK's MetadataName transformation maps spaces to underscores, same as OData.
 
 ### OData name collisions not caught by compiler
 
-Our unique value is in catching collisions caused by:
-- Dot removal (`.` → removed)
-- Parenthesis removal (`()` → removed)
-- Slash to underscore (`/` → `_`)
-- Percent expansion (`%` → `Percent`)
+Our unique value is in catching collisions caused by the OData/EDMX transformation (SDK's `MangleIntoValidXmlIdentifier`), which differs from the compiler's MetadataName mangling (`MangleUnquotedIdentifierName`):
+- Dot, hyphen, colon, at, backslash, parentheses → `_` (with consecutive dedup + trailing trim)
+- Percent → `Percent`
+- Subform → Line
 
-These transformations differ from the SDK's MetadataName mangling, so the compiler's AL0757/AL0758 checks miss them.
+These transformations differ from the MetadataName mangling (where `.` → `a46`, `(` → `a40`), so the compiler's AL0757/AL0758 checks miss them.
+
+### SDK method unavailability
+
+If the SDK's `MangleIntoValidXmlIdentifier` method is not found (older BC SDK versions that don't have `Microsoft.Dynamics.Nav.AL.Common.NameTransformations`), the analyzer silently produces no diagnostics. This is by design: the `ODataNameHelper.IsAvailable` check at the top of `AnalyzeSymbol` returns early.
 
 ## Test coverage
 
@@ -147,7 +167,7 @@ These transformations differ from the SDK's MetadataName mangling, so the compil
 | SlashToUnderscore | `"Country/Region"` and `Country_Region` both become `Country_Region` |
 | PageExtensionCollision | Extension control `"Item No"` collides with base page `"Item No."` |
 | PrimaryKeyCollision | Control `Primary_Key` collides with PK field `"Primary Key"` |
-| ThreeWayCollision | Three controls with dots in different positions all producing `Amt` |
+| ThreeWayCollision | Three controls with different special chars (`"A B"`, `"A.B"`, `"A-B"`) all producing `A_B` |
 | MultiplePageExtensionCollision | Two page extensions each adding a control that collides (`"PTE No"` and `"PTE No."` both → `PTE_No`) |
 
 ### NoDiagnostic (5 cases)

--- a/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
+++ b/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
@@ -1,0 +1,158 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/DuplicateODataEntityName*'
+---
+
+# PC0033: DuplicateODataEntityName
+
+## Purpose
+
+Detects page controls that produce duplicate OData EntityNames after the EDMX name transformation. For example, `"PTE No."` and `"PTE No"` both transform to `PTE_No`, causing a runtime error when users use "Edit in Excel" or any OData integration. The AL compiler has similar checks (AL0757/AL0758/AL0678) but they use a different name mangling (`MangleUnquotedIdentifierName()` which maps `.` → `a46`), NOT the OData/EDMX transformation, so those checks don't catch OData-specific collisions.
+
+**References:**
+- [GitHub Discussion #119](https://github.com/ALCops/Analyzers/discussions/119)
+- [MS Docs: EDMX Metadata](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/return-obtain-service-metadata-edmx-document)
+- [MS Docs: Edit in Excel](https://learn.microsoft.com/en-us/dynamics365/business-central/across-work-with-excel)
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | `PC0033` |
+| Category | Design |
+| Severity | Warning |
+| Enabled by default | true |
+| MessageFormat | `Control '{0}' has a duplicate OData EntityName '{1}'. This will cause a runtime error when using 'Edit in Excel'.` |
+| Version gate | None |
+| netstandard2.1 | Full support (no net8.0-only APIs used) |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Cop | PlatformCop (PC0033) | Platform runtime behavior (OData/EDMX transformation, Edit in Excel) |
+| Severity | Warning | Causes runtime errors in OData integrations and Edit in Excel |
+| Page types checked | Card, Document, List, ListPart, ListPlus, Worksheet | These page types support Edit in Excel / OData |
+| Page types excluded | API, RoleCenter, ConfirmationDialog, NavigatePage, etc. | API pages have separate naming rules (AL0528); others don't expose OData |
+| Object types | Page + PageExtension | PageExtensions add fields that participate in OData |
+| PageExtension reporting | Only on extension-added controls | Developer can only fix their own code, not the base page |
+| Primary keys | Included in uniqueness check | EDMX docs: PK fields are auto-added as OData properties |
+| AllowInCustomizations | Skipped for v1 | Added complexity; deferred to Phase 2 |
+| Query objects | Not checked | Query objects restrict special characters already |
+| OData name comparison | Case-insensitive | OData property names are case-insensitive per OData spec |
+| Control filtering | `ControlKind.Field` only | Only Field controls produce OData properties; Group/Area/Part are structural |
+| Registration | `RegisterSymbolAction` on Page + PageExtension | Single-pass per symbol, no compilation-wide analysis needed |
+| CodeFix | None for v1 | Auto-renaming controls is complex and could break existing integrations |
+| Skip obsolete | Yes | Standard ALCops convention |
+| OData transformation location | Static method in analyzer class | Only used by this rule; move to Common if reuse emerges |
+
+## OData/EDMX Name Transformation
+
+The EDMX specification defines how AL control names are transformed to OData property names:
+
+| Character | Transformation | Example |
+|---|---|---|
+| Space (` `) | `_` (underscore) | `"PTE No"` → `PTE_No` |
+| Dot (`.`) | Removed | `"No."` → `No` |
+| Parentheses `()` | Removed | `"Balance (LCY)"` → `Balance_LCY` |
+| Slash (`/`) | `_` (underscore) | `"Country/Region"` → `Country_Region` |
+| Apostrophe (`'`) | `_x0027_` | `"O'Brien"` → `O_x0027_Brien` |
+| Percent (`%`) | `Percent` | `"Tax%"` → `TaxPercent` |
+
+### SDK MetadataName vs OData (critical difference)
+
+The SDK's `MangleUnquotedIdentifierName()` (used by AL0757/AL0758) maps characters differently:
+- `.` → `a46` (not removed)
+- `(` → `a40` (not removed)
+- `/` → `a47` (not `_`)
+
+So `"PTE No."` has MetadataName `PTE_Noa46` (unique from `"PTE No"` = `PTE_No`), but OData name `PTE_No` (duplicate). This is why the compiler's checks don't catch OData-specific collisions.
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterSymbolAction` on `Page` and `PageExtension` symbol kinds.
+
+### Analysis flow
+
+**For Pages (`IPageBaseTypeSymbol`):**
+1. Skip obsolete symbols
+2. Check `PageType` against `RelevantPageTypes` set
+3. Collect field controls from `FlattenedControls` (filter to `ControlKind.Field`)
+4. Collect PK fields from `RelatedTable.PrimaryKey.Fields`
+5. Transform all names via `ToODataEntityName()`
+6. Group by OData name (case-insensitive), report all members of groups with count > 1
+
+**For PageExtensions (`IPageExtensionBaseTypeSymbol`):**
+1. Skip obsolete symbols
+2. Resolve target page via `Target.OriginalDefinition`, check `PageType`
+3. Collect extension's own controls from `AddedControlsFlattened`
+4. Collect base page controls from `FlattenedControls`
+5. Collect PK fields from target page's `RelatedTable`
+6. Combined duplicate check across all entries
+7. Only report diagnostics on extension-added controls (filter via `extensionControlSet`)
+
+### Key SDK interfaces
+
+- `IPageBaseTypeSymbol`: `PageType`, `RelatedTable`, `FlattenedControls`
+- `IPageExtensionBaseTypeSymbol`: `AddedControlsFlattened`, `Target`
+- `IControlSymbol`: `ControlKind`, `Name`, `GetLocation()`
+- `ITableTypeSymbol`: `PrimaryKey` → `IKeySymbol` → `Fields`
+
+### Data structure
+
+```
+ODataNameEntry (record struct, #if guarded):
+  - ODataName: string (transformed name)
+  - OriginalName: string (source name)
+  - Location: Location (for diagnostic reporting)
+  - Control: IControlSymbol? (null for PK entries)
+```
+
+## Known issues and workarounds
+
+### Space→underscore collisions already caught by AL0757
+
+The SDK's MetadataName transformation maps spaces to underscores, same as OData. So `"PTE No"` and `PTE_No` both have MetadataName `PTE_No`, triggering AL0757. Our rule would also flag these, but the compiler catches them first. This is not a problem (redundant warnings are acceptable), but test fixtures must avoid this pattern to prevent compilation errors.
+
+### OData name collisions not caught by compiler
+
+Our unique value is in catching collisions caused by:
+- Dot removal (`.` → removed)
+- Parenthesis removal (`()` → removed)
+- Slash to underscore (`/` → `_`)
+- Percent expansion (`%` → `Percent`)
+
+These transformations differ from the SDK's MetadataName mangling, so the compiler's AL0757/AL0758 checks miss them.
+
+## Test coverage
+
+### HasDiagnostic (7 cases)
+
+| Test case | Scenario |
+|---|---|
+| DotRemoval | `"PTE No."` and `"PTE No"` both become `PTE_No` |
+| PercentSign | `"Tax%"` and `TaxPercent` both become `TaxPercent` |
+| ParenthesisRemoval | `"Balance (LCY)"` and `Balance_LCY` both become `Balance_LCY` |
+| SlashToUnderscore | `"Country/Region"` and `Country_Region` both become `Country_Region` |
+| PageExtensionCollision | Extension control `"Item No"` collides with base page `"Item No."` |
+| PrimaryKeyCollision | Control `Primary_Key` collides with PK field `"Primary Key"` |
+| ThreeWayCollision | Three controls with dots in different positions all producing `Amt` |
+
+### NoDiagnostic (5 cases)
+
+| Test case | Suppression reason |
+|---|---|
+| UniqueNames | All controls have distinct OData names |
+| ApiPage | API page type (excluded from check) |
+| RoleCenterPage | RoleCenter page type (excluded) |
+| ObsoletePage | Page with `ObsoleteState = Pending` (skipped) |
+| PageExtensionUniqueNames | Extension controls have unique names relative to base |
+
+## Phase 2 roadmap (not yet implemented)
+
+- **AllowInCustomizations**: Check table fields with `AllowInCustomizations = Always` for potential collisions with page controls
+- **CodeFix**: Suggest renaming controls to avoid collision
+- **Query objects**: Evaluate if needed despite restricted characters
+- **Cross-extension collision**: Detect when two page extensions for the same base page collide with each other
+- **Apostrophe test case**: Add test for `'` → `_x0027_` transformation

--- a/.github/instructions/project-overview.instructions.md
+++ b/.github/instructions/project-overview.instructions.md
@@ -119,7 +119,7 @@ Each diagnostic has a help URI pointing to `https://alcops.dev/docs/analyzers/{c
 - `{copslug}` is the lowercase cop name (e.g. `lintercop`, `applicationcop`, `platformcop`)
 - `{id}` is the lowercase diagnostic ID (e.g. `lc0003`, `ac0001`)
 
-The documentation site source lives at `/Users/arthur/repo/ALCops/alcops.dev/` (Hugo-based, separate from this repo).
+The documentation site source is a sibling repo (`../alcops.dev` relative to the Analyzers repo root, or `https://github.com/ALCops/alcops.dev`). It is a Hugo-based site. Every new diagnostic rule must have a corresponding documentation page at `content/docs/analyzers/{copslug}/{ID}.md`.
 
 ## Settings system
 

--- a/src/ALCops.Common/Helpers/ODataNameHelper.cs
+++ b/src/ALCops.Common/Helpers/ODataNameHelper.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+
+namespace ALCops.Common.Helpers;
+
+/// <summary>
+/// Provides access to the SDK's OData/EDMX name transformation via reflection.
+/// The method <c>MangleIntoValidXmlIdentifier</c> lives in
+/// <c>Microsoft.Dynamics.Nav.AL.Common.NameTransformations</c>, which is loaded by
+/// the AL compiler process (referenced by <c>Microsoft.Dynamics.Nav.CodeAnalysis.dll</c>).
+/// </summary>
+public static class ODataNameHelper
+{
+    private static readonly Lazy<Func<string, string>?> _mangleIntoValidXmlIdentifier =
+        new(BuildDelegate, LazyThreadSafetyMode.PublicationOnly);
+
+    /// <summary>
+    /// Transforms an AL identifier name into its OData/EDMX entity name representation
+    /// using the SDK's <c>NameTransformations.MangleIntoValidXmlIdentifier</c> method.
+    /// Returns <c>null</c> if the SDK method is not available (e.g., older SDK versions).
+    /// </summary>
+    public static string? MangleIntoValidXmlIdentifier(string name)
+    {
+        var func = _mangleIntoValidXmlIdentifier.Value;
+        if (func is null)
+            return null;
+
+        return func(name);
+    }
+
+    /// <summary>
+    /// Indicates whether the SDK's OData name transformation is available.
+    /// </summary>
+    public static bool IsAvailable => _mangleIntoValidXmlIdentifier.Value is not null;
+
+    private static Func<string, string>? BuildDelegate()
+    {
+        var type = Type.GetType(
+            "Microsoft.Dynamics.Nav.AL.Common.NameTransformations, Microsoft.Dynamics.Nav.AL.Common",
+            throwOnError: false);
+
+        if (type is null)
+            return null;
+
+        var methodInfo = type.GetMethod(
+            "MangleIntoValidXmlIdentifier",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(string) },
+            modifiers: null);
+
+        if (methodInfo is null)
+            return null;
+
+        return (Func<string, string>)methodInfo.CreateDelegate(typeof(Func<string, string>));
+    }
+}

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -533,11 +533,26 @@ public static class EnumProvider
     {
         private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _api =
             new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.API)));
+        private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _card =
+            new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.Card)));
+        private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _document =
+            new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.Document)));
         private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _list =
             new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.List)));
+        private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _listPart =
+            new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.ListPart)));
+        private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _listPlus =
+            new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.ListPlus)));
+        private static readonly Lazy<NavCodeAnalysis.PageTypeKind> _worksheet =
+            new(() => ParseEnum<NavCodeAnalysis.PageTypeKind>(nameof(NavCodeAnalysis.PageTypeKind.Worksheet)));
 
         public static NavCodeAnalysis.PageTypeKind API => _api.Value;
+        public static NavCodeAnalysis.PageTypeKind Card => _card.Value;
+        public static NavCodeAnalysis.PageTypeKind Document => _document.Value;
         public static NavCodeAnalysis.PageTypeKind List => _list.Value;
+        public static NavCodeAnalysis.PageTypeKind ListPart => _listPart.Value;
+        public static NavCodeAnalysis.PageTypeKind ListPlus => _listPlus.Value;
+        public static NavCodeAnalysis.PageTypeKind Worksheet => _worksheet.Value;
     }
 
     /// <summary>

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
@@ -26,6 +26,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("PageExtensionCollision")]
         [TestCase("PrimaryKeyCollision")]
         [TestCase("ThreeWayCollision")]
+        [TestCase("MultiplePageExtensionCollision")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
@@ -30,7 +30,7 @@ namespace ALCops.PlatformCop.Test
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["MultiplePageExtensionCollision", "PageExtensionCollision", "PageExtensionUniqueNames"],
+                ["PageExtensionCollision", "MultiplePageExtensionCollision"],
                 testCase,
                 "13.0",
                 "No support for pageextensions when target itself is already declared in the same module");
@@ -49,6 +49,12 @@ namespace ALCops.PlatformCop.Test
         [TestCase("PageExtensionUniqueNames")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["PageExtensionUniqueNames"],
+                testCase,
+                "13.0",
+                "No support for pageextensions when target itself is already declared in the same module");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
@@ -29,6 +29,12 @@ namespace ALCops.PlatformCop.Test
         [TestCase("MultiplePageExtensionCollision")]
         public async Task HasDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["MultiplePageExtensionCollision", "PageExtensionCollision", "PageExtensionUniqueNames"],
+                testCase,
+                "13.0",
+                "No support for pageextensions when target itself is already declared in the same module");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
@@ -1,0 +1,51 @@
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test
+{
+    public class DuplicateODataEntityName : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.DuplicateODataEntityName>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(DuplicateODataEntityName)));
+        }
+
+        [Test]
+        [TestCase("DotRemoval")]
+        [TestCase("PercentSign")]
+        [TestCase("ParenthesisRemoval")]
+        [TestCase("SlashToUnderscore")]
+        [TestCase("PageExtensionCollision")]
+        [TestCase("PrimaryKeyCollision")]
+        [TestCase("ThreeWayCollision")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.DuplicateODataEntityName);
+        }
+
+        [Test]
+        [TestCase("UniqueNames")]
+        [TestCase("ApiPage")]
+        [TestCase("RoleCenterPage")]
+        [TestCase("ObsoletePage")]
+        [TestCase("PageExtensionUniqueNames")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.DuplicateODataEntityName);
+        }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/DotRemoval.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/DotRemoval.al
@@ -1,4 +1,4 @@
-// "PTE No." and "PTE No" both become "PTE_No" after dot removal
+// "PTE No." and "PTE No" both become "PTE_No" after OData transformation (dot and space become _, trailing _ trimmed)
 page 50100 MyPage
 {
     PageType = List;

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/DotRemoval.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/DotRemoval.al
@@ -1,0 +1,33 @@
+// "PTE No." and "PTE No" both become "PTE_No" after dot removal
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("PTE No."; Rec.MyField) { }|]
+                [|field("PTE No"; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/MultiplePageExtensionCollision.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/MultiplePageExtensionCollision.al
@@ -1,0 +1,47 @@
+// Two page extensions adding controls that collide after OData transformation
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content) { }
+    }
+}
+
+pageextension 50100 MyExtension extends MyPage
+{
+    layout
+    {
+        addlast(Content)
+        {
+            [|field("PTE No"; Rec.MyField) { ApplicationArea = All; }|]
+        }
+    }
+}
+
+pageextension 50101 MyExtension2 extends MyPage
+{
+    layout
+    {
+        addlast(Content)
+        {
+            [|field("PTE No."; Rec.MyField) { ApplicationArea = All; }|]
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PageExtensionCollision.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PageExtensionCollision.al
@@ -1,0 +1,43 @@
+// Extension adds a control that collides with the base page control
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field("Item No."; Rec.MyField) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+pageextension 50100 MyPageExt extends MyPage
+{
+    layout
+    {
+        addlast(Lines)
+        {
+            [|field("Item No"; Rec.MyField2) { }|]
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ParenthesisRemoval.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ParenthesisRemoval.al
@@ -1,0 +1,33 @@
+// "Balance (LCY)" and "Balance_LCY" both become "Balance_LCY"
+page 50100 MyPage
+{
+    PageType = Document;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                [|field("Balance (LCY)"; Rec.MyField) { }|]
+                [|field(Balance_LCY; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ParenthesisRemoval.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ParenthesisRemoval.al
@@ -1,4 +1,5 @@
-// "Balance (LCY)" and "Balance_LCY" both become "Balance_LCY"
+// "Balance (LCY)" becomes "Balance_LCY" (space, parens → _, consecutive _ deduped, trailing _ trimmed)
+// "Balance_LCY" stays "Balance_LCY" — both collide
 page 50100 MyPage
 {
     PageType = Document;

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PercentSign.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PercentSign.al
@@ -1,0 +1,33 @@
+// "Tax%" becomes "TaxPercent" after percent transformation, colliding with "TaxPercent"
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("Tax%"; Rec.MyField) { }|]
+                [|field(TaxPercent; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PercentSign.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PercentSign.al
@@ -1,4 +1,4 @@
-// "Tax%" becomes "TaxPercent" after percent transformation, colliding with "TaxPercent"
+// "Tax%" becomes "TaxPercent" after OData transformation, colliding with "TaxPercent"
 page 50100 MyPage
 {
     PageType = List;

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PrimaryKeyCollision.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/PrimaryKeyCollision.al
@@ -1,0 +1,31 @@
+// Control "Primary_Key" collides with the auto-included PK field "Primary Key" (both become "Primary_Key")
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field(Primary_Key; Rec.MyField) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/SlashToUnderscore.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/SlashToUnderscore.al
@@ -1,0 +1,33 @@
+// "Country/Region" and "Country_Region" both become "Country_Region"
+page 50100 MyPage
+{
+    PageType = Worksheet;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("Country/Region"; Rec.MyField) { }|]
+                [|field(Country_Region; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ThreeWayCollision.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ThreeWayCollision.al
@@ -1,0 +1,35 @@
+// "A.mt", "Am.t", and "Amt." all become "Amt" after dot removal
+page 50100 MyPage
+{
+    PageType = Card;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                [|field("A.mt"; Rec.MyField) { }|]
+                [|field("Am.t"; Rec.MyField2) { }|]
+                [|field("Amt."; Rec.MyField3) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+        field(4; MyField3; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ThreeWayCollision.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/HasDiagnostic/ThreeWayCollision.al
@@ -1,4 +1,4 @@
-// "A.mt", "Am.t", and "Amt." all become "Amt" after dot removal
+// "A B", "A.B", and "A-B" all become "A_B" after OData transformation (space, dot, hyphen → _)
 page 50100 MyPage
 {
     PageType = Card;
@@ -10,9 +10,9 @@ page 50100 MyPage
         {
             group(General)
             {
-                [|field("A.mt"; Rec.MyField) { }|]
-                [|field("Am.t"; Rec.MyField2) { }|]
-                [|field("Amt."; Rec.MyField3) { }|]
+                [|field("A B"; Rec.MyField) { }|]
+                [|field("A.B"; Rec.MyField2) { }|]
+                [|field("A-B"; Rec.MyField3) { }|]
             }
         }
     }

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/ApiPage.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/ApiPage.al
@@ -1,0 +1,39 @@
+// API pages are excluded from this check
+page 50100 MyApiPage
+{
+    PageType = API;
+    SourceTable = MyTable;
+    DelayedInsert = true;
+    APIGroup = 'myGroup';
+    APIPublisher = 'myPublisher';
+    APIVersion = 'v1.0';
+    EntityName = 'myEntity';
+    EntitySetName = 'myEntities';
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field(myField; Rec.MyField) { }|]
+                [|field(myField2; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/ObsoletePage.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/ObsoletePage.al
@@ -1,0 +1,35 @@
+// Obsolete pages are skipped
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Use MyNewPage instead.';
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("PTE No."; Rec.MyField) { }|]
+                [|field("PTE No"; Rec.MyField2) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/PageExtensionUniqueNames.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/PageExtensionUniqueNames.al
@@ -1,0 +1,43 @@
+// Extension controls have unique OData names relative to base page
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field("Item No."; Rec.MyField) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+pageextension 50100 MyPageExt extends MyPage
+{
+    layout
+    {
+        addlast(Lines)
+        {
+            [|field("Item Description"; Rec.MyField2) { }|]
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/RoleCenterPage.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/RoleCenterPage.al
@@ -1,0 +1,45 @@
+// RoleCenter pages are excluded from this check
+page 50100 MyRoleCenter
+{
+    PageType = RoleCenter;
+
+    layout
+    {
+        area(RoleCenter)
+        {
+            [|part("PTE No."; MyListPart) { }|]
+            [|part("PTE No"; MyListPart) { }|]
+        }
+    }
+}
+
+page 50101 MyListPart
+{
+    PageType = ListPart;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field(MyField; Rec.MyField) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/UniqueNames.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/UniqueNames.al
@@ -1,0 +1,35 @@
+// All controls have unique OData names
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("Customer No."; Rec.MyField) { }|]
+                [|field("Customer Name"; Rec.MyField2) { }|]
+                [|field(Amount; Rec.MyField3) { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Integer) { }
+        field(2; MyField; Integer) { }
+        field(3; MyField2; Integer) { }
+        field(4; MyField3; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -444,4 +444,13 @@
   <data name="ReportLayoutPropertyLengthDescription" xml:space="preserve">
     <value>The Caption and Summary properties on report layout blocks are stored in database fields limited to 250 characters. Values exceeding this limit compile without error but cause a runtime crash ("The length of the string is N, but it must be less than or equal to 250 characters") when a user opens the Report Layout Selection page in Business Central.</value>
   </data>
+  <data name="DuplicateODataEntityNameTitle" xml:space="preserve">
+    <value>Duplicate OData EntityName on page controls</value>
+  </data>
+  <data name="DuplicateODataEntityNameMessageFormat" xml:space="preserve">
+    <value>Control '{0}' has a duplicate OData EntityName '{1}'. This will cause a runtime error when using 'Edit in Excel'.</value>
+  </data>
+  <data name="DuplicateODataEntityNameDescription" xml:space="preserve">
+    <value>Page controls are exposed as OData properties with transformed names (dots removed, spaces replaced by underscores, parentheses removed, slashes replaced by underscores, apostrophes replaced by _x0027_, percent signs replaced by Percent). When two or more controls produce the same OData EntityName after transformation, 'Edit in Excel' and other OData integrations fail at runtime. Primary key fields are automatically included in the OData metadata even if not on the page, so control names must also be unique relative to primary key field names.</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
@@ -20,6 +21,20 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         EnumProvider.PageTypeKind.ListPlus,
         EnumProvider.PageTypeKind.Worksheet
     ];
+
+    private static ImmutableArray<IPageExtensionBaseTypeSymbol> GetCachedPageExtensions(Compilation compilation)
+        => PageExtensionsCache.GetValue(compilation, static c => new PageExtensionsCacheEntry(c)).Value.Value;
+    private static readonly ConditionalWeakTable<Compilation, PageExtensionsCacheEntry> PageExtensionsCache = new();
+    private sealed class PageExtensionsCacheEntry(Compilation compilation)
+    {
+        public Lazy<ImmutableArray<IPageExtensionBaseTypeSymbol>> Value { get; } =
+            new Lazy<ImmutableArray<IPageExtensionBaseTypeSymbol>>(
+                () => compilation
+                    .GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection(EnumProvider.SymbolKind.PageExtension)
+                    .OfType<IPageExtensionBaseTypeSymbol>()
+                    .ToImmutableArray(),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+    }
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(DiagnosticDescriptors.DuplicateODataEntityName);
@@ -74,16 +89,68 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         var baseControls = CollectFieldControlEntries(targetPage.FlattenedControls);
         var pkEntries = CollectPrimaryKeyEntries(targetPage.RelatedTable);
 
-        var allEntries = new List<ODataNameEntry>(extensionControls.Count + baseControls.Count + pkEntries.Count);
+        // Collect controls from sibling page extensions targeting the same base page
+        var siblingControls = CollectSiblingExtensionControls(ctx, pageExtension, targetPage);
+
+        var allEntries = new List<ODataNameEntry>(
+            extensionControls.Count + baseControls.Count + pkEntries.Count + siblingControls.Count);
         allEntries.AddRange(extensionControls);
         allEntries.AddRange(baseControls);
         allEntries.AddRange(pkEntries);
+        allEntries.AddRange(siblingControls);
 
         // Only report diagnostics on the extension's own controls
         var extensionControlSet = new HashSet<IControlSymbol>(
             extensionControls.Where(e => e.Control is not null).Select(e => e.Control!));
 
         ReportDuplicates(ctx, allEntries, reportableFilter: entry => entry.Control is not null && extensionControlSet.Contains(entry.Control));
+    }
+
+    private static List<ODataNameEntry> CollectSiblingExtensionControls(
+        SymbolAnalysisContext ctx,
+        IPageExtensionBaseTypeSymbol currentExtension,
+        IPageBaseTypeSymbol targetPage)
+    {
+        var allPageExtensions = GetCachedPageExtensions(ctx.Compilation);
+        var entries = new List<ODataNameEntry>();
+
+        foreach (var ext in allPageExtensions)
+        {
+            if (ReferenceEquals(ext, currentExtension))
+                continue;
+
+            if (!SameApplicationObject(ext.Target?.OriginalDefinition, targetPage))
+                continue;
+
+            foreach (var control in ext.AddedControlsFlattened)
+            {
+                if (control.ControlKind != EnumProvider.ControlKind.Field)
+                    continue;
+
+                var odataName = ToODataEntityName(control.Name);
+                // Use null Control so sibling controls are not reportable
+                entries.Add(new ODataNameEntry(odataName, control.Name, control.GetLocation(), null));
+            }
+        }
+
+        return entries;
+    }
+
+    private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
+    {
+        if (source is null || target is null)
+            return false;
+
+        source = source.OriginalDefinition;
+        target = target.OriginalDefinition;
+
+        if (ReferenceEquals(source, target))
+            return true;
+
+        if (source is ISymbolWithId lId && target is ISymbolWithId rId)
+            return lId.Id == rId.Id && source.Kind == target.Kind;
+
+        return source.Equals(target);
     }
 
     private static List<ODataNameEntry> CollectFieldControlEntries(ImmutableArray<IControlSymbol> controls)

--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -1,0 +1,198 @@
+using System.Collections.Immutable;
+using System.Text;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
+{
+    private static readonly HashSet<PageTypeKind> RelevantPageTypes =
+    [
+        EnumProvider.PageTypeKind.Card,
+        EnumProvider.PageTypeKind.Document,
+        EnumProvider.PageTypeKind.List,
+        EnumProvider.PageTypeKind.ListPart,
+        EnumProvider.PageTypeKind.ListPlus,
+        EnumProvider.PageTypeKind.Worksheet
+    ];
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.DuplicateODataEntityName);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSymbolAction(
+            AnalyzeSymbol,
+            EnumProvider.SymbolKind.Page,
+            EnumProvider.SymbolKind.PageExtension);
+
+    private void AnalyzeSymbol(SymbolAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete())
+            return;
+
+        switch (ctx.Symbol)
+        {
+            case IPageBaseTypeSymbol page:
+                AnalyzePage(ctx, page);
+                break;
+            case IPageExtensionBaseTypeSymbol pageExtension:
+                AnalyzePageExtension(ctx, pageExtension);
+                break;
+        }
+    }
+
+    private static void AnalyzePage(SymbolAnalysisContext ctx, IPageBaseTypeSymbol page)
+    {
+        if (!RelevantPageTypes.Contains(page.PageType))
+            return;
+
+        var controlEntries = CollectFieldControlEntries(page.FlattenedControls);
+        var pkEntries = CollectPrimaryKeyEntries(page.RelatedTable);
+
+        var allEntries = new List<ODataNameEntry>(controlEntries.Count + pkEntries.Count);
+        allEntries.AddRange(controlEntries);
+        allEntries.AddRange(pkEntries);
+
+        ReportDuplicates(ctx, allEntries, reportableFilter: null);
+    }
+
+    private static void AnalyzePageExtension(SymbolAnalysisContext ctx, IPageExtensionBaseTypeSymbol pageExtension)
+    {
+        var targetPage = pageExtension.Target?.OriginalDefinition as IPageBaseTypeSymbol;
+        if (targetPage is null || !RelevantPageTypes.Contains(targetPage.PageType))
+            return;
+
+        var extensionControls = CollectFieldControlEntries(pageExtension.AddedControlsFlattened);
+        if (extensionControls.Count == 0)
+            return;
+
+        var baseControls = CollectFieldControlEntries(targetPage.FlattenedControls);
+        var pkEntries = CollectPrimaryKeyEntries(targetPage.RelatedTable);
+
+        var allEntries = new List<ODataNameEntry>(extensionControls.Count + baseControls.Count + pkEntries.Count);
+        allEntries.AddRange(extensionControls);
+        allEntries.AddRange(baseControls);
+        allEntries.AddRange(pkEntries);
+
+        // Only report diagnostics on the extension's own controls
+        var extensionControlSet = new HashSet<IControlSymbol>(
+            extensionControls.Where(e => e.Control is not null).Select(e => e.Control!));
+
+        ReportDuplicates(ctx, allEntries, reportableFilter: entry => entry.Control is not null && extensionControlSet.Contains(entry.Control));
+    }
+
+    private static List<ODataNameEntry> CollectFieldControlEntries(ImmutableArray<IControlSymbol> controls)
+    {
+        var entries = new List<ODataNameEntry>();
+        foreach (var control in controls)
+        {
+            if (control.ControlKind != EnumProvider.ControlKind.Field)
+                continue;
+
+            var odataName = ToODataEntityName(control.Name);
+            entries.Add(new ODataNameEntry(odataName, control.Name, control.GetLocation(), control));
+        }
+        return entries;
+    }
+
+    private static List<ODataNameEntry> CollectPrimaryKeyEntries(ITableTypeSymbol? table)
+    {
+        var entries = new List<ODataNameEntry>();
+        if (table?.PrimaryKey is null)
+            return entries;
+
+        foreach (var field in table.PrimaryKey.Fields)
+        {
+            var odataName = ToODataEntityName(field.Name);
+            entries.Add(new ODataNameEntry(odataName, field.Name, field.GetLocation(), null));
+        }
+        return entries;
+    }
+
+    private static void ReportDuplicates(
+        SymbolAnalysisContext ctx,
+        List<ODataNameEntry> entries,
+        Func<ODataNameEntry, bool>? reportableFilter)
+    {
+        var groups = entries
+            .GroupBy(e => e.ODataName, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1);
+
+        foreach (var group in groups)
+        {
+            foreach (var entry in group)
+            {
+                if (reportableFilter is not null && !reportableFilter(entry))
+                    continue;
+
+                ctx.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.DuplicateODataEntityName,
+                    entry.Location,
+                    entry.OriginalName,
+                    group.Key));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Transforms a control/field name to its OData EntityName representation
+    /// following the EDMX specification for Business Central.
+    /// </summary>
+    internal static string ToODataEntityName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return name;
+
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            switch (c)
+            {
+                case ' ':
+                case '/':
+                    sb.Append('_');
+                    break;
+                case '.':
+                case '(':
+                case ')':
+                    // Removed
+                    break;
+                case '\'':
+                    sb.Append("_x0027_");
+                    break;
+                case '%':
+                    sb.Append("Percent");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+#if NETSTANDARD2_1
+    private readonly struct ODataNameEntry
+    {
+        public string ODataName { get; }
+        public string OriginalName { get; }
+        public Location Location { get; }
+        public IControlSymbol? Control { get; }
+
+        public ODataNameEntry(string odataName, string originalName, Location location, IControlSymbol? control)
+        {
+            ODataName = odataName;
+            OriginalName = originalName;
+            Location = location;
+            Control = control;
+        }
+    }
+#else
+    private readonly record struct ODataNameEntry(string ODataName, string OriginalName, Location Location, IControlSymbol? Control);
+#endif
+}

--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -1,7 +1,7 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
-using System.Text;
 using ALCops.Common.Extensions;
+using ALCops.Common.Helpers;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
@@ -47,6 +47,9 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
 
     private void AnalyzeSymbol(SymbolAnalysisContext ctx)
     {
+        if (!ODataNameHelper.IsAvailable)
+            return;
+
         if (ctx.IsObsolete())
             return;
 
@@ -127,7 +130,10 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
                 if (control.ControlKind != EnumProvider.ControlKind.Field)
                     continue;
 
-                var odataName = ToODataEntityName(control.Name);
+                var odataName = ODataNameHelper.MangleIntoValidXmlIdentifier(control.Name);
+                if (odataName is null)
+                    continue;
+
                 // Use null Control so sibling controls are not reportable
                 entries.Add(new ODataNameEntry(odataName, control.Name, control.GetLocation(), null));
             }
@@ -161,7 +167,10 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             if (control.ControlKind != EnumProvider.ControlKind.Field)
                 continue;
 
-            var odataName = ToODataEntityName(control.Name);
+            var odataName = ODataNameHelper.MangleIntoValidXmlIdentifier(control.Name);
+            if (odataName is null)
+                continue;
+
             entries.Add(new ODataNameEntry(odataName, control.Name, control.GetLocation(), control));
         }
         return entries;
@@ -175,7 +184,10 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
 
         foreach (var field in table.PrimaryKey.Fields)
         {
-            var odataName = ToODataEntityName(field.Name);
+            var odataName = ODataNameHelper.MangleIntoValidXmlIdentifier(field.Name);
+            if (odataName is null)
+                continue;
+
             entries.Add(new ODataNameEntry(odataName, field.Name, field.GetLocation(), null));
         }
         return entries;
@@ -206,42 +218,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         }
     }
 
-    /// <summary>
-    /// Transforms a control/field name to its OData EntityName representation
-    /// following the EDMX specification for Business Central.
-    /// </summary>
-    internal static string ToODataEntityName(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-            return name;
-
-        var sb = new StringBuilder(name.Length);
-        foreach (var c in name)
-        {
-            switch (c)
-            {
-                case ' ':
-                case '/':
-                    sb.Append('_');
-                    break;
-                case '.':
-                case '(':
-                case ')':
-                    // Removed
-                    break;
-                case '\'':
-                    sb.Append("_x0027_");
-                    break;
-                case '%':
-                    sb.Append("Percent");
-                    break;
-                default:
-                    sb.Append(c);
-                    break;
-            }
-        }
-        return sb.ToString();
-    }
 
 #if NETSTANDARD2_1
     private readonly struct ODataNameEntry

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -315,6 +315,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.ReportLayoutPropertyLengthDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.ReportLayoutPropertyLength));
 
+    public static readonly DiagnosticDescriptor DuplicateODataEntityName = new(
+        id: DiagnosticIds.DuplicateODataEntityName,
+        title: PlatformCopAnalyzers.DuplicateODataEntityNameTitle,
+        messageFormat: PlatformCopAnalyzers.DuplicateODataEntityNameMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.DuplicateODataEntityNameDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.DuplicateODataEntityName));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -33,4 +33,5 @@ public static class DiagnosticIds
     public static readonly string UsePartialRecordsOnRead = "PC0030";
     public static readonly string PartialRecordsBeforeWriteOperation = "PC0031";
     public static readonly string ReportLayoutPropertyLength = "PC0032";
+    public static readonly string DuplicateODataEntityName = "PC0033";
 }


### PR DESCRIPTION
## Summary

Adds **PC0033** (`DuplicateODataEntityName`) to PlatformCop. Detects page controls that produce duplicate OData EntityNames after the EDMX name transformation, causing runtime errors in "Edit in Excel" and OData integrations.

Closes #119

## What it does

The BC platform transforms control names for OData/EDMX (e.g., `"PTE No."` → `PTE_No`, `"PTE No"` → `PTE_No`). When two controls on the same page produce the same transformed name, "Edit in Excel" fails at runtime. The AL compiler has similar checks (AL0757/AL0758), but those use a different transformation (`MangleUnquotedIdentifierName` where `.` → `a46`), so they miss OData-specific collisions.

## Design

- **OData transformation**: Uses the SDK's authoritative `MangleIntoValidXmlIdentifier()` method from `Microsoft.Dynamics.Nav.AL.Common` via reflection (`ODataNameHelper` in `ALCops.Common`). Gracefully exits if unavailable (older SDKs).
- **Page types**: Card, Document, List, ListPart, ListPlus, Worksheet
- **Scope**: Page controls + primary key fields + page extension controls (including sibling extensions)
- **Sibling extensions**: `ConditionalWeakTable<Compilation, Lazy<...>>` cache pattern (same as `TransferFieldsSchemaCompatibility`)
- **Severity**: Warning
- **CodeFix**: None (v1)

## New files

- `src/ALCops.Common/Helpers/ODataNameHelper.cs` — Reflection accessor for SDK method
- `src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs` — Analyzer
- `src/ALCops.PlatformCop/DiagnosticIds.cs` / `DiagnosticDescriptors.cs` / `.resx` — Rule definition
- `.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md` — Rule docs
- 13 test cases (8 HasDiagnostic + 5 NoDiagnostic)

## Test coverage

| Category | Cases |
|---|---|
| DotRemoval | `"PTE No."` vs `"PTE No"` → both `PTE_No` |
| ParenthesisRemoval | `"Balance (LCY)"` vs `Balance_LCY` |
| PercentSign | `"Tax%"` vs `TaxPercent` |
| SlashToUnderscore | `"Country/Region"` vs `Country_Region` |
| PrimaryKeyCollision | Control vs auto-included PK field |
| ThreeWayCollision | Space, dot, hyphen all → `_` |
| PageExtensionCollision | Extension vs base page control |
| MultiplePageExtensionCollision | Two extensions targeting same base |
| NoDiagnostic | UniqueNames, ApiPage, RoleCenter, Obsolete, UniqueExtension |