### PR TITLE
fix: resolve multi-target build race condition in ResX code generation

### DIFF
--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.ApplicationCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.ApplicationCopAnalyzers.resx">
             <LogicalName>ALCops.ApplicationCop.ApplicationCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.ApplicationCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.ApplicationCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>ApplicationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
+++ b/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.DocumentationCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.DocumentationCopAnalyzers.resx">
             <LogicalName>ALCops.DocumentationCop.DocumentationCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.DocumentationCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.DocumentationCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>DocumentationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.FormattingCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.FormattingCopAnalyzers.resx">
             <LogicalName>ALCops.FormattingCop.FormattingCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.FormattingCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.FormattingCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>FormattingCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/ALCops.LinterCop/ALCops.LinterCop.csproj
+++ b/src/ALCops.LinterCop/ALCops.LinterCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.LinterCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.LinterCopAnalyzers.resx">
             <LogicalName>ALCops.LinterCop.LinterCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.LinterCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.LinterCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>LinterCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.PlatformCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.PlatformCopAnalyzers.resx">
             <LogicalName>ALCops.PlatformCop.PlatformCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.PlatformCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.PlatformCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>PlatformCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
+++ b/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
@@ -14,13 +14,12 @@
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Remove="ALCops.TestAutomationCopAnalyzers.cs" />
         <EmbeddedResource Update="ALCops.TestAutomationCopAnalyzers.resx">
             <LogicalName>ALCops.TestAutomationCop.TestAutomationCopAnalyzers.resources</LogicalName>
             <Generator>MSBuild:Compile</Generator>
             <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
             <StronglyTypedNamespace>ALCops.TestAutomationCop</StronglyTypedNamespace>
-            <StronglyTypedFileName>ALCops.TestAutomationCopAnalyzers.cs</StronglyTypedFileName>
+            <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>TestAutomationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
     </ItemGroup>


### PR DESCRIPTION
## Problem

The [build-and-release run #106](https://github.com/ALCops/Analyzers/actions/runs/24931665247/job/73010542087) failed with `CS1010: Newline in constant` in `ALCops.ApplicationCopAnalyzers.cs` on the `net8.0` target. The `netstandard2.1` and `net10.0` targets succeeded.

## Root cause

Race condition in multi-target builds. All 6 cop projects set `StronglyTypedFileName` to a project-relative path, so the `GenerateResource` MSBuild task writes the auto-generated `.cs` file to the same location for all target frameworks. When MSBuild parallelizes inner builds, one TFM's write corrupts another TFM's read.

The PR CI (#221) didn't catch this because the race is timing-dependent and manifested differently on the release runner.

## Fix

Prefix `StronglyTypedFileName` with `$(IntermediateOutputPath)` in all 6 cop `.csproj` files:

```diff
- <StronglyTypedFileName>ALCops.{Cop}Analyzers.cs</StronglyTypedFileName>
+ <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.{Cop}Analyzers.cs</StronglyTypedFileName>
```

Each TFM now writes to its own `obj/{Configuration}/{TFM}/` directory, eliminating the shared write entirely.

## Verification

- CI-mode multi-target build passes all 7 projects (Common + 6 cops)
- Local non-CI build (net10.0 only) succeeds
- All 914 tests pass