### PR TITLE
feat: centralize record method classification and fix missing GetBySystemId

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -80,6 +80,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `codefix-development` | `'src/ALCops.*/CodeFixes/**'` | How to write code fixes |
 | `testing` | `'src/*.Test/**'` | Test conventions and patterns |
 | `common-library` | `'src/ALCops.Common/**'` | Shared library guidelines |
+| `record-method-classification` | `'src/ALCops.Common/RecordMethodClassification.cs'` | Record method categorization utility |
 | `netstandard21-compatibility` | `'src/ALCops.*/**'` | netstandard2.1 compat patterns |
 | `settings-schema` | `ALCopsSettings.cs` | Settings file schema |
 | `cicd` | `'.github/**'` | CI/CD workflows |

--- a/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
@@ -143,8 +143,14 @@ This is an SDK bug. If a future SDK version fixes it, the type checks become har
 
 ## Method classification
 
+Method classifications are centralized in `ALCops.Common.RecordMethodClassification`. This analyzer uses:
+- `RecordMethodClassification.SingleRecordReadMethods` + `FindSet` for read methods (trigger diagnostic)
+- `RecordMethodClassification.WriteMethods` for write/mutation methods (suppress entire variable)
+- `RecordMethodClassification.LoadFieldsMethods` for load fields methods (suppress diagnostic)
+- `RecordMethodClassification.JitLoadWriteMethods` for JIT load write methods (used by PC0031)
+
 ### Read methods (trigger diagnostic)
-`Get`, `Find`, `FindFirst`, `FindLast`, `FindSet`
+`Get`, `GetBySystemId`, `Find`, `FindFirst`, `FindLast`, `FindSet`
 
 ### Load fields methods (suppress diagnostic)
 `SetLoadFields`, `AddLoadFields`, `SetBaseLoadFields`
@@ -172,11 +178,11 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 
 ## Test coverage
 
-52 test cases total:
+55 test cases total:
 
-**HasDiagnostic (16 cases):** LocalRecordGet, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, LoopNoSetLoadFields.
+**HasDiagnostic (17 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, LoopNoSetLoadFields.
 
-**NoDiagnostic (25 cases):** HasSetLoadFields, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore.
+**NoDiagnostic (26 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore.
 
 **HasFix (11 cases):** SingleField, MultipleFields, QuotedFieldName, NoFieldAccess, SetRangeFieldExcluded, SetFilterFieldExcluded, SetRangeValueArgIncluded, AllFieldsInFilters, TestFieldIncluded, SetCurrentKeyExcluded, MixedFilterAndConsume.
 

--- a/.github/instructions/record-method-classification.instructions.md
+++ b/.github/instructions/record-method-classification.instructions.md
@@ -1,0 +1,59 @@
+---
+applyTo: 'src/ALCops.Common/RecordMethodClassification.cs'
+---
+
+# RecordMethodClassification: Centralized Record Method Categories
+
+## Purpose
+
+Single source of truth for classifying AL built-in record methods by behavioral category. Eliminates duplicated method lists across analyzer projects and ensures consistent coverage when new record methods are added (e.g., `GetBySystemId`).
+
+Builds on `ALCops.Common.Permissions.MethodOperationMap` which handles RIMD permission-level classification. This class extends beyond permissions to cover partial records, triggers, and other analyzer concerns.
+
+## Categories
+
+All properties are `ImmutableHashSet<string>` with `StringComparer.OrdinalIgnoreCase`.
+
+| Property | Methods | Used by |
+|---|---|---|
+| `ReadMethods` | Find, FindFirst, FindLast, FindSet, Get, GetBySystemId, IsEmpty, Count | General read classification |
+| `SingleRecordReadMethods` | Find, FindFirst, FindLast, Get, GetBySystemId | AC0030 (return value check) |
+| `InsertMethods` | Insert | General insert classification |
+| `ModifyMethods` | Modify, ModifyAll, Rename | General modify classification |
+| `DeleteMethods` | Delete, DeleteAll | General delete classification |
+| `WriteMethods` | Insert, Modify, ModifyAll, Delete, DeleteAll, Rename, TransferFields, Init, Copy | PC0030/PC0031 (partial records) |
+| `LoadFieldsMethods` | SetLoadFields, AddLoadFields, SetBaseLoadFields | PC0030/PC0031 (partial records) |
+| `JitLoadWriteMethods` | Insert, Modify, Delete, Rename, TransferFields, Copy | PC0031 (JIT load detection) |
+| `TriggerMethods` | Insert, Modify, Delete, DeleteAll, Validate, ModifyAll | PC0028 (temp record triggers) |
+| `RunTriggerParameterMethods` | Insert, Modify, ModifyAll, Delete, DeleteAll | LC0047 (explicit RunTrigger) |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Location | `ALCops.Common` root namespace | Cross-cutting concern, not specific to Permissions |
+| Relationship to MethodOperationMap | Complementary, not replacing | MethodOperationMap handles RIMD permission chars; this handles behavioral categories |
+| WriteMethods includes non-RIMD methods | Yes (TransferFields, Init, Copy) | These mutate the record buffer even though they don't require RIMD permissions |
+| SingleRecordReadMethods excludes FindSet | Yes | FindSet is used with repeat..until Next loops; different return value semantics |
+| ReadMethods includes IsEmpty and Count | Yes | These perform SQL reads even though they don't load record buffers |
+| Case sensitivity | OrdinalIgnoreCase | AL method names are case-insensitive |
+
+## Adding new methods
+
+When Microsoft adds a new record built-in method:
+
+1. Determine its behavioral category (read, write, trigger, etc.)
+2. Add it to the appropriate set(s) in `RecordMethodClassification.cs`
+3. If it requires RIMD permissions, also add it to `MethodOperationMap.cs`
+4. Run all tests to verify no regressions
+5. Check if any analyzer needs specific handling beyond the set membership
+
+## Consumers
+
+| Analyzer | Properties used |
+|---|---|
+| `PartialRecordOperations` (PC0030/PC0031) | `SingleRecordReadMethods` + FindSet, `WriteMethods`, `LoadFieldsMethods`, `JitLoadWriteMethods` |
+| `UseReturnValueForDatabaseReadMethods` (AC0030) | `SingleRecordReadMethods` |
+| `ExplicitlySetRunTrigger` (LC0047) | `RunTriggerParameterMethods` |
+| `TemporaryRecordTriggerInvocation` (PC0028) | `TriggerMethods` |
+| `TableDataAccessRequiresPermissions` (AC0027) | Uses `MethodOperationMap` directly (not this class) |

--- a/src/ALCops.ApplicationCop/Analyzers/UseReturnValueForDatabaseReadMethods.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/UseReturnValueForDatabaseReadMethods.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ALCops.Common;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -16,13 +17,7 @@ public class UseReturnValueForDatabaseReadMethods : DiagnosticAnalyzer
             DiagnosticDescriptors.UseReturnValueForDatabaseReadMethods);
 
     private static readonly ImmutableHashSet<string> DatabaseReadMethods =
-        ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
-            "Find",
-            "FindFirst",
-            "FindLast",
-            "Get",
-            "GetBySystemId");
+        RecordMethodClassification.SingleRecordReadMethods;
 
     public override void Initialize(AnalysisContext context) =>
         context.RegisterOperationAction(

--- a/src/ALCops.Common/RecordMethodClassification.cs
+++ b/src/ALCops.Common/RecordMethodClassification.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using ALCops.Common.Permissions;
+
+namespace ALCops.Common;
+
+/// <summary>
+/// Centralized classification of AL built-in record methods by their behavioral category.
+/// Builds on <see cref="MethodOperationMap"/> (RIMD permission mapping) and adds categories
+/// for partial records, triggers, and other non-permission concerns.
+/// </summary>
+public static class RecordMethodClassification
+{
+    /// <summary>
+    /// Methods that read record data from the database.
+    /// Includes Find, FindFirst, FindLast, FindSet, Get, GetBySystemId, IsEmpty, Count.
+    /// Derived from <see cref="MethodOperationMap"/> where operation == <see cref="DatabaseOperation.Read"/>.
+    /// </summary>
+    public static ImmutableHashSet<string> ReadMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Find", "FindFirst", "FindLast", "FindSet",
+            "Get", "GetBySystemId",
+            "IsEmpty", "Count");
+
+    /// <summary>
+    /// Subset of <see cref="ReadMethods"/> that load a single record buffer.
+    /// Excludes FindSet (used with repeat..until Next loops) and aggregate reads (IsEmpty, Count).
+    /// </summary>
+    public static ImmutableHashSet<string> SingleRecordReadMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Find", "FindFirst", "FindLast",
+            "Get", "GetBySystemId");
+
+    /// <summary>
+    /// Methods that insert records into the database.
+    /// </summary>
+    public static ImmutableHashSet<string> InsertMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Insert");
+
+    /// <summary>
+    /// Methods that modify existing records in the database.
+    /// </summary>
+    public static ImmutableHashSet<string> ModifyMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Modify", "ModifyAll", "Rename");
+
+    /// <summary>
+    /// Methods that delete records from the database.
+    /// </summary>
+    public static ImmutableHashSet<string> DeleteMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Delete", "DeleteAll");
+
+    /// <summary>
+    /// All methods that mutate record data, including non-permission operations
+    /// like TransferFields, Init, and Copy that affect the record buffer.
+    /// </summary>
+    public static ImmutableHashSet<string> WriteMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll",
+            "Rename", "TransferFields", "Init", "Copy");
+
+    /// <summary>
+    /// Methods that configure partial record loading (SetLoadFields, AddLoadFields, SetBaseLoadFields).
+    /// </summary>
+    public static ImmutableHashSet<string> LoadFieldsMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "SetLoadFields", "AddLoadFields", "SetBaseLoadFields");
+
+    /// <summary>
+    /// Subset of write methods that trigger JIT field loads when partial records are active.
+    /// Excludes ModifyAll (set-based, no record load), DeleteAll (same), Init (no SQL).
+    /// </summary>
+    public static ImmutableHashSet<string> JitLoadWriteMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Insert", "Modify", "Delete", "Rename", "TransferFields", "Copy");
+
+    /// <summary>
+    /// Methods that can execute table triggers or field validation.
+    /// </summary>
+    public static ImmutableHashSet<string> TriggerMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Insert", "Modify", "Delete", "DeleteAll", "Validate", "ModifyAll");
+
+    /// <summary>
+    /// Methods that accept a RunTrigger boolean parameter.
+    /// </summary>
+    public static ImmutableHashSet<string> RunTriggerParameterMethods { get; } =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll");
+}

--- a/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
+++ b/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ALCops.Common;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -14,14 +15,7 @@ public sealed class ExplicitlySetRunTrigger : DiagnosticAnalyzer
 {
     private const string RunTriggerParameterName = "RunTrigger";
     private static readonly ImmutableHashSet<string> BuiltInMethodNames =
-        ImmutableHashSet.Create(
-            StringComparer.Ordinal,
-            "Insert",
-            "Modify",
-            "ModifyAll",
-            "Delete",
-            "DeleteAll"
-        );
+        RecordMethodClassification.RunTriggerParameterMethods;
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(

--- a/src/ALCops.PlatformCop.Test/Rules/PartialRecordsBeforeWriteOperation/HasDiagnostic/SetLoadFieldsThenGetBySystemIdThenModify.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PartialRecordsBeforeWriteOperation/HasDiagnostic/SetLoadFieldsThenGetBySystemIdThenModify.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.SetLoadFields(MyTable."No.")|];
+        MyTable.GetBySystemId('00000000-0000-0000-0000-000000000001');
+        MyTable.Description := 'Updated';
+        MyTable.Modify();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PartialRecordsBeforeWriteOperation/PartialRecordsBeforeWriteOperation.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/PartialRecordsBeforeWriteOperation/PartialRecordsBeforeWriteOperation.cs
@@ -30,6 +30,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("SetBaseLoadFieldsThenModify")]
         [TestCase("BranchWithWrite")]
         [TestCase("QualifiedSetLoadFields")]
+        [TestCase("SetLoadFieldsThenGetBySystemIdThenModify")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGetBySystemId.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGetBySystemId.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.GetBySystemId('00000000-0000-0000-0000-000000000001')|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetLoadFieldsGetBySystemId.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/HasSetLoadFieldsGetBySystemId.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetLoadFields(MyTable.MyField);
+        [|MyTable.GetBySystemId('00000000-0000-0000-0000-000000000001')|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -22,6 +22,7 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("LocalRecordGet")]
+        [TestCase("LocalRecordGetBySystemId")]
         [TestCase("LocalRecordFindFirst")]
         [TestCase("LocalRecordFindSet")]
         [TestCase("LocalRecordFindLast")]
@@ -47,6 +48,7 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("HasSetLoadFields")]
+        [TestCase("HasSetLoadFieldsGetBySystemId")]
         [TestCase("HasAddLoadFields")]
         [TestCase("HasSetBaseLoadFields")]
         [TestCase("HasModify")]

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ALCops.Common;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -12,30 +13,18 @@ namespace ALCops.PlatformCop.Analyzers;
 [DiagnosticAnalyzer]
 public sealed class PartialRecordOperations : DiagnosticAnalyzer
 {
-    private static readonly HashSet<string> ReadMethods = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Get", "Find", "FindFirst", "FindLast", "FindSet"
-    };
+    private static readonly ImmutableHashSet<string> ReadMethods = RecordMethodClassification.SingleRecordReadMethods
+        .Union(ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "FindSet"));
 
-    private static readonly HashSet<string> LoadFieldsMethods = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "SetLoadFields", "AddLoadFields", "SetBaseLoadFields"
-    };
+    private static readonly ImmutableHashSet<string> LoadFieldsMethods = RecordMethodClassification.LoadFieldsMethods;
 
-    private static readonly HashSet<string> WriteMethods = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll",
-        "Rename", "TransferFields", "Init", "Copy"
-    };
+    private static readonly ImmutableHashSet<string> WriteMethods = RecordMethodClassification.WriteMethods;
 
     /// <summary>
     /// Subset of WriteMethods that trigger JIT loads when partial records are active.
     /// Excludes ModifyAll (set-based, no record load), DeleteAll (same), Init (no SQL).
     /// </summary>
-    private static readonly HashSet<string> JitLoadWriteMethods = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Insert", "Modify", "Delete", "Rename", "TransferFields", "Copy"
-    };
+    private static readonly ImmutableHashSet<string> JitLoadWriteMethods = RecordMethodClassification.JitLoadWriteMethods;
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(

--- a/src/ALCops.PlatformCop/Analyzers/TemporaryRecordTriggerInvocation.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TemporaryRecordTriggerInvocation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
+using ALCops.Common;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -10,9 +11,7 @@ namespace ALCops.PlatformCop.Analyzers;
 public sealed class TemporaryRecordTriggerInvocation : DiagnosticAnalyzer
 {
     private static readonly ImmutableHashSet<string> MethodsThatMayRunTriggers =
-        ImmutableHashSet.Create(
-            StringComparer.Ordinal,
-            "Insert", "Modify", "Delete", "DeleteAll", "Validate", "ModifyAll");
+        RecordMethodClassification.TriggerMethods;
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(
             DiagnosticDescriptors.TemporaryRecordTriggerInvocation);


### PR DESCRIPTION
## Summary

Create `RecordMethodClassification` in `ALCops.Common` as single source of truth for categorizing AL built-in record methods. Replaces duplicated method lists across 4 analyzers and fixes `GetBySystemId` missing from `PartialRecordOperations` (PC0030/PC0031).

## Bug fix

`Record.GetBySystemId` was missing from `PartialRecordOperations` ReadMethods. Records fetched via `GetBySystemId` without `SetLoadFields` now correctly trigger PC0030. The method was also missing from PC0031 partial read tracking, meaning `SetLoadFields` followed by `GetBySystemId` followed by a write would not warn about JIT loads.

Reference: https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/record/record-getbysystemid-method

## New shared utility

`RecordMethodClassification.cs` provides 10 categorized `ImmutableHashSet<string>` properties:

| Property | Methods |
|---|---|
| `ReadMethods` | Find, FindFirst, FindLast, FindSet, Get, GetBySystemId, IsEmpty, Count |
| `SingleRecordReadMethods` | Find, FindFirst, FindLast, Get, GetBySystemId |
| `InsertMethods` | Insert |
| `ModifyMethods` | Modify, ModifyAll, Rename |
| `DeleteMethods` | Delete, DeleteAll |
| `WriteMethods` | Insert, Modify, ModifyAll, Delete, DeleteAll, Rename, TransferFields, Init, Copy |
| `LoadFieldsMethods` | SetLoadFields, AddLoadFields, SetBaseLoadFields |
| `JitLoadWriteMethods` | Insert, Modify, Delete, Rename, TransferFields, Copy |
| `TriggerMethods` | Insert, Modify, Delete, DeleteAll, Validate, ModifyAll |
| `RunTriggerParameterMethods` | Insert, Modify, ModifyAll, Delete, DeleteAll |

Builds on the existing `MethodOperationMap` from `ALCops.Common.Permissions` (used by AC0027).

## Refactored analyzers

| Analyzer | Change |
|---|---|
| `PartialRecordOperations` (PC0030/PC0031) | Bug fix + replaced 4 local sets |
| `UseReturnValueForDatabaseReadMethods` (AC0030) | Replaced local `DatabaseReadMethods` |
| `ExplicitlySetRunTrigger` (LC0047) | Replaced local `BuiltInMethodNames` |
| `TemporaryRecordTriggerInvocation` (PC0028) | Replaced local `MethodsThatMayRunTriggers` |

**No changes to AC0027** (already uses `MethodOperationMap`).

## Behavioral note

`ExplicitlySetRunTrigger` (LC0047) and `TemporaryRecordTriggerInvocation` (PC0028) previously used `StringComparer.Ordinal` (case-sensitive matching). The shared utility uses `OrdinalIgnoreCase`, which is correct for AL method names. The SDK returns canonical casing so this has no practical impact, but is more robust.

## Tests

917 tests pass. 3 new test fixtures added:
- `LocalRecordGetBySystemId` (PC0030 HasDiagnostic)
- `HasSetLoadFieldsGetBySystemId` (PC0030 NoDiagnostic)
- `SetLoadFieldsThenGetBySystemIdThenModify` (PC0031 HasDiagnostic)
