### PR TITLE
feat: add AC0032 unused permissions, FC0004 permission ordering, and refactor permission detection

### DIFF
--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -111,12 +111,14 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
 | `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
+| Custom `PermissionsFixAllProvider` replaces `BatchFixer` (net8.0+) | BatchFixer applies fixes sequentially, causing uppercase normalization and phantom entries when multiple diagnostics modify the same Permissions node. Custom provider collects all diagnostics and applies a single tree transformation. |
+| `insertIndex == 0` gets special trivia handling in multi-line lists | First entry sits on the `Permissions = ` line with no leading indentation; displaced entries need indentation added |
 
 ## Test coverage
 
 **HasDiagnostic (8 cases):** ProcedureCalls, ProcedureCallsExtended, GetBySystemId, Count, ImplicitSelfCallInTable, XmlPorts, Queries, Reports.
 **NoDiagnostic (21 cases):** ProcedureCallsPermissionsProperty, ProcedureCallsPermissionsPropertyFullyQualified, ProcedureCallsInherentPermissionsProperty, ProcedureCallsInherentPermissionsAttribute, PageSourceTable, PageExtensionSourceTable, XmlPortPermissionsProperty, XmlPortInherentPermissions, QueryPermissionsProperty, QueryInherentPermissions, ReportPermissionsProperty, ReportInherentPermissions, XMLPortWithTableElementProps, PermissionsAsObjectId, PermissionPropertyWithPragma, PermissionPropertyWithComment, MultiplePermissionsDifferentType, TestPermissionsDisabled, GetBySystemIdWithPermissions, CountWithPermissions, ImplicitSelfCallWithInherentPermissions.
-**HasFix (8 cases):** AddNewPermissionsProperty, AddNewTableEntry, MergePermissionChar, MergeCanonicalOrder, AddEntryMultiLine, AddEntrySingleLine, AddEntryAlphabetical, AddEntryAppend.
+**HasFix (9 cases):** AddNewPermissionsProperty, AddNewTableEntry, MergePermissionChar, MergeCanonicalOrder, AddEntryMultiLine, AddEntrySingleLine, AddEntryAlphabetical, AddEntryAppend, AddEntryAlphabeticalFirst.
 
 ## Known issues / future work
 
@@ -125,4 +127,5 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 - **CalcFields/CalcSums** are not yet covered (out of scope for initial implementation)
 - **CodeFix: blank line formatting** When creating a new Permissions property on an object that has no properties, no blank line is inserted between the new property and the first member (trigger/procedure)
 - **CodeFix: cross-namespace test** The single-file test framework cannot test qualified table name resolution; both objects must be in the same file
+- **CodeFix: FixAll not directly testable** RoslynTestKit has no FixAll test API; FixAll behavior can only be verified via VS Code
 - **Inverted rule** (permissions declared but not needed) is planned as a separate diagnostic

--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -77,6 +77,7 @@ Maps AL built-in record methods to `DatabaseOperation`:
 | `Rec.Modify()` in table objects detected via explicit Instance path | The AL compiler resolves `Rec.Modify()` with a non-null Instance |
 | InherentPermissions attribute parsed via syntax text splitting | The attribute's syntax is well-defined; avoids complex semantic analysis |
 | `TestPermissions = Disabled` suppresses diagnostic | Test codeunits with disabled permissions are intentionally testing without permission checks |
+| Skip permissionset/permissionsetextension objects | These objects declare permissions as their core purpose, not code that accesses tables; skipping improves performance |
 
 ## CodeFix
 

--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -107,11 +107,11 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Decision | Rationale |
 |---|---|
 | Passes TableName, TableNamespace, PermissionChar via `ImmutableDictionary` properties | Standard CodeFix data passing pattern |
-| Permission chars are lowercase (`rimd`) | Consistent with AL conventions |
+| Permission chars preserve existing casing convention | If existing permissions use uppercase (e.g. `RM`), added chars match (`RIM`). Defaults to lowercase for new entries. |
+| `ApplyFix` re-finds ObjectSyntax by kind+name from current tree | BatchFixer applies fixes sequentially; using captured node references causes stale-reference bugs (phantom entries, wrong merges) |
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
 | `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
-| Custom `PermissionsFixAllProvider` replaces `BatchFixer` (net8.0+) | BatchFixer applies fixes sequentially, causing uppercase normalization and phantom entries when multiple diagnostics modify the same Permissions node. Custom provider collects all diagnostics and applies a single tree transformation. |
 | `insertIndex == 0` gets special trivia handling in multi-line lists | First entry sits on the `Permissions = ` line with no leading indentation; displaced entries need indentation added |
 
 ## Test coverage
@@ -127,5 +127,4 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 - **CalcFields/CalcSums** are not yet covered (out of scope for initial implementation)
 - **CodeFix: blank line formatting** When creating a new Permissions property on an object that has no properties, no blank line is inserted between the new property and the first member (trigger/procedure)
 - **CodeFix: cross-namespace test** The single-file test framework cannot test qualified table name resolution; both objects must be in the same file
-- **CodeFix: FixAll not directly testable** RoslynTestKit has no FixAll test API; FixAll behavior can only be verified via VS Code
 - **Inverted rule** (permissions declared but not needed) is planned as a separate diagnostic

--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -110,6 +110,7 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Permission chars are lowercase (`rimd`) | Consistent with AL conventions |
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
+| `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
 
 ## Test coverage
 

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -71,6 +71,7 @@ Single-threaded. `RegisterCompilationAction` runs once after compilation complet
 | `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
 | Page SourceTable exemption | Pages implicitly need RIMD on their source table |
 | Temporary records NOT exempted | Declaring permissions on temp-only tables is dead code |
+| Skip permissionset/permissionsetextension objects | These objects declare permissions as their core purpose, not as code-access declarations; flagging them is always a false positive |
 | `DeclaredPermissionSet` reused for RIMD tracking | Existing type from AC0031's permission module |
 
 ## CodeFix
@@ -108,7 +109,7 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 ## Test coverage
 
 **HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
-**NoDiagnostic (6 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead.
+**NoDiagnostic (8 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension.
 **HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
 
 ## Known limitations

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -23,12 +23,12 @@ Two `DiagnosticDescriptor` instances share the same ID but have different messag
 
 ## Architecture
 
-Uses `RegisterCompilationAction` (whole-object analysis) because `CompilationStartAnalysisContext` does not expose `RegisterOperationAction`.
+Uses a `CompilationStartAction` closure pattern for two-phase analysis: parallel collection followed by sequential analysis. All actions share state via closures captured in `OnCompilationStart`.
 
 ```
 src/ALCops.ApplicationCop/
 ├── Analyzers/
-│   └── TableDataAccessUnusedPermissions.cs           # Analyzer (CompilationAction)
+│   └── TableDataAccessUnusedPermissions.cs           # Analyzer (CompilationStart + CodeBlock + CompilationEnd)
 └── CodeFixes/
     └── TableDataAccessUnusedPermissionsCodeFixProvider.cs  # CodeFix (remove entry / reduce chars / remove property)
 
@@ -39,34 +39,47 @@ src/ALCops.Common/
 
 ### Analysis flow
 
-1. Iterate all objects via `compilation.GetDeclaredApplicationObjectSymbols()`
-2. Skip test codeunits with `TestPermissions = Disabled`
-3. For each object with a `Permissions` property:
-   a. Collect all required permissions (invocations, data items, xmlport nodes)
-   b. Get page SourceTable context (implicit RIMD exemption)
-   c. For each declared `tabledata` entry, check if the table is accessed
-4. Report per-entry diagnostics with properties for the CodeFix
+**Registration (`Initialize` + `OnCompilationStart`):**
+- `RegisterCompilationStartAction` creates a shared `ConcurrentDictionary` accumulator
+- From within `CompilationStartAction`, registers `CodeBlockAction`, `SymbolAction` (x3), and `CompilationEndAction`
+- All callbacks capture the accumulator via closure (guaranteed same instance)
+
+**Phase 1 (parallel, compiler-driven):**
+1. `RegisterCodeBlockAction`: For each method/trigger, check if containing object has `Permissions` property (early exit for ~70% of callbacks). Syntax-level pre-filter scans for DB method names before the expensive `GetOperation` call (eliminates ~75% of remaining methods). Call `GetOperation(body)` once per method, then walk the operation tree via `InvocationCollectorWalker` (extends `OperationWalker`).
+2. `RegisterSymbolAction` (ReportDataItem, QueryDataItem, XmlPortNode): Collect data item permissions into the same accumulator.
+
+**Phase 2 (sequential):**
+3. `RegisterCompilationEndAction`: Iterate objects with `Permissions` property, look up accumulated data, compare declared vs. required, report diagnostics.
 
 ### Key methods
 
 | Method | Purpose |
 |---|---|
-| `AnalyzeCompilation` | Entry point; iterates objects |
-| `CollectRequiredPermissions` | Aggregates all table accesses in the object |
-| `CollectFromInvocations` | Walks syntax tree for `InvocationExpression` nodes, bridges to `SemanticModel.GetOperation()` |
+| `OnCompilationStart` | Creates shared accumulator, registers all inner actions with closures |
+| `CollectFromCodeBlock` | Phase 1 entry; syntax pre-filter, then `GetOperation` + `InvocationCollectorWalker` |
+| `InvocationCollectorWalker` | `OperationWalker` subclass; visits `IInvocationExpression` nodes |
+| `CollectFromReportDataItem/QueryDataItem/XmlPortNode` | Phase 1; data item collection via `RegisterSymbolAction` |
+| `AnalyzeCompilation` | Phase 2; iterates objects, reads accumulated data, reports diagnostics |
 | `AnalyzePermissionEntry` | Compares one declared entry against collected required permissions |
 | `PermissionMatchesTable` | Matches identifier/qualified/objectId syntax against `ITableTypeSymbol` |
 
 ### Threading model
 
-Single-threaded. `RegisterCompilationAction` runs once after compilation completes. No `ConcurrentDictionary` needed (unlike the earlier CompilationStart+End design).
+Phase 1 callbacks run in parallel (compiler-managed thread pool). `ConcurrentDictionary` + `ConcurrentBag` ensure thread safety. Shared state is captured via closures from `CompilationStartAction` (no `ConditionalWeakTable` needed). Object keys use `$"{Kind}:{Id}"` strings for safe identity across different symbol instances.
+
+Phase 2 (`RegisterCompilationEndAction`) runs once after all Phase 1 callbacks complete. Reads are sequential, no concurrent writes.
 
 ## Design decisions
 
 | Decision | Rationale |
 |---|---|
-| `RegisterCompilationAction` instead of CompilationStart+End | `CompilationStartAnalysisContext` lacks `RegisterOperationAction` |
-| Whole-object analysis (not per-invocation collection) | Simpler, no thread-safety concerns, single pass |
+| `CompilationStartAction` + `CompilationEndAction` closure pattern | Guarantees shared state across CodeBlockAction, SymbolAction, and CompilationEndAction via closures. `ConditionalWeakTable<Compilation>` does NOT work because `Compilation` instances differ across action types. |
+| `RegisterCodeBlockAction` + `OperationWalker` | Amortizes `GetOperation` cost: one call per method body instead of per invocation node. Compiler parallelizes callbacks. |
+| Syntax-level pre-filter before `GetOperation` | Scans method body for DB method names (Find, Get, Insert, etc.) via syntax tree walk. Eliminates ~75% of `GetOperation` calls. `GetOperation` dominates cost at ~0.1ms each. |
+| `OperationWalker` for invocation collection | SDK-provided visitor pattern; only visits `IInvocationExpression` nodes efficiently |
+| String keys (`Kind:Id`) instead of symbol reference equality | Symbol instances from `GetContainingApplicationObjectTypeSymbol()` and `GetDeclaredApplicationObjectSymbols()` may differ |
+| Early exit on `Permissions` property check in CodeBlockAction | ~70% of callbacks are in objects without `Permissions`; avoids `GetOperation` call entirely |
+| `RegisterSymbolAction` for data items | Compiler handles member enumeration; simpler than manual iteration |
 | Two descriptors sharing one ID | Same conceptual rule, different message clarity |
 | `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
 | Page SourceTable exemption | Pages implicitly need RIMD on their source table |

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -1,0 +1,119 @@
+---
+applyTo: 'src/ALCops.ApplicationCop/**/TableDataAccessUnusedPermissions*'
+---
+
+# AC0032: Unused Permissions
+
+## Purpose
+
+Detects `Permissions` property entries that have no corresponding table data access in the object. This is the inverse of AC0031 (which detects missing permissions). Reports an Info-level diagnostic per unused permission entry. Unused permissions are dead code because the `Permissions` property only applies to the object that directly accesses the table (no call-stack inheritance).
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | AC0032 |
+| Category | Design |
+| Severity | Info |
+| Help URI | https://alcops.dev/docs/analyzers/applicationcop/ac0032/ |
+
+Two `DiagnosticDescriptor` instances share the same ID but have different message formats:
+- `TableDataAccessUnusedPermissionsEntireEntry`: table not accessed at all
+- `TableDataAccessUnusedPermissionsPartialChars`: table accessed but not all declared RIMD chars are needed
+
+## Architecture
+
+Uses `RegisterCompilationAction` (whole-object analysis) because `CompilationStartAnalysisContext` does not expose `RegisterOperationAction`.
+
+```
+src/ALCops.ApplicationCop/
+├── Analyzers/
+│   └── TableDataAccessUnusedPermissions.cs           # Analyzer (CompilationAction)
+└── CodeFixes/
+    └── TableDataAccessUnusedPermissionsCodeFixProvider.cs  # CodeFix (remove entry / reduce chars / remove property)
+
+src/ALCops.Common/
+└── Permissions/
+    └── RequiredPermissionDetector.cs   # Shared detection logic (also used by AC0031)
+```
+
+### Analysis flow
+
+1. Iterate all objects via `compilation.GetDeclaredApplicationObjectSymbols()`
+2. Skip test codeunits with `TestPermissions = Disabled`
+3. For each object with a `Permissions` property:
+   a. Collect all required permissions (invocations, data items, xmlport nodes)
+   b. Get page SourceTable context (implicit RIMD exemption)
+   c. For each declared `tabledata` entry, check if the table is accessed
+4. Report per-entry diagnostics with properties for the CodeFix
+
+### Key methods
+
+| Method | Purpose |
+|---|---|
+| `AnalyzeCompilation` | Entry point; iterates objects |
+| `CollectRequiredPermissions` | Aggregates all table accesses in the object |
+| `CollectFromInvocations` | Walks syntax tree for `InvocationExpression` nodes, bridges to `SemanticModel.GetOperation()` |
+| `AnalyzePermissionEntry` | Compares one declared entry against collected required permissions |
+| `PermissionMatchesTable` | Matches identifier/qualified/objectId syntax against `ITableTypeSymbol` |
+
+### Threading model
+
+Single-threaded. `RegisterCompilationAction` runs once after compilation completes. No `ConcurrentDictionary` needed (unlike the earlier CompilationStart+End design).
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| `RegisterCompilationAction` instead of CompilationStart+End | `CompilationStartAnalysisContext` lacks `RegisterOperationAction` |
+| Whole-object analysis (not per-invocation collection) | Simpler, no thread-safety concerns, single pass |
+| Two descriptors sharing one ID | Same conceptual rule, different message clarity |
+| `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
+| Page SourceTable exemption | Pages implicitly need RIMD on their source table |
+| Temporary records NOT exempted | Declaring permissions on temp-only tables is dead code |
+| `DeclaredPermissionSet` reused for RIMD tracking | Existing type from AC0031's permission module |
+
+## CodeFix
+
+The `TableDataAccessUnusedPermissionsCodeFixProvider` removes or reduces unused permission entries. Supports FixAll.
+
+### Scenarios
+
+| Scenario | Behavior |
+|---|---|
+| Entire entry unused, other entries remain | Remove the entry from the permission list |
+| Entire entry unused, only entry | Remove the entire `Permissions` property |
+| Partial chars unused | Replace permission chars with only the used subset |
+
+### Data passing (analyzer -> CodeFix)
+
+`ImmutableDictionary<string, string>` properties on the diagnostic:
+- `TableName`: table name as written in the permission declaration
+- `UnusedChars`: chars to remove (e.g., "imd")
+- `UsedChars`: chars to keep (e.g., "r"); empty string when entire entry is unused
+
+### Node finding
+
+`syntaxRoot.FindNode(span)` may return `PermissionPropertyValueSyntax` instead of `PermissionSyntax` when there is only one entry (identical spans). The code fix handles this by searching descendants:
+```csharp
+var permissionNode = node as PermissionSyntax
+    ?? node.FirstAncestorOrSelf<PermissionSyntax>()
+    ?? node.DescendantNodes().OfType<PermissionSyntax>().FirstOrDefault();
+```
+
+### Trivia handling
+
+When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remove` preserves the second entry's leading trivia (newline + indent). The code fix strips this trivia to avoid `Permissions =\n              tabledata ...` artifacts.
+
+## Test coverage
+
+**HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
+**NoDiagnostic (6 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead.
+**HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
+
+## Known limitations
+
+1. **Extension objects**: Cannot see base object code; may flag permissions needed by the base as unused
+2. **CalcFields/CalcSums**: Indirect table access through FlowFields is not traced
+3. **InherentPermissions overlap**: Table-level `InherentPermissions` may make an object-level entry redundant, but the analyzer does not flag this (different concern from unused)
+4. **Cross-object calls**: If codeunit A calls codeunit B, and B accesses a table, A's permission for that table appears unused (correct, because permissions don't flow through the call stack)

--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -643,6 +643,7 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
 - `GetApplicationObjectTypeSymbolsByKindAcrossModulesWithReflection` retrieves symbols from all referenced modules, not just the current one
 - Always use `OriginalDefinition` when comparing symbols from different contexts (extension target vs base object)
 - Requires `using System.Runtime.CompilerServices;` for `ConditionalWeakTable`
+- **Only use `ConditionalWeakTable<Compilation, ...>` within a single action type.** The `Compilation` object instance from `SemanticModel.Compilation` (in `CodeBlockAction`, `OperationAction`, `SyntaxNodeAction`) is a **different object** from `ctx.Compilation` in `CompilationAction` or `CompilationStartAction`. `ConditionalWeakTable` uses reference equality, so data written by one action type is invisible to another. If you need to share state across action types, use `CompilationStartAction` closures instead (see "Performance Anti-Patterns" below).
 
 ### Existing implementations
 
@@ -672,6 +673,106 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
 - **One analyzer class per rule or tightly related rule group.** The `AnalyzeCountMethod` analyzer handles both `LC0081` (IsEmpty) and `LC0082` (FindWithNext) because they share the same analysis logic.
 - **Use `ImmutableArray.Create()`** for `SupportedDiagnostics`, listing all descriptors the analyzer may report.
 - **Location matters.** Report diagnostics at the most specific location: the offending property, syntax node, or symbol, not the entire object.
+
+## Performance Anti-Patterns
+
+Performance matters. The Base Application has ~7,900 files and ~100,000 method/trigger bodies. A rule that adds 0.1ms per method adds 10 seconds to compilation. The following anti-patterns have caused real regressions.
+
+### DO NOT use `RegisterOperationAction` for high-frequency invocations
+
+`RegisterOperationAction(callback, OperationKind.InvocationExpression)` fires once per invocation expression in the entire compilation. Each callback carries overhead from the SDK's action dispatching. For the Base Application, this means ~115,000 callbacks for invocation expressions alone.
+
+If your analyzer only cares about invocations in methods that meet certain criteria (e.g., the containing object has a `Permissions` property), most of these callbacks are wasted.
+
+**Instead:** Use `RegisterCodeBlockAction` to get the full method body, apply cheap pre-filters first, then call `GetOperation(body)` once per qualifying method and walk the operation tree with an `OperationWalker` subclass. This gives you one semantic call per method instead of one per invocation.
+
+```csharp
+// WRONG - fires for every invocation in the entire compilation
+context.RegisterOperationAction(
+    AnalyzeInvocation,
+    EnumProvider.OperationKind.InvocationExpression);
+
+// BETTER - one callback per method, pre-filter before expensive work
+compilationCtx.RegisterCodeBlockAction(ctx =>
+{
+    if (ctx.CodeBlock is not MethodOrTriggerDeclarationSyntax method)
+        return;
+
+    // Cheap pre-filter: skip methods in objects that can't produce diagnostics
+    var obj = ctx.OwningSymbol?.GetContainingApplicationObjectTypeSymbol();
+    if (obj?.GetProperty(EnumProvider.PropertyKind.Permissions) is null)
+        return;
+
+    // Walk the operation tree for this method body
+    var operation = ctx.SemanticModel.GetOperation(method.Body, ctx.CancellationToken);
+    if (operation is null)
+        return;
+
+    var walker = new MyOperationWalker(/* ... */);
+    walker.Visit(operation);
+});
+```
+
+See `PartialRecordOperations.cs` and `TableDataAccessUnusedPermissions.cs` for real examples.
+
+### DO NOT call `GetOperation()` without pre-filtering
+
+`SemanticModel.GetOperation()` costs ~0.05-0.1ms per call. Across 100K methods, that is 5-10 seconds. Most methods will not contain the patterns your analyzer cares about.
+
+**Pre-filter at the syntax level first.** Walk the syntax tree (which is free, already parsed) looking for relevant invocation names, node kinds, or keywords. Only call `GetOperation()` if the syntax scan finds a potential match.
+
+```csharp
+// Scan syntax tree for DB method names before expensive GetOperation
+bool hasPossibleMatch = false;
+body.WalkDescendantsAndPerformAction(node =>
+{
+    if (hasPossibleMatch) return;
+    if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression)) return;
+
+    var invocation = (InvocationExpressionSyntax)node;
+    string? name = invocation.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        _ => null
+    };
+
+    if (name is not null && IsRelevantMethodName(name))
+        hasPossibleMatch = true;
+});
+
+if (!hasPossibleMatch) return; // Skip GetOperation entirely
+```
+
+Note: syntax-level method name checks are case-insensitive string comparisons, not semantic resolution. This is acceptable as a pre-filter because false positives just mean an unnecessary (but inexpensive) `GetOperation` call. False negatives would be a correctness bug, so the name set must be comprehensive.
+
+### DO NOT share state across action types via `ConditionalWeakTable<Compilation>`
+
+`ConditionalWeakTable` uses reference equality on the `Compilation` key. The `Compilation` instance from `SemanticModel.Compilation` (available in `CodeBlockAction`, `OperationAction`, `SyntaxNodeAction`) is a **different object** from `ctx.Compilation` in `CompilationAction`. Data stored by one action type is invisible to the other, causing silent data loss.
+
+`ConditionalWeakTable<Compilation>` is safe when used within a single action type (e.g., only in `SymbolAction` callbacks, as in `DuplicateODataEntityName`). It fails when you need to write in `CodeBlockAction` and read in `CompilationAction`.
+
+**Instead:** Use `CompilationStartAction` + `RegisterCompilationEndAction` with closures:
+
+```csharp
+public override void Initialize(AnalysisContext context)
+{
+    context.RegisterCompilationStartAction(OnCompilationStart);
+}
+
+private void OnCompilationStart(CompilationStartAnalysisContext compilationCtx)
+{
+    // Shared state, guaranteed same instance across all callbacks
+    var accumulator = new ConcurrentDictionary<string, ConcurrentBag<MyData>>();
+
+    // All inner actions capture the same accumulator via closure
+    compilationCtx.RegisterCodeBlockAction(ctx => CollectData(ctx, accumulator));
+    compilationCtx.RegisterSymbolAction(ctx => CollectMore(ctx, accumulator), ...);
+    compilationCtx.RegisterCompilationEndAction(ctx => Analyze(ctx, accumulator));
+}
+```
+
+`RegisterCompilationEndAction` runs after all `CodeBlockAction` and `SymbolAction` callbacks complete. This is the correct way to implement collect-then-analyze patterns.
 
 ## SDK GetSymbol() Bug
 

--- a/.github/instructions/codefix-development.instructions.md
+++ b/.github/instructions/codefix-development.instructions.md
@@ -496,36 +496,43 @@ See `testing.instructions.md` for the full testing guide. CodeFix-specific detai
 
 ## Existing implementations reference
 
-| Cop | File | Diagnostic | Fix type |
+| Cop | File | Diagnostic | Fix description |
 |---|---|---|---|
+| ApplicationCop | `EmptyCaptionLocked.cs` | AC0018 | Add `Locked = true` to empty caption |
+| ApplicationCop | `GlobalLanguageImplementTranslationHelper.cs` | AC0005 | Refactor to use Translation Helper codeunit |
+| ApplicationCop | `InstallAndUpgradeCodeunitsShouldBeInternal.cs` | AC0007 | Set `Access = Internal` |
+| ApplicationCop | `IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs` | AC0012 | Convert IntegrationEvent to InternalEvent |
+| ApplicationCop | `IntegrationEventsInInternalCodeunitRemoveAccessInternal.cs` | AC0012 | Remove `Access = Internal` property |
+| ApplicationCop | `LabelWithTokSuffixMustBeLocked.cs` | AC0020 | Add `Locked = true` to Tok-suffixed label |
+| ApplicationCop | `NotBlankNotAllowedOnPrimaryKeyField.cs` | AC0003 | Set `NotBlank = false` on PK field |
+| ApplicationCop | `NotBlankRequiredOnPrimaryKeyField.cs` | AC0002 | Set `NotBlank = true` on PK field |
+| ApplicationCop | `PermissionSetCaptionLength.cs` | AC0009 | Truncate PermissionSet caption to 30 chars |
+| ApplicationCop | `PublicEventPublisher.cs` | AC0024 | Make event publisher method local |
+| ApplicationCop | `RunPageImplementPageManagement.cs` | AC0006 | Refactor to use Page Management codeunit |
+| ApplicationCop | `TableDataAccessRequiresPermissions.cs` | AC0031 | Add missing permission declaration |
+| ApplicationCop | `TableDataAccessUnusedPermissionsCodeFixProvider.cs` | AC0032 | Remove unused permission declaration |
+| FormattingCop | `CasingMismatchKeyword.cs` | FC0002 | Fix keyword casing via text replacement |
+| FormattingCop | `PermissionDeclarationOrderCodeFixProvider.cs` | FC0004 | Sort permission declarations alphabetically |
+| FormattingCop | `UseParenthesisForFunctionCall.cs` | FC0003 | Add `()` to function calls |
+| LinterCop | `AllowInCustomizationsRedundancy.cs` | LC0094 | Remove redundant AllowInCustomizations property |
+| LinterCop | `ApplicationAreaRedundancy.cs` | LC0020 | Remove redundant ApplicationArea property |
+| LinterCop | `BuiltInDateTimeMethod.cs` | LC0083 | Replace deprecated DateTime method |
+| LinterCop | `DataClassificationRedundancy.cs` | LC0019 | Remove redundant DataClassification property |
+| LinterCop | `ObjectIdInDeclaration.cs` | LC0003 | Replace numeric object ID with name reference |
+| LinterCop | `RecordInstanceIsolationLevel.cs` | LC0031 | Add `ReadIsolation` with UpdLock |
+| PlatformCop | `ApplicationAreaOnApiPage.cs` | PC0024 | Remove ApplicationArea from API page |
 | PlatformCop | `EditableFlowField.cs` | PC0001 | Add/update `Editable = false` property |
-| PlatformCop | `GuidEmptyStringComparison.cs` | PC0015 | Replace `guid == ''` with `System.IsNullGuid(guid)` |
+| PlatformCop | `EventPublisherIsHandledByVar.cs` | PC0011 | Add `var` keyword to IsHandled parameter |
 | PlatformCop | `EventSubscriberVarKeyword.cs` | PC0010 | Add `var` keyword to parameter |
-| PlatformCop | `EventPublisherIsHandledByVar.cs` | PC0009 | Add `var` keyword to IsHandled parameter |
-| PlatformCop | `ExtensiblePropertyExplicitlySet.cs` | PC0012 | Set Extensible property |
-| PlatformCop | `JsonTokenJPathUsesDoubleQuotes.cs` | PC0016 | Replace double quotes with single quotes in JPath |
-| PlatformCop | `SetRangeWithFilterOperators.cs` | PC0003 | Replace SetRange with SetFilter |
+| PlatformCop | `ExtensiblePropertyExplicitlySet.cs` | PC0005 | Set Extensible property |
 | PlatformCop | `FilterStringSingleQuoteEscaping.cs` | PC0019 | Fix quote escaping in filter strings |
-| PlatformCop | `OperatorAndPlaceholderInFilterExpression.cs` | PC0017 | Fix filter expression operators |
-| PlatformCop | `MandatoryFieldMissingOnApiPage.cs` | PC0022 | Add mandatory field to API page |
-| PlatformCop | `ApplicationAreaOnApiPage.cs` | PC0013 | Remove ApplicationArea from API page |
-| PlatformCop | `PossibleOverflowAssigningAppendMaxLengthToLabel.cs` | PC0024 | Apply MaxLength/CopyStr to prevent overflow |
-| PlatformCop | `PossibleOverflowAssigningApplyCopyStr.cs` | PC0024 | Apply CopyStr to prevent overflow |
-| ApplicationCop | `EmptyCaptionLocked.cs` | AC0033 | Add `Locked = true` to empty caption |
-| ApplicationCop | `LabelWithTokSuffixMustBeLocked.cs` | AC0017 | Add `Locked = true` to Tok-suffixed label |
-| ApplicationCop | `InstallAndUpgradeCodeunitsShouldBeInternal.cs` | AC0011 | Add `Access = Internal` |
-| ApplicationCop | `PublicEventPublisher.cs` | AC0040 | Change event publisher access |
-| ApplicationCop | `NotBlankRequiredOnPrimaryKeyField.cs` | AC0043 | Add NotBlank to PK field |
-| ApplicationCop | `NotBlankNotAllowedOnPrimaryKeyField.cs` | AC0044 | Remove NotBlank from PK field |
-| ApplicationCop | `PermissionSetCaptionLength.cs` | AC0012 | Truncate PermissionSet caption |
-| ApplicationCop | `GlobalLanguageImplementTranslationHelper.cs` | AC0022 | Replace GlobalLanguage with TranslationHelper |
-| ApplicationCop | `RunPageImplementPageManagement.cs` | AC0024 | Replace RunPage with PageManagement |
-| ApplicationCop | `IntegrationEventsInInternalCodeunit*.cs` | AC0029 | Two fixes: remove internal access or convert event type |
-| FormattingCop | `UseParenthesisForFunctionCall.cs` | FC0009 | Add `()` to function calls |
-| FormattingCop | `CasingMismatchKeyword.cs` | FC0004 | Fix keyword casing via text replacement |
-| LinterCop | `AllowInCustomizationsRedundancy.cs` | LC0024 | Remove redundant AllowInCustomizations property |
-| LinterCop | `DataClassificationRedundancy.cs` | LC0025 | Remove redundant DataClassification property |
-| LinterCop | `ApplicationAreaRedundancy.cs` | LC0026 | Remove redundant ApplicationArea property |
-| LinterCop | `RecordInstanceIsolationLevel.cs` | LC0005 | Replace `LockTable()` with `ReadIsolation()` |
-| LinterCop | `BuiltInDateTimeMethod.cs` | LC0022 | Replace deprecated DateTime method |
-| LinterCop | `ObjectIdInDeclaration.cs` | LC0030 | Replace numeric object ID with name reference |
+| PlatformCop | `GuidEmptyStringComparison.cs` | PC0015 | Replace `guid == ''` with `IsNullGuid(guid)` |
+| PlatformCop | `JsonTokenJPathUsesDoubleQuotes.cs` | PC0014 | Replace double quotes with single quotes in JPath |
+| PlatformCop | `MandatoryFieldMissingOnApiPage.cs` | PC0026 | Add mandatory field to API page |
+| PlatformCop | `OperatorAndPlaceholderInFilterExpression.cs` | PC0008 | Wrap filter placeholder in StrSubstNo |
+| PlatformCop | `PartialRecordsBeforeWriteOperation.cs` | PC0031 | Remove partial record operations before write |
+| PlatformCop | `PossibleOverflowAssigningAppendMaxLengthToLabel.cs` | PC0022 | Add MaxLength to label to prevent overflow |
+| PlatformCop | `PossibleOverflowAssigningApplyCopyStr.cs` | PC0022 | Apply CopyStr to prevent overflow |
+| PlatformCop | `SetRangeWithFilterOperators.cs` | PC0003 | Replace SetRange with SetFilter |
+| PlatformCop | `UsePartialRecordsOnRead.cs` | PC0030 | Add SetLoadFields for partial records |
+| PlatformCop | `UseSequentialGuid.cs` | PC0029 | Replace CreateGuid with CreateSequentialGuid |

--- a/.github/instructions/codefix-development.instructions.md
+++ b/.github/instructions/codefix-development.instructions.md
@@ -494,45 +494,21 @@ See `testing.instructions.md` for the full testing guide. CodeFix-specific detai
 - `fixture.TestCodeFix()` verifies the transformation from current to expected code
 - Test cases live in `HasFix/<TestCaseName>/` with `current.al` (with `[|...|]` marker) and `expected.al`
 
-## Existing implementations reference
+## Reference implementations by pattern
 
-| Cop | File | Diagnostic | Fix description |
-|---|---|---|---|
-| ApplicationCop | `EmptyCaptionLocked.cs` | AC0018 | Add `Locked = true` to empty caption |
-| ApplicationCop | `GlobalLanguageImplementTranslationHelper.cs` | AC0005 | Refactor to use Translation Helper codeunit |
-| ApplicationCop | `InstallAndUpgradeCodeunitsShouldBeInternal.cs` | AC0007 | Set `Access = Internal` |
-| ApplicationCop | `IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs` | AC0012 | Convert IntegrationEvent to InternalEvent |
-| ApplicationCop | `IntegrationEventsInInternalCodeunitRemoveAccessInternal.cs` | AC0012 | Remove `Access = Internal` property |
-| ApplicationCop | `LabelWithTokSuffixMustBeLocked.cs` | AC0020 | Add `Locked = true` to Tok-suffixed label |
-| ApplicationCop | `NotBlankNotAllowedOnPrimaryKeyField.cs` | AC0003 | Set `NotBlank = false` on PK field |
-| ApplicationCop | `NotBlankRequiredOnPrimaryKeyField.cs` | AC0002 | Set `NotBlank = true` on PK field |
-| ApplicationCop | `PermissionSetCaptionLength.cs` | AC0009 | Truncate PermissionSet caption to 30 chars |
-| ApplicationCop | `PublicEventPublisher.cs` | AC0024 | Make event publisher method local |
-| ApplicationCop | `RunPageImplementPageManagement.cs` | AC0006 | Refactor to use Page Management codeunit |
-| ApplicationCop | `TableDataAccessRequiresPermissions.cs` | AC0031 | Add missing permission declaration |
-| ApplicationCop | `TableDataAccessUnusedPermissionsCodeFixProvider.cs` | AC0032 | Remove unused permission declaration |
-| FormattingCop | `CasingMismatchKeyword.cs` | FC0002 | Fix keyword casing via text replacement |
-| FormattingCop | `PermissionDeclarationOrderCodeFixProvider.cs` | FC0004 | Sort permission declarations alphabetically |
-| FormattingCop | `UseParenthesisForFunctionCall.cs` | FC0003 | Add `()` to function calls |
-| LinterCop | `AllowInCustomizationsRedundancy.cs` | LC0094 | Remove redundant AllowInCustomizations property |
-| LinterCop | `ApplicationAreaRedundancy.cs` | LC0020 | Remove redundant ApplicationArea property |
-| LinterCop | `BuiltInDateTimeMethod.cs` | LC0083 | Replace deprecated DateTime method |
-| LinterCop | `DataClassificationRedundancy.cs` | LC0019 | Remove redundant DataClassification property |
-| LinterCop | `ObjectIdInDeclaration.cs` | LC0003 | Replace numeric object ID with name reference |
-| LinterCop | `RecordInstanceIsolationLevel.cs` | LC0031 | Add `ReadIsolation` with UpdLock |
-| PlatformCop | `ApplicationAreaOnApiPage.cs` | PC0024 | Remove ApplicationArea from API page |
-| PlatformCop | `EditableFlowField.cs` | PC0001 | Add/update `Editable = false` property |
-| PlatformCop | `EventPublisherIsHandledByVar.cs` | PC0011 | Add `var` keyword to IsHandled parameter |
-| PlatformCop | `EventSubscriberVarKeyword.cs` | PC0010 | Add `var` keyword to parameter |
-| PlatformCop | `ExtensiblePropertyExplicitlySet.cs` | PC0005 | Set Extensible property |
-| PlatformCop | `FilterStringSingleQuoteEscaping.cs` | PC0019 | Fix quote escaping in filter strings |
-| PlatformCop | `GuidEmptyStringComparison.cs` | PC0015 | Replace `guid == ''` with `IsNullGuid(guid)` |
-| PlatformCop | `JsonTokenJPathUsesDoubleQuotes.cs` | PC0014 | Replace double quotes with single quotes in JPath |
-| PlatformCop | `MandatoryFieldMissingOnApiPage.cs` | PC0026 | Add mandatory field to API page |
-| PlatformCop | `OperatorAndPlaceholderInFilterExpression.cs` | PC0008 | Wrap filter placeholder in StrSubstNo |
-| PlatformCop | `PartialRecordsBeforeWriteOperation.cs` | PC0031 | Remove partial record operations before write |
-| PlatformCop | `PossibleOverflowAssigningAppendMaxLengthToLabel.cs` | PC0022 | Add MaxLength to label to prevent overflow |
-| PlatformCop | `PossibleOverflowAssigningApplyCopyStr.cs` | PC0022 | Apply CopyStr to prevent overflow |
-| PlatformCop | `SetRangeWithFilterOperators.cs` | PC0003 | Replace SetRange with SetFilter |
-| PlatformCop | `UsePartialRecordsOnRead.cs` | PC0030 | Add SetLoadFields for partial records |
-| PlatformCop | `UseSequentialGuid.cs` | PC0029 | Replace CreateGuid with CreateSequentialGuid |
+When writing a new CodeFix, find an existing one that uses the same technique. Use `ls src/*/CodeFixes/` to discover all CodeFix files.
+
+| Pattern | Good reference | What it demonstrates |
+|---|---|---|
+| Add/set a property | `EditableFlowField.cs` (PlatformCop) | Insert or update a property on a syntax node |
+| Remove a property | `AllowInCustomizationsRedundancy.cs` (LinterCop) | Delete a property and clean up trivia |
+| Add a keyword/token | `EventSubscriberVarKeyword.cs` (PlatformCop) | Insert a keyword into a parameter list |
+| Replace an expression | `GuidEmptyStringComparison.cs` (PlatformCop) | Swap one expression for another |
+| Replace a method call | `SetRangeWithFilterOperators.cs` (PlatformCop) | Rewrite a method invocation with different method/args |
+| Rewrite a string literal | `JsonTokenJPathUsesDoubleQuotes.cs` (PlatformCop) | Text manipulation within a string token |
+| Add syntax tokens | `UseParenthesisForFunctionCall.cs` (FormattingCop) | Insert tokens (parentheses) into existing syntax |
+| Reorder/rebuild a property value | `PermissionDeclarationOrderCodeFixProvider.cs` (FormattingCop) | Sort entries, rebuild multi-line `PermissionPropertyValue` |
+| Add entries to a list property | `TableDataAccessRequiresPermissions.cs` (ApplicationCop) | Insert into existing list, handle alphabetical insertion |
+| Remove entries from a list property | `TableDataAccessUnusedPermissionsCodeFixProvider.cs` (ApplicationCop) | Remove specific entries, handle cleanup of entire property |
+| Two alternative fixes for one diagnostic | `IntegrationEventsInInternalCodeunit*.cs` (ApplicationCop) | Two CodeFix classes sharing one diagnostic ID |
+| Complex multi-node rewrite | `PossibleOverflowAssigningApplyCopyStr.cs` (PlatformCop) | Wrap expressions in function calls, handle multiple overload shapes |

--- a/.github/instructions/fc0004-permission-declaration-order.instructions.md
+++ b/.github/instructions/fc0004-permission-declaration-order.instructions.md
@@ -1,0 +1,105 @@
+---
+applyTo: 'src/ALCops.FormattingCop/**/PermissionDeclarationOrder*'
+---
+
+# FC0004: Permission Declaration Order
+
+## Purpose
+
+Detects `Permissions` property entries that are not sorted alphabetically by (type keyword, object name). Provides a CodeFix that reorders the entries and converts single-line format to multi-line when there are 2+ entries.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | FC0004 |
+| Category | Style |
+| Severity | Info |
+| Help URI | https://alcops.dev/docs/analyzers/formattingcop/fc0004/ |
+
+## Architecture
+
+```
+src/ALCops.Common/
+└── Permissions/
+    └── PermissionSyntaxHelper.cs    # Shared sort logic, multi-line builder
+
+src/ALCops.FormattingCop/
+├── Analyzers/
+│   └── PermissionDeclarationOrder.cs           # Analyzer (CompilationAction)
+└── CodeFixes/
+    └── PermissionDeclarationOrderCodeFixProvider.cs  # CodeFix (sort + reformat)
+```
+
+### Sort order
+
+Entries are sorted by two keys:
+1. **Type keyword** (alphabetical, case-insensitive): `codeunit` < `page` < `query` < `record` < `report` < `table` < `tabledata` < `xmlport`
+2. **Object name** (alphabetical, case-insensitive) within the same type
+
+Uses `StringComparison.OrdinalIgnoreCase` for both comparisons. Note that ordinal comparison means `(` < `+` < `0` < `A`, which may differ from culture-specific ordering.
+
+### Analysis flow
+
+1. Iterate all objects via `compilation.GetDeclaredApplicationObjectSymbols()` (including permissionset/permissionsetextension)
+2. For each object with a `Permissions` property containing 2+ entries
+3. Check if entries are sorted using `PermissionSyntaxHelper.ArePermissionsSorted`
+4. Report one diagnostic on the `PropertySyntax` node if not sorted
+
+### Key difference from AC0031/AC0032
+
+- Does NOT skip `permissionset`/`permissionsetextension` objects (AC0031/AC0032 skip them)
+- Does NOT skip test codeunits with `TestPermissions = Disabled`
+- Analyzes all permission types (codeunit, page, report, table, tabledata, etc.), not just `tabledata`
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| `RegisterCompilationAction` | Same pattern as AC0032; iterates all objects in one pass |
+| One diagnostic per object, not per entry | The fix reorders the entire list; per-entry diagnostics would be noise |
+| Diagnostic on `PropertySyntax` node | Ensures CodeFix can find the node via `FindNode` + ancestor/descendant traversal |
+| Type+name sorting applied globally (affects AC0031/AC0032) | `ArePermissionsSorted` was refactored from name-only to type+name; consistent behavior across all permission rules |
+| CodeFix always outputs multi-line for 2+ entries | Consistent formatting; single-line permissions are hard to scan |
+| Single entry stays single-line | No formatting benefit from multi-line with one entry |
+| Permission chars casing preserved | Each entry keeps its original `r`/`R`/`rimd`/`RIMD`/`X` casing |
+
+## CodeFix
+
+The `PermissionDeclarationOrderCodeFixProvider` sorts all entries and reformats to multi-line. Supports FixAll via BatchFixer.
+
+### Scenarios
+
+| Scenario | Behavior |
+|---|---|
+| Multi-line, unsorted | Reorder entries, preserve multi-line format with matching indentation |
+| Single-line, 2+ entries, unsorted | Reorder and convert to multi-line format |
+| Single entry | No diagnostic (trivially sorted) |
+
+### Node finding
+
+The CodeFix uses a robust node-finding pattern:
+```csharp
+var propertySyntax = node as PropertySyntax
+    ?? node.FirstAncestorOrSelf<PropertySyntax>()
+    ?? node.DescendantNodes().OfType<PropertySyntax>().FirstOrDefault();
+```
+
+### Shared helpers used
+
+- `PermissionSyntaxHelper.GetSortedPermissions`: Sorts entries by (type, name)
+- `PermissionSyntaxHelper.BuildMultiLinePermissionValue`: Creates multi-line formatted output
+- `PermissionSyntaxHelper.GetEntryIndentation`: Detects existing indentation pattern
+
+## Test coverage
+
+**HasDiagnostic (4 cases):** UnsortedTabledata, UnsortedMixedTypes, UnsortedSingleType, UnsortedCodeunit.
+**NoDiagnostic (4 cases):** AlreadySorted, SingleEntry, NoPermissionsProperty, SortedTabledata.
+**HasFix (4 cases):** ReorderTabledata, ReorderMixedTypes, SingleLineToMultiLine, PreserveCasing.
+
+## Refactoring impact
+
+The `PermissionSyntaxHelper.ArePermissionsSorted` method was changed from name-only to type+name comparison. This affects AC0031's `FindInsertionIndex` (used by its CodeFix to decide alphabetical vs append insertion). The behavioral change is:
+- A list sorted by name but not by type is now detected as "unsorted"
+- AC0031's CodeFix will append (instead of inserting alphabetically) for such lists
+- This is the correct behavior since type+name is the canonical sort order

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -88,6 +88,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0013-field-groups-required` | rule-scoped | AC0013 rule |
 | `ac0026-allow-in-customizations-for-omitted-fields` | rule-scoped | AC0026 rule |
 | `ac0031-table-data-access-requires-permissions` | rule-scoped | AC0031 rule |
+| `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -89,6 +89,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0026-allow-in-customizations-for-omitted-fields` | rule-scoped | AC0026 rule |
 | `ac0031-table-data-access-requires-permissions` | rule-scoped | AC0031 rule |
 | `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
+| `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/ac0045-unused-permissions.instructions.md
+++ b/ac0045-unused-permissions.instructions.md
@@ -1,0 +1,270 @@
+# AC0045: Unused Permissions (Inverse of AC0031)
+
+## Goal
+
+Create a new diagnostic rule that detects **declared permissions that are not needed** by any code in the object. This is the inverse of AC0031 (TableDataAccessRequiresPermissions), which detects table data access not covered by permissions. AC0045 detects permissions that have no corresponding table data access.
+
+The diagnostic ID AC0045 is a placeholder. Check `DiagnosticIds.cs` for the next available ID before implementation.
+
+## Example
+
+```AL
+codeunit 50100 MyCodeunit
+{
+    Permissions = tabledata Customer = rimd,    // ← AC0045: 'i', 'm', 'd' are unused (only Read is needed)
+                  tabledata "Sales Header" = r;  // ← AC0045: no code accesses Sales Header at all
+
+    procedure DoSomething()
+    var
+        Cust: Record Customer;
+    begin
+        Cust.FindFirst(); // Read only
+    end;
+}
+```
+
+## Shared infrastructure in ALCops.Common/Permissions/
+
+The AC0031 rewrite moved all permission logic to `ALCops.Common/Permissions/`. This module is designed for reuse by the inverse rule:
+
+| File | Purpose | Reuse for AC0045 |
+|---|---|---|
+| `DatabaseOperation.cs` | Enum: None, Read, Insert, Modify, Delete | Direct reuse |
+| `MethodOperationMap.cs` | Maps AL method names (Find, Insert, Modify, Delete, etc.) to `DatabaseOperation` | Direct reuse: same method-to-operation mapping |
+| `RequiredPermission.cs` | Record struct: Table + VariableType + Operation + Location | Direct reuse: collect all required permissions |
+| `DeclaredPermissionSet.cs` | Tracks granted RIMD per table | May need extension: track which chars are *used* |
+| `PermissionResolver.cs` | `IsCovered()` checks if a required permission is covered by declarations | **Inverse needed**: collect all *declared* permissions, then diff against *required* |
+| `PermissionSyntaxHelper.cs` | Syntax helpers for multi-line format, sorted insertion, etc. | Reuse for CodeFix (removing entries) |
+| `PermissionTableNameResolver.cs` | Namespace resolution for table names in CodeFix | Reuse for CodeFix |
+
+### PermissionResolver resolution order (AC0031)
+
+AC0031 checks these sources in order when determining if a required permission is covered:
+
+1. **Page SourceTable exemption**: All CRUD on the page's own source table is always exempt
+2. **Table-level `InherentPermissions` property**: Permission granted on the table definition itself
+3. **Method-level `[InherentPermissions]` attribute**: Permission granted per-method
+4. **Object-level `Permissions` property**: The `Permissions = tabledata ...` property
+
+For the inverse rule (AC0045), only source #4 (object-level `Permissions` property) matters. Sources #1-#3 are "implicit" permissions that don't appear in the `Permissions` property, so they can't be "unused" in the same way.
+
+## Architecture approach
+
+### Key difference from AC0031
+
+AC0031 uses **per-invocation analysis** (RegisterOperationAction on each method call). It checks: "does this single call have permission?" and reports immediately if not.
+
+AC0045 requires **whole-object analysis**: collect ALL required permissions across the entire object, then compare against ALL declared permissions. You can't determine if a permission is unused by looking at one call site.
+
+### Recommended analysis strategy
+
+```
+1. Register a CompilationAction or SymbolAction on the object level (codeunit, report, xmlport, query)
+2. For the object:
+   a. Parse the Permissions property → get all declared tabledata entries
+   b. Walk all code in the object → collect all required permissions (table + operation)
+   c. For each declared permission entry:
+      - If the table is not accessed at all → report "entire entry unused"
+      - If the table is accessed but some RIMD chars aren't needed → report "specific chars unused"
+```
+
+### What to collect as "required permissions"
+
+Reuse the same detection logic as AC0031's four analysis callbacks:
+
+| Source | What it detects | Operation |
+|---|---|---|
+| `AnalyzeInvocation` | `Record.Find()`, `Record.Insert()`, etc. | Per method name via `MethodOperationMap` |
+| `AnalyzeReportDataItem` | Report DataItem referencing a table | Read |
+| `AnalyzeQueryDataItem` | Query DataItem referencing a table | Read |
+| `AnalyzeXmlPortNode` | XmlPort table node | Read/Insert/Modify based on Direction + Auto* properties |
+
+Consider extracting the "collect required permissions" logic into a shared helper in `ALCops.Common/Permissions/` so both AC0031 and AC0045 can use it. AC0031 currently reports per-invocation, so this may require refactoring AC0031 to share the collection phase, or AC0045 can duplicate the collection independently.
+
+### Exemptions to carry over from AC0031
+
+- **System tables** (ID > 2,000,000,000): Skip
+- **Temporary records**: Skip (no real DB access)
+- **Test codeunits with `TestPermissions = Disabled`**: Skip
+- **Obsolete symbols**: Skip
+- **Page SourceTable**: The page's own source table implicitly requires RIMD, so `Permissions` entries for it are NOT unused
+- **InherentPermissions**: If a method has `[InherentPermissions(..., Database::"Customer", 'r')]`, that doesn't mean the object-level `Permissions` entry for Customer Read is unused. The object-level entry may still be needed for other methods without the attribute.
+
+### Edge cases to consider
+
+1. **Permissions inherited from base objects**: A page extension might declare permissions for tables accessed in the base page. These are not "unused" but the analyzer can't see the base page's code. Consider skipping extension objects initially (AC0031 CodeFix already skips `ApplicationObjectExtensionSyntax`).
+
+2. **Permissions for indirect access**: A codeunit might declare permissions for tables accessed by called codeunits. The analyzer can only see direct code, not cross-object calls. This is a known limitation. Consider making the severity Info (not Warning) to account for this.
+
+3. **Permission sets referenced via PermissionSet objects**: Out of scope. Only analyze the object's `Permissions` property.
+
+4. **CalcFields/CalcSums**: These access FlowField source tables indirectly. AC0031 doesn't cover these yet either. Track as a known limitation.
+
+5. **Multiple variables of the same table type**: A codeunit might have `Cust1: Record Customer` and `Cust2: Record Customer`. The required operations should be unioned across all variables of the same table.
+
+## Diagnostic properties
+
+| Property | Suggested value |
+|---|---|
+| ID | AC0045 (placeholder, check `DiagnosticIds.cs`) |
+| Category | Design |
+| Severity | Info (not Warning, because of indirect access limitations) |
+| Help URI | `https://alcops.dev/docs/analyzers/applicationcop/ac0045/` |
+
+### Message format options
+
+Two scenarios need different messages:
+
+1. **Entire entry unused**: `Permission 'tabledata {TableName}' is declared but no code accesses this table.`
+2. **Specific chars unused**: `Permission '{UnusedChars}' on 'tabledata {TableName}' is declared but not needed. Only '{UsedChars}' is required.`
+
+## CodeFix
+
+### Scenario 1: Remove entire unused permission entry
+
+Remove the `tabledata "Sales Header" = r` entry from the Permissions list. Reuse `PermissionSyntaxHelper` for format-aware removal (preserve multi-line/single-line style).
+
+### Scenario 2: Reduce permission chars
+
+Change `tabledata Customer = rimd` to `tabledata Customer = r`. Reuse `PermissionSyntaxHelper.NormalizePermissionString()` for canonical ordering.
+
+### Scenario 3: Remove entire Permissions property
+
+If ALL entries are unused, remove the entire `Permissions = ...;` property. This is the simplest case syntactically.
+
+### CodeFix data passing (analyzer → CodeFix)
+
+Use the `CodeFixProperties` record pattern (see `codefix-development.instructions.md`):
+
+```csharp
+#if NET8_0_OR_GREATER
+private sealed record CodeFixProperties(string TableName, string UnusedChars, string UsedChars)
+{
+    public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties) { ... }
+}
+#endif
+```
+
+The analyzer should pass:
+- `TableName`: The table name as it appears in the Permissions property
+- `UnusedChars`: The permission chars to remove (e.g., "imd")
+- `UsedChars`: The permission chars to keep (e.g., "r"), empty if entire entry is unused
+
+## Test scenarios
+
+### HasDiagnostic (permission IS unused)
+
+| Test case | Description |
+|---|---|
+| EntireEntryUnused | `Permissions = tabledata Customer = r` but no code accesses Customer |
+| PartialCharsUnused | `Permissions = tabledata Customer = rimd` but only Read used |
+| MultipleUnusedEntries | Multiple tabledata entries, some used, some not |
+| SingleCharUnused | `tabledata Customer = ri` but only Read used (single 'i' unused) |
+| NoCodeInCodeunit | Empty codeunit with Permissions declared |
+| UnusedOnReport | Report with permissions for table not in any DataItem |
+| UnusedOnXmlPort | XmlPort with permissions for table not accessed |
+| UnusedOnQuery | Query with permissions for table not in any DataItem |
+
+### NoDiagnostic (permission IS needed)
+
+| Test case | Description |
+|---|---|
+| AllPermissionsUsed | All declared RIMD chars have corresponding code |
+| PageSourceTable | Permission for the page's own SourceTable (implicitly needed) |
+| InherentPermissionsOnTable | Table has InherentPermissions, but object-level entry still used by other paths |
+| TemporaryRecord | Temporary record, permissions should be ignored entirely |
+| SystemTable | System table (ID > 2B), no diagnostic |
+| TestCodeunitDisabled | Test codeunit with TestPermissions = Disabled |
+| ReadFromFind | Basic `Record.FindFirst()` matches `= r` |
+| InsertUsed | `Record.Insert()` matches `= i` |
+| ModifyUsed | `Record.Modify()` matches `= m` |
+| DeleteUsed | `Record.Delete()` matches `= d` |
+| MultipleMethodsSameTable | Multiple different operations on same table, all covered |
+| ReportDataItemRead | Report DataItem counts as Read |
+| QueryDataItemRead | Query DataItem counts as Read |
+| XmlPortImport | XmlPort import direction uses Insert+Modify |
+| XmlPortExport | XmlPort export direction uses Read |
+
+### HasFix (CodeFix scenarios)
+
+| Test case | Description |
+|---|---|
+| RemoveEntireEntry | Remove one unused tabledata entry from multi-entry list |
+| RemoveEntireEntryLastItem | Remove the last entry (handle trailing comma) |
+| ReduceChars | Change `= rimd` to `= r` |
+| RemoveEntireProperty | All entries unused, remove entire `Permissions = ...;` |
+| RemoveEntryMultiLine | Multi-line format, remove one entry, preserve formatting |
+| RemoveEntrySingleLine | Single-line format, remove one entry |
+
+## Lessons learned from AC0031
+
+These are patterns and pitfalls discovered during the AC0031 rewrite that apply directly:
+
+### Enum-based comparisons, not string comparisons
+
+Never use `string.Equals(property.Name, "Subtype")`. Always use:
+- `EnumProvider.PropertyKind.Subtype` for property kinds
+- `GetEnumPropertyValue<CodeunitSubtypeKind>()` for property values
+- `EnumProvider.SyntaxKind.*` for syntax kinds
+- See `analyzer-development.instructions.md` for the full list
+
+### SeparatedSyntaxList.Insert() trivia bug
+
+`SeparatedSyntaxList<T>.Insert()` creates comma separators with **default trivia** (space only). For multi-line permission lists, the comma needs trailing `\n` trivia. The fix: after `Insert()`, find the separator missing newline trivia and replace it with a template from an existing separator. See `PermissionSyntaxHelper.InsertIntoMultiLineList()`.
+
+This applies to the CodeFix for AC0045 as well if you need to modify entries in-place.
+
+### PropertySyntax has no PropertyKind enum
+
+At the **syntax** level, `PropertySyntax` only has `.Name.Identifier.ValueText` (string). The `PropertyKind` enum is only on `IPropertySymbol` (semantic/symbol level). In CodeFixes that work with syntax trees, use `nameof(PropertyKind.Permissions)` for compile-time safety.
+
+### Test fixture naming
+
+Use names that sort correctly for alphabetical tests. Avoid MyTableOne/Two/Three (Three < Two alphabetically). Use Alpha/Bravo/Charlie or similar.
+
+### ApprovalTests masking real errors
+
+`RoslynTestKit.Verify.CodeAction` tries to load `ApprovalTests` assembly for diff reporting. If missing, `FileNotFoundException` is thrown BEFORE the actual test error. If CodeFix tests fail with assembly errors, temporarily add `ApprovalTests 3.0.0` NuGet to see real diffs, then remove it.
+
+### netstandard2.1 compatibility
+
+- Records need `#if NETSTANDARD2_1` / `#if NET8_0_OR_GREATER` dual definitions
+- `System.Text.Json` unavailable on netstandard2.1 (use `Newtonsoft.Json`)
+- `System.Collections.Immutable` needs explicit NuGet reference
+- See `netstandard21-compatibility.instructions.md`
+
+## Files to create/modify
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `src/ALCops.ApplicationCop/Analyzers/UnusedPermissions.cs` | Analyzer |
+| `src/ALCops.ApplicationCop/CodeFixes/UnusedPermissions.cs` | CodeFix |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/UnusedPermissions.cs` | Test class |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/HasDiagnostic/*/current.al` | Test fixtures |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/NoDiagnostic/*.al` | Test fixtures |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/HasFix/*/current.al` + `expected.al` | Test fixtures |
+| `.github/instructions/ac0045-unused-permissions.instructions.md` | Rule instruction file |
+| `../alcops.dev/content/docs/analyzers/ApplicationCop/AC0045.md` | Documentation page |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/ALCops.ApplicationCop/DiagnosticIds.cs` | Add `UnusedPermissions = "AC0045"` |
+| `src/ALCops.ApplicationCop/DiagnosticDescriptors.cs` | Add descriptor |
+| `src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx` | Add Title, MessageFormat, Description, CodeAction strings |
+| `ALCops.Common/Permissions/` | Possibly extract shared "collect required permissions" helper |
+
+## Open questions to discuss before implementation
+
+1. **Should the analyzer scan the whole object in one pass, or use per-invocation collection with a final symbol-level check?** A CompilationEndAction could aggregate per-invocation results, but this adds complexity. A single SymbolAction on the object that walks all descendants may be simpler.
+
+2. **How to handle extension objects?** The extension can't see what the base object accesses. Options: skip extensions entirely (simplest), or only flag permissions for tables the extension itself declares variables for.
+
+3. **Should we refactor AC0031 to share the "collect required permissions" logic, or let AC0045 have its own collection?** Sharing reduces duplication but risks coupling. AC0031's per-invocation model is different from AC0045's whole-object model.
+
+4. **Should we report one diagnostic per unused char, or one diagnostic per unused entry?** Per-entry with the full list of unused chars seems cleaner (fewer diagnostics, one CodeFix per entry).
+
+5. **What about permissions for tables accessed via Codeunit.Run or Event subscribers?** These are indirect and the analyzer can't trace them. Accept this as a known limitation and use Info severity.

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/current.al
@@ -1,0 +1,36 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata Charlie = r,
+                  tabledata Delta = r;
+
+    procedure Test()
+    var
+        Alpha: Record Alpha;
+    begin
+        [|Alpha.FindFirst();|]
+    end;
+}
+
+table 50000 Alpha
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 Charlie
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50002 Delta
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/expected.al
@@ -1,0 +1,37 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata Alpha = r,
+                  tabledata Charlie = r,
+                  tabledata Delta = r;
+
+    procedure Test()
+    var
+        Alpha: Record Alpha;
+    begin
+        Alpha.FindFirst();
+    end;
+}
+
+table 50000 Alpha
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 Charlie
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50002 Delta
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
@@ -82,6 +82,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("AddEntryMultiLine")]
         [TestCase("AddEntrySingleLine")]
         [TestCase("AddEntryAlphabetical")]
+        [TestCase("AddEntryAlphabeticalFirst")]
         [TestCase("AddEntryAppend")]
         public async Task HasFix(string testCase)
         {

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/EntireEntryUnused.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/EntireEntryUnused.al
@@ -1,0 +1,22 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/MultipleUnusedEntries.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/MultipleUnusedEntries.al
@@ -1,0 +1,37 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|],
+                  [|tabledata OtherTable = r|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/NoCodeInCodeunit.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/NoCodeInCodeunit.al
@@ -1,0 +1,18 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/PartialCharsUnused.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/PartialCharsUnused.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/TemporaryRecord.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/TemporaryRecord.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnQuery.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnQuery.al
@@ -1,0 +1,42 @@
+query 50000 MyQuery
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    elements
+    {
+        dataitem(MyTable; MyTable)
+        {
+            column(MyField; MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnReport.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnReport.al
@@ -1,0 +1,39 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnXmlPort.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnXmlPort.al
@@ -1,0 +1,45 @@
+xmlport 50000 MyXmlPort
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    schema
+    {
+        textelement(Root)
+        {
+            tableelement(MyTable; MyTable)
+            {
+                fieldelement(MyField; MyTable.MyField)
+                {
+                }
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/current.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/expected.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata MyTable = r;
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/current.al
@@ -1,0 +1,40 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|],
+                  tabledata OtherTable = r;
+
+    trigger OnRun()
+    var
+        OtherTable: Record OtherTable;
+    begin
+        OtherTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/expected.al
@@ -1,0 +1,39 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata OtherTable = r;
+
+    trigger OnRun()
+    var
+        OtherTable: Record OtherTable;
+    begin
+        OtherTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/current.al
@@ -1,0 +1,22 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/expected.al
@@ -1,0 +1,21 @@
+codeunit 50000 MyCodeunit
+{
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/AllPermissionsUsed.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/AllPermissionsUsed.al
@@ -1,0 +1,28 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+        MyTable.Insert();
+        MyTable.Modify();
+        MyTable.Delete();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PageSourceTable.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PageSourceTable.al
@@ -1,0 +1,29 @@
+page 50000 MyPage
+{
+    SourceTable = MyTable;
+    Permissions = [|tabledata MyTable = rimd|];
+
+    layout
+    {
+        area(Content)
+        {
+            field(MyField; Rec.MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSet.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSet.al
@@ -1,0 +1,36 @@
+permissionset 50000 MyPermissionSet
+{
+    Caption = '', Locked = true;
+    Assignable = true;
+    Permissions =
+        [|tabledata MyTable = RIMD|],
+        [|tabledata MyOtherTable = R|];
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 MyOtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSetExtension.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSetExtension.al
@@ -1,0 +1,41 @@
+permissionsetextension 50000 MyPermissionSetExt extends MyPermissionSet
+{
+    Permissions =
+        [|tabledata MyOtherTable = RIMD|];
+}
+
+permissionset 50000 MyPermissionSet
+{
+    Caption = '', Locked = true;
+    Assignable = true;
+    Permissions =
+        tabledata MyTable = RIMD;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 MyOtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/QueryDataItemRead.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/QueryDataItemRead.al
@@ -1,0 +1,28 @@
+query 50000 MyQuery
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    elements
+    {
+        dataitem(MyTable; MyTable)
+        {
+            column(MyField; MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReadUsed.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReadUsed.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemRead.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemRead.al
@@ -1,0 +1,25 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/TestCodeunitDisabled.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/TestCodeunitDisabled.al
@@ -1,0 +1,24 @@
+codeunit 50000 MyCodeunit
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -1,0 +1,98 @@
+using ALCops.ApplicationCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.ApplicationCop.Test
+{
+    public class TableDataAccessUnusedPermissions : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.TableDataAccessUnusedPermissions _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.TableDataAccessUnusedPermissions>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(TableDataAccessUnusedPermissions)));
+        }
+
+        [Test]
+        [TestCase("EntireEntryUnused")]
+        [TestCase("PartialCharsUnused")]
+        [TestCase("MultipleUnusedEntries")]
+        [TestCase("NoCodeInCodeunit")]
+        [TestCase("UnusedOnReport")]
+        [TestCase("UnusedOnQuery")]
+        [TestCase("UnusedOnXmlPort")]
+        [TestCase("TemporaryRecord")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataAccessUnusedPermissions);
+        }
+
+        [Test]
+        [TestCase("AllPermissionsUsed")]
+        [TestCase("PageSourceTable")]
+        [TestCase("TestCodeunitDisabled")]
+        [TestCase("ReadUsed")]
+        [TestCase("ReportDataItemRead")]
+        [TestCase("QueryDataItemRead")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataAccessUnusedPermissions);
+        }
+
+        [Test]
+        [TestCase("RemoveEntireEntry")]
+        [TestCase("RemoveEntireProperty")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<TableDataAccessUnusedPermissionsCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry);
+        }
+
+        [Test]
+        [TestCase("ReduceChars")]
+        public async Task HasFixPartialChars(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<TableDataAccessUnusedPermissionsCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars);
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -48,6 +48,13 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("PermissionSetExtension")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["PermissionSetExtension"],
+                testCase,
+                "13.0",
+                "No support for tableextensions when target itself is already declared in the same module");
+
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -44,6 +44,8 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("ReadUsed")]
         [TestCase("ReportDataItemRead")]
         [TestCase("QueryDataItemRead")]
+        [TestCase("PermissionSet")]
+        [TestCase("PermissionSetExtension")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -426,6 +426,21 @@
   <data name="UseReturnValueForDatabaseReadMethodsDescription" xml:space="preserve">
     <value>Database read methods, like Record.Get(), returns a boolean indicating whether the record was successfully retrieved. Failing to use this return value can lead to uncaught errors, poor error handling, and a lack of actionable feedback for users when something goes wrong.</value>
   </data>
+  <data name="TableDataAccessUnusedPermissionsTitle" xml:space="preserve">
+    <value>Unused permission declared</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsEntireEntryMessageFormat" xml:space="preserve">
+    <value>Permission 'tabledata {0}' is declared but no code in this object accesses table '{0}'.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsPartialCharsMessageFormat" xml:space="preserve">
+    <value>Permission '{0}' on 'tabledata {1}' is not needed. Only '{2}' is required.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsDescription" xml:space="preserve">
+    <value>The Permissions property declares table data access that is not used by any code in this object. Unused permissions are dead code and should be removed or reduced to match actual usage. The Permissions property only applies to direct table access within the object itself; it does not flow through to called objects.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
+    <value>ALCops: Remove unused permission for table '{0}'</value>
+  </data>
   <data name="ZeroEnumValueReservedForEmptyTitle" xml:space="preserve">
     <value>Reserve Enum value zero (0) for empty value</value>
   </data>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -444,6 +444,9 @@
   <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Remove unused permission for table '{0}'</value>
   </data>
+  <data name="TableDataAccessUnusedPermissionsFixAllCodeAction" xml:space="preserve">
+    <value>ALCops: Remove all unused permissions</value>
+  </data>
   <data name="ZeroEnumValueReservedForEmptyTitle" xml:space="preserve">
     <value>Reserve Enum value zero (0) for empty value</value>
   </data>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -363,9 +363,6 @@
   <data name="TableDataAccessRequiresPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Add missing permission '{0}' for table '{1}'</value>
   </data>
-  <data name="TableDataAccessRequiresPermissionsFixAllCodeAction" xml:space="preserve">
-    <value>ALCops: Add all missing permissions</value>
-  </data>
   <data name="TableDataPerCompanyDeclarationTitle" xml:space="preserve">
     <value>DataPerCompany must be explicitly set on table objects</value>
   </data>
@@ -443,9 +440,6 @@
   </data>
   <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Remove unused permission for table '{0}'</value>
-  </data>
-  <data name="TableDataAccessUnusedPermissionsFixAllCodeAction" xml:space="preserve">
-    <value>ALCops: Remove all unused permissions</value>
   </data>
   <data name="ZeroEnumValueReservedForEmptyTitle" xml:space="preserve">
     <value>Reserve Enum value zero (0) for empty value</value>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -363,6 +363,9 @@
   <data name="TableDataAccessRequiresPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Add missing permission '{0}' for table '{1}'</value>
   </data>
+  <data name="TableDataAccessRequiresPermissionsFixAllCodeAction" xml:space="preserve">
+    <value>ALCops: Add all missing permissions</value>
+  </data>
   <data name="TableDataPerCompanyDeclarationTitle" xml:space="preserve">
     <value>DataPerCompany must be explicitly set on table objects</value>
   </data>

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
@@ -4,7 +4,6 @@ using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 
 namespace ALCops.ApplicationCop.Analyzers;
 

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
@@ -5,7 +5,6 @@ using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace ALCops.ApplicationCop.Analyzers;
 
@@ -40,52 +39,22 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
         if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
             return;
 
-        if (invocation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
-            return;
-
-        var operation = MethodOperationMap.GetOperation(invocation.TargetMethod.Name);
-        if (operation == DatabaseOperation.None)
-            return;
-
-        // Resolve the record type: either from the instance (explicit call) or from the containing table (implicit self-call)
-        IRecordTypeSymbol? recordType;
-        ITableTypeSymbol? tableType;
-
-        if (invocation.Instance is not null)
-        {
-            // Explicit call: MyTable.Modify()
-            recordType = invocation.Instance.Type as IRecordTypeSymbol;
-        }
-        else
-        {
-            // Implicit self-call: Modify() or this.Modify() inside a table object
-            recordType = ctx.ContainingSymbol.ContainingType as IRecordTypeSymbol;
-        }
-
-        if (recordType is null || recordType.Temporary)
-            return;
-
-        tableType = recordType.OriginalDefinition as ITableTypeSymbol;
-        if (tableType is null)
-            return;
-
-        if (IsSystemTable(tableType))
+        var required = RequiredPermissionDetector.TryGetFromInvocation(invocation, ctx.ContainingSymbol);
+        if (required is null)
             return;
 
         var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
 
-        if (IsTestCodeunitWithPermissionsDisabled(containingObject))
+        if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(containingObject))
             return;
 
         var pageContext = PermissionResolver.GetPageContext(containingObject);
         var containingMethod = ctx.ContainingSymbol as IMethodSymbol;
 
-        var required = new RequiredPermission(tableType, recordType, operation, invocation.Syntax.GetLocation());
-
-        if (PermissionResolver.IsCovered(required, containingObject, containingMethod, pageContext))
+        if (PermissionResolver.IsCovered(required.Value, containingObject, containingMethod, pageContext))
             return;
 
-        ReportDiagnostic(ctx.ReportDiagnostic, required);
+        ReportDiagnostic(ctx.ReportDiagnostic, required.Value);
     }
 
     private void AnalyzeReportDataItem(SymbolAnalysisContext ctx)
@@ -93,29 +62,16 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
         if (ctx.IsObsolete())
             return;
 
-        if (ctx.Symbol.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is true)
-            return;
-
-        if (ctx.Symbol is not IReportDataItemSymbol reportDataItem)
-            return;
-
-        if (reportDataItem.GetTypeSymbol() is not IRecordTypeSymbol recordType)
-            return;
-
-        if (recordType.Temporary)
-            return;
-
-        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+        var required = RequiredPermissionDetector.TryGetFromReportDataItem(ctx.Symbol);
+        if (required is null)
             return;
 
         var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
 
-        var required = new RequiredPermission(tableType, recordType, DatabaseOperation.Read, ctx.Symbol.GetLocation());
-
-        if (PermissionResolver.IsCovered(required, containingObject, containingMethod: null, pageContext: null))
+        if (PermissionResolver.IsCovered(required.Value, containingObject, containingMethod: null, pageContext: null))
             return;
 
-        ReportDiagnostic(ctx.ReportDiagnostic, required);
+        ReportDiagnostic(ctx.ReportDiagnostic, required.Value);
     }
 
     private void AnalyzeQueryDataItem(SymbolAnalysisContext ctx)
@@ -123,18 +79,16 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
         if (ctx.IsObsolete())
             return;
 
-        var targetSymbol = ((IQueryDataItemSymbol)ctx.Symbol).GetTypeSymbol();
-        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+        var required = RequiredPermissionDetector.TryGetFromQueryDataItem(ctx.Symbol);
+        if (required is null)
             return;
 
         var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
 
-        var required = new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Read, ctx.Symbol.GetLocation());
-
-        if (PermissionResolver.IsCovered(required, containingObject, containingMethod: null, pageContext: null))
+        if (PermissionResolver.IsCovered(required.Value, containingObject, containingMethod: null, pageContext: null))
             return;
 
-        ReportDiagnostic(ctx.ReportDiagnostic, required);
+        ReportDiagnostic(ctx.ReportDiagnostic, required.Value);
     }
 
     private void AnalyzeXmlPortNode(SymbolAnalysisContext ctx)
@@ -142,50 +96,15 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
         if (ctx.IsObsolete())
             return;
 
-        var nodeSymbol = (IXmlPortNodeSymbol)ctx.Symbol.OriginalDefinition;
-        if (nodeSymbol.SourceTypeKind != EnumProvider.XmlPortSourceTypeKind.Table)
-            return;
+        var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
 
-        var targetSymbol = nodeSymbol.GetTypeSymbol();
-        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
-            return;
-
-        var xmlPort = (IXmlPortTypeSymbol)ctx.Symbol.GetContainingObjectTypeSymbol();
-        var containingObject = xmlPort as IApplicationObjectTypeSymbol;
-
-        var direction = ResolveXmlPortDirection(xmlPort);
-        var autoReplace = GetXmlPortNodeBoolProperty(ctx.Symbol, EnumProvider.PropertyKind.AutoReplace) ?? true;
-        var autoUpdate = GetXmlPortNodeBoolProperty(ctx.Symbol, EnumProvider.PropertyKind.AutoUpdate) ?? true;
-        var autoSave = GetXmlPortNodeBoolProperty(ctx.Symbol, EnumProvider.PropertyKind.AutoSave) ?? true;
-
-        var location = ctx.Symbol.GetLocation();
-
-        if (direction == EnumProvider.DirectionKind.Import || direction == EnumProvider.DirectionKind.Both)
+        foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(ctx.Symbol))
         {
-            if (autoReplace || autoUpdate)
-                CheckAndReport(containingObject, targetSymbol, tableType, DatabaseOperation.Modify, location, ctx.ReportDiagnostic);
-            if (autoSave)
-                CheckAndReport(containingObject, targetSymbol, tableType, DatabaseOperation.Insert, location, ctx.ReportDiagnostic);
+            if (PermissionResolver.IsCovered(required, containingObject, containingMethod: null, pageContext: null))
+                continue;
+
+            ReportDiagnostic(ctx.ReportDiagnostic, required);
         }
-
-        if (direction == EnumProvider.DirectionKind.Export || direction == EnumProvider.DirectionKind.Both)
-            CheckAndReport(containingObject, targetSymbol, tableType, DatabaseOperation.Read, location, ctx.ReportDiagnostic);
-    }
-
-    private static void CheckAndReport(
-        IApplicationObjectTypeSymbol? containingObject,
-        ITypeSymbol variableType,
-        ITableTypeSymbol tableType,
-        DatabaseOperation operation,
-        Microsoft.Dynamics.Nav.CodeAnalysis.Text.Location location,
-        Action<Diagnostic> reportDiagnostic)
-    {
-        var required = new RequiredPermission(tableType, variableType, operation, location);
-
-        if (PermissionResolver.IsCovered(required, containingObject, containingMethod: null, pageContext: null))
-            return;
-
-        ReportDiagnostic(reportDiagnostic, required);
     }
 
     private static void ReportDiagnostic(Action<Diagnostic> report, RequiredPermission required)
@@ -204,32 +123,5 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
             properties,
             permissionChar,
             required.VariableType.Name));
-    }
-
-    private static bool IsSystemTable(ITableTypeSymbol table) => table.Id > 2000000000;
-
-    private static bool IsTestCodeunitWithPermissionsDisabled(IApplicationObjectTypeSymbol? containingObject)
-    {
-        if (containingObject is not ICodeunitTypeSymbol codeunit)
-            return false;
-
-        var subtype = codeunit.GetEnumPropertyValue<CodeunitSubtypeKind>(EnumProvider.PropertyKind.Subtype);
-        if (subtype is null || subtype != EnumProvider.CodeunitSubtypeKind.Test)
-            return false;
-
-        var testPermissions = codeunit.GetEnumPropertyValue<TestPermissionsKind>(EnumProvider.PropertyKind.TestPermissions);
-        return testPermissions is not null && testPermissions == EnumProvider.TestPermissionsKind.Disabled;
-    }
-
-    private static DirectionKind ResolveXmlPortDirection(IXmlPortTypeSymbol xmlPort)
-    {
-        var direction = xmlPort.GetEnumPropertyValue<DirectionKind>(EnumProvider.PropertyKind.Direction);
-        return direction ?? EnumProvider.DirectionKind.Both;
-    }
-
-    private static bool? GetXmlPortNodeBoolProperty(ISymbol nodeSymbol, PropertyKind propertyKind)
-    {
-        return (bool?)nodeSymbol.Properties
-            .FirstOrDefault(p => p.PropertyKind == propertyKind)?.Value;
     }
 }

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
@@ -36,14 +36,18 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
 
     private void AnalyzeInvocation(OperationAnalysisContext ctx)
     {
+        var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
+
+        if (containingObject?.Kind == EnumProvider.SymbolKind.PermissionSet
+            || containingObject?.Kind == EnumProvider.SymbolKind.PermissionSetExtension)
+            return;
+
         if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
             return;
 
         var required = RequiredPermissionDetector.TryGetFromInvocation(invocation, ctx.ContainingSymbol);
         if (required is null)
             return;
-
-        var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
 
         if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(containingObject))
             return;

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -1,9 +1,11 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Permissions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 
@@ -19,10 +21,173 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.RegisterCompilationAction(AnalyzeCompilation);
+        context.RegisterCompilationStartAction(OnCompilationStart);
     }
 
-    private void AnalyzeCompilation(CompilationAnalysisContext ctx)
+    private void OnCompilationStart(CompilationStartAnalysisContext compilationCtx)
+    {
+        var accumulator = new ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>>();
+
+        compilationCtx.RegisterCodeBlockAction(ctx => CollectFromCodeBlock(ctx, accumulator));
+        compilationCtx.RegisterSymbolAction(
+            ctx => CollectFromReportDataItem(ctx, accumulator),
+            EnumProvider.SymbolKind.ReportDataItem);
+        compilationCtx.RegisterSymbolAction(
+            ctx => CollectFromQueryDataItem(ctx, accumulator),
+            EnumProvider.SymbolKind.QueryDataItem);
+        compilationCtx.RegisterSymbolAction(
+            ctx => CollectFromXmlPortNode(ctx, accumulator),
+            EnumProvider.SymbolKind.XmlPortNode);
+        compilationCtx.RegisterCompilationEndAction(ctx => AnalyzeCompilation(ctx, accumulator));
+    }
+
+    private static string GetObjectKey(IApplicationObjectTypeSymbol obj)
+        => string.Concat(obj.Kind.ToString(), ":", obj.Id.ToString());
+
+    private static void AddRequiredPermission(
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator,
+        IApplicationObjectTypeSymbol obj,
+        RequiredPermission permission)
+    {
+        var key = GetObjectKey(obj);
+        var bag = accumulator.GetOrAdd(key, _ => new ConcurrentBag<RequiredPermission>());
+        bag.Add(permission);
+    }
+
+    /// <summary>
+    /// Collects required database permissions from invocations within a code block.
+    /// Uses GetOperation on the full method body (one semantic call per method),
+    /// then walks the operation tree in-memory via OperationWalker.
+    /// </summary>
+    private static void CollectFromCodeBlock(
+        CodeBlockAnalysisContext context,
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
+    {
+        if (context.IsObsolete() ||
+            context.CodeBlock is not MethodOrTriggerDeclarationSyntax methodOrTrigger)
+            return;
+
+        var containingObject = context.OwningSymbol?.GetContainingApplicationObjectTypeSymbol();
+        if (containingObject is null)
+            return;
+
+        if (containingObject.GetProperty(EnumProvider.PropertyKind.Permissions) is null)
+            return;
+
+        var body = methodOrTrigger.Body;
+        if (body is null)
+            return;
+
+        // Syntax-level pre-filter: scan for invocations with DB method names
+        // before the expensive GetOperation call. Most methods have no DB calls.
+        bool hasPossibleDbInvocation = false;
+        body.WalkDescendantsAndPerformAction(node =>
+        {
+            if (hasPossibleDbInvocation)
+                return;
+
+            if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
+                return;
+
+            var invocationSyntax = (InvocationExpressionSyntax)node;
+            string? methodName = invocationSyntax.Expression switch
+            {
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+                IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
+                _ => null
+            };
+
+            if (methodName is not null && MethodOperationMap.GetOperation(methodName) != DatabaseOperation.None)
+                hasPossibleDbInvocation = true;
+        });
+
+        if (!hasPossibleDbInvocation)
+            return;
+
+        var operation = context.SemanticModel.GetOperation(body, context.CancellationToken);
+        if (operation is null)
+            return;
+
+        var walker = new InvocationCollectorWalker(accumulator, containingObject, context.OwningSymbol!, context.CancellationToken);
+        walker.Visit(operation);
+    }
+
+    private sealed class InvocationCollectorWalker : OperationWalker
+    {
+        private readonly ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> _accumulator;
+        private readonly IApplicationObjectTypeSymbol _containingObject;
+        private readonly ISymbol _containingSymbol;
+        private readonly CancellationToken _cancellationToken;
+
+        public InvocationCollectorWalker(
+            ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator,
+            IApplicationObjectTypeSymbol containingObject,
+            ISymbol containingSymbol,
+            CancellationToken cancellationToken)
+        {
+            _accumulator = accumulator;
+            _containingObject = containingObject;
+            _containingSymbol = containingSymbol;
+            _cancellationToken = cancellationToken;
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, _containingSymbol);
+            if (required is not null)
+                AddRequiredPermission(_accumulator, _containingObject, required.Value);
+
+            base.VisitInvocationExpression(operation);
+        }
+    }
+
+    private static void CollectFromReportDataItem(
+        SymbolAnalysisContext ctx,
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
+    {
+        var required = RequiredPermissionDetector.TryGetFromReportDataItem(ctx.Symbol);
+        if (required is null)
+            return;
+
+        var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
+        if (containingObject is null)
+            return;
+
+        AddRequiredPermission(accumulator, containingObject, required.Value);
+    }
+
+    private static void CollectFromQueryDataItem(
+        SymbolAnalysisContext ctx,
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
+    {
+        var required = RequiredPermissionDetector.TryGetFromQueryDataItem(ctx.Symbol);
+        if (required is null)
+            return;
+
+        var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
+        if (containingObject is null)
+            return;
+
+        AddRequiredPermission(accumulator, containingObject, required.Value);
+    }
+
+    private static void CollectFromXmlPortNode(
+        SymbolAnalysisContext ctx,
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
+    {
+        var containingObject = ctx.Symbol.GetContainingApplicationObjectTypeSymbol();
+        if (containingObject is null)
+            return;
+
+        foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(ctx.Symbol))
+            AddRequiredPermission(accumulator, containingObject, required);
+    }
+
+    private static void AnalyzeCompilation(
+        CompilationAnalysisContext ctx,
+        ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
     {
         var compilation = ctx.Compilation;
 
@@ -49,7 +214,9 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             if (declaredEntries.Count == 0)
                 continue;
 
-            var requiredPermissions = CollectRequiredPermissions(obj, compilation, ctx.CancellationToken);
+            var requiredPermissions = accumulator.TryGetValue(GetObjectKey(obj), out var bag)
+                ? bag.ToList()
+                : new List<RequiredPermission>();
             var pageContext = PermissionResolver.GetPageContext(obj);
 
             foreach (var entry in declaredEntries)
@@ -153,145 +320,6 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Walks all code in the object and collects required database permissions.
-    /// </summary>
-    private static List<RequiredPermission> CollectRequiredPermissions(
-        IApplicationObjectTypeSymbol obj,
-        Compilation compilation,
-        CancellationToken cancellationToken)
-    {
-        var result = new List<RequiredPermission>();
-
-        CollectFromInvocations(obj, compilation, result, cancellationToken);
-        CollectFromReportDataItems(obj, result);
-        CollectFromQueryDataItems(obj, result);
-        CollectFromXmlPortNodes(obj, result);
-
-        return result;
-    }
-
-    private static void CollectFromInvocations(
-        IApplicationObjectTypeSymbol obj,
-        Compilation compilation,
-        List<RequiredPermission> result,
-        CancellationToken cancellationToken)
-    {
-        var syntaxRef = obj.DeclaringSyntaxReference;
-        if (syntaxRef is null)
-            return;
-
-        var syntaxNode = syntaxRef.GetSyntax();
-        var syntaxTree = syntaxNode.SyntaxTree;
-        if (syntaxTree is null)
-            return;
-
-        var semanticModel = compilation.GetSemanticModel(syntaxTree);
-
-        syntaxNode.WalkDescendantsAndPerformAction(node =>
-        {
-            if (cancellationToken.IsCancellationRequested)
-                return;
-
-            if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
-                return;
-
-            var operation = semanticModel.GetOperation(node, cancellationToken) as IInvocationExpression;
-            if (operation is null)
-                return;
-
-            var containingSymbol = semanticModel.GetDeclaredSymbol(
-                FindContainingMethodOrTrigger(node), cancellationToken);
-
-            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, containingSymbol ?? obj);
-            if (required is not null)
-                result.Add(required.Value);
-        });
-    }
-
-    private static SyntaxNode FindContainingMethodOrTrigger(SyntaxNode node)
-    {
-        var current = node.Parent;
-        while (current is not null)
-        {
-            if (current.IsKind(EnumProvider.SyntaxKind.MethodDeclaration)
-                || current.IsKind(EnumProvider.SyntaxKind.TriggerDeclaration))
-                return current;
-            current = current.Parent;
-        }
-
-        return node;
-    }
-
-    private static void CollectFromReportDataItems(
-        IApplicationObjectTypeSymbol obj,
-        List<RequiredPermission> result)
-    {
-        if (obj is not IReportTypeSymbol report)
-            return;
-
-        var dataItems = new List<ISymbol>();
-        CollectReportDataItemsRecursively(report, dataItems);
-
-        foreach (var dataItem in dataItems)
-        {
-            var required = RequiredPermissionDetector.TryGetFromReportDataItem(dataItem);
-            if (required is not null)
-                result.Add(required.Value);
-        }
-    }
-
-    /// <summary>
-    /// Recursively collects all report data item symbols, including nested ones.
-    /// </summary>
-    private static void CollectReportDataItemsRecursively(IContainerSymbol container, List<ISymbol> result)
-    {
-        foreach (var member in container.GetMembers())
-        {
-            if (member.Kind == EnumProvider.SymbolKind.ReportDataItem)
-            {
-                result.Add(member);
-                if (member is IContainerSymbol nestedContainer)
-                    CollectReportDataItemsRecursively(nestedContainer, result);
-            }
-        }
-    }
-
-    private static void CollectFromQueryDataItems(
-        IApplicationObjectTypeSymbol obj,
-        List<RequiredPermission> result)
-    {
-        if (obj is not IQueryTypeSymbol query)
-            return;
-
-        foreach (var member in query.GetMembers())
-        {
-            if (member.Kind != EnumProvider.SymbolKind.QueryDataItem)
-                continue;
-
-            var required = RequiredPermissionDetector.TryGetFromQueryDataItem(member);
-            if (required is not null)
-                result.Add(required.Value);
-        }
-    }
-
-    private static void CollectFromXmlPortNodes(
-        IApplicationObjectTypeSymbol obj,
-        List<RequiredPermission> result)
-    {
-        if (obj is not IXmlPortTypeSymbol xmlPort)
-            return;
-
-        foreach (var member in xmlPort.GetMembers())
-        {
-            if (member.Kind != EnumProvider.SymbolKind.XmlPortNode)
-                continue;
-
-            foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(member))
-                result.Add(required);
-        }
     }
 
     /// <summary>

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -1,0 +1,355 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
+
+namespace ALCops.ApplicationCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(
+            DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry,
+            DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    private void AnalyzeCompilation(CompilationAnalysisContext ctx)
+    {
+        var compilation = ctx.Compilation;
+
+        foreach (var obj in compilation.GetDeclaredApplicationObjectSymbols())
+        {
+            ctx.CancellationToken.ThrowIfCancellationRequested();
+
+            if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(obj))
+                continue;
+
+            var permissionsProperty = obj.GetProperty(EnumProvider.PropertyKind.Permissions);
+            if (permissionsProperty is null)
+                continue;
+
+            var permissionsSyntax = permissionsProperty.GetPropertyValueSyntax<PermissionPropertyValueSyntax>();
+            if (permissionsSyntax is null)
+                continue;
+
+            var declaredEntries = permissionsSyntax.PermissionProperties;
+            if (declaredEntries.Count == 0)
+                continue;
+
+            var requiredPermissions = CollectRequiredPermissions(obj, compilation, ctx.CancellationToken);
+            var pageContext = PermissionResolver.GetPageContext(obj);
+
+            foreach (var entry in declaredEntries)
+            {
+                if (!entry.ObjectType.IsKind(EnumProvider.SyntaxKind.TableDataKeyword))
+                    continue;
+
+                AnalyzePermissionEntry(entry, requiredPermissions, pageContext, ctx.ReportDiagnostic);
+            }
+        }
+    }
+
+    private static void AnalyzePermissionEntry(
+        PermissionSyntax entry,
+        List<RequiredPermission> requiredPermissions,
+        IPageBaseTypeSymbol? pageContext,
+        Action<Diagnostic> reportDiagnostic)
+    {
+        var identifier = entry.ObjectReference.Identifier;
+
+        // Page SourceTable exemption: the page's own source table implicitly needs permissions
+        if (pageContext?.RelatedTable is not null
+            && PermissionMatchesTable(identifier, pageContext.RelatedTable))
+            return;
+
+        // Find all required permissions that match this declared entry
+        var matchingOps = new DeclaredPermissionSet();
+        bool hasMatch = false;
+
+        foreach (var required in requiredPermissions)
+        {
+            if (PermissionMatchesTable(identifier, required.Table))
+            {
+                matchingOps.Grant(required.Operation);
+                hasMatch = true;
+            }
+        }
+
+        var declaredChars = entry.Permissions.ValueText ?? string.Empty;
+        var tableName = GetDisplayTableName(entry);
+
+        if (!hasMatch)
+        {
+            // Table not accessed at all
+            var normalizedDeclared = NormalizePermissionChars(declaredChars);
+            var properties = BuildProperties(tableName, normalizedDeclared, string.Empty);
+            reportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry,
+                entry.GetLocation(),
+                properties,
+                tableName));
+            return;
+        }
+
+        var unusedChars = GetUnusedChars(declaredChars, matchingOps);
+        if (unusedChars.Length > 0)
+        {
+            var usedChars = GetUsedChars(declaredChars, matchingOps);
+            var properties = BuildProperties(tableName, unusedChars, usedChars);
+            reportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars,
+                entry.GetLocation(),
+                properties,
+                unusedChars,
+                tableName,
+                usedChars));
+        }
+    }
+
+    /// <summary>
+    /// Matches a permission entry's table reference against a table type symbol.
+    /// Handles IdentifierNameSyntax, QualifiedNameSyntax, and ObjectIdSyntax.
+    /// </summary>
+    private static bool PermissionMatchesTable(SyntaxNode identifier, ITableTypeSymbol table)
+    {
+        if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
+        {
+            var name = ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier();
+            return name is not null && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
+        {
+            if (int.TryParse(((ObjectIdSyntax)identifier).Value.ValueText, out var objectId))
+                return objectId == table.Id;
+            return false;
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.QualifiedName)
+        {
+            var qualified = (QualifiedNameSyntax)identifier;
+            var qualifier = qualified.Left.GetText().ToString();
+            var name = qualified.Right.Identifier.ValueText?.UnquoteIdentifier();
+
+            if (name is null)
+                return false;
+
+            var tableNamespace = table.OriginalDefinition.GetContainingNamespaceQualifiedNameWithReflection();
+            return qualifier.Equals(tableNamespace, StringComparison.OrdinalIgnoreCase)
+                && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Walks all code in the object and collects required database permissions.
+    /// </summary>
+    private static List<RequiredPermission> CollectRequiredPermissions(
+        IApplicationObjectTypeSymbol obj,
+        Compilation compilation,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<RequiredPermission>();
+
+        CollectFromInvocations(obj, compilation, result, cancellationToken);
+        CollectFromReportDataItems(obj, result);
+        CollectFromQueryDataItems(obj, result);
+        CollectFromXmlPortNodes(obj, result);
+
+        return result;
+    }
+
+    private static void CollectFromInvocations(
+        IApplicationObjectTypeSymbol obj,
+        Compilation compilation,
+        List<RequiredPermission> result,
+        CancellationToken cancellationToken)
+    {
+        var syntaxRef = obj.DeclaringSyntaxReference;
+        if (syntaxRef is null)
+            return;
+
+        var syntaxNode = syntaxRef.GetSyntax();
+        var syntaxTree = syntaxNode.SyntaxTree;
+        if (syntaxTree is null)
+            return;
+
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        syntaxNode.WalkDescendantsAndPerformAction(node =>
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
+                return;
+
+            var operation = semanticModel.GetOperation(node, cancellationToken) as IInvocationExpression;
+            if (operation is null)
+                return;
+
+            var containingSymbol = semanticModel.GetDeclaredSymbol(
+                FindContainingMethodOrTrigger(node), cancellationToken);
+
+            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, containingSymbol ?? obj);
+            if (required is not null)
+                result.Add(required.Value);
+        });
+    }
+
+    private static SyntaxNode FindContainingMethodOrTrigger(SyntaxNode node)
+    {
+        var current = node.Parent;
+        while (current is not null)
+        {
+            if (current.IsKind(EnumProvider.SyntaxKind.MethodDeclaration)
+                || current.IsKind(EnumProvider.SyntaxKind.TriggerDeclaration))
+                return current;
+            current = current.Parent;
+        }
+
+        return node;
+    }
+
+    private static void CollectFromReportDataItems(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IReportTypeSymbol report)
+            return;
+
+        var dataItems = new List<ISymbol>();
+        CollectReportDataItemsRecursively(report, dataItems);
+
+        foreach (var dataItem in dataItems)
+        {
+            var required = RequiredPermissionDetector.TryGetFromReportDataItem(dataItem);
+            if (required is not null)
+                result.Add(required.Value);
+        }
+    }
+
+    /// <summary>
+    /// Recursively collects all report data item symbols, including nested ones.
+    /// </summary>
+    private static void CollectReportDataItemsRecursively(IContainerSymbol container, List<ISymbol> result)
+    {
+        foreach (var member in container.GetMembers())
+        {
+            if (member.Kind == EnumProvider.SymbolKind.ReportDataItem)
+            {
+                result.Add(member);
+                if (member is IContainerSymbol nestedContainer)
+                    CollectReportDataItemsRecursively(nestedContainer, result);
+            }
+        }
+    }
+
+    private static void CollectFromQueryDataItems(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IQueryTypeSymbol query)
+            return;
+
+        foreach (var member in query.GetMembers())
+        {
+            if (member.Kind != EnumProvider.SymbolKind.QueryDataItem)
+                continue;
+
+            var required = RequiredPermissionDetector.TryGetFromQueryDataItem(member);
+            if (required is not null)
+                result.Add(required.Value);
+        }
+    }
+
+    private static void CollectFromXmlPortNodes(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IXmlPortTypeSymbol xmlPort)
+            return;
+
+        foreach (var member in xmlPort.GetMembers())
+        {
+            if (member.Kind != EnumProvider.SymbolKind.XmlPortNode)
+                continue;
+
+            foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(member))
+                result.Add(required);
+        }
+    }
+
+    /// <summary>
+    /// Gets a display name for the table from a permission entry.
+    /// Uses the original text as written in the permission declaration.
+    /// </summary>
+    private static string GetDisplayTableName(PermissionSyntax entry)
+    {
+        var identifier = entry.ObjectReference.Identifier;
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
+            return ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier() ?? string.Empty;
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.QualifiedName)
+        {
+            var qualified = (QualifiedNameSyntax)identifier;
+            return qualified.Right.Identifier.ValueText?.UnquoteIdentifier() ?? string.Empty;
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
+            return ((ObjectIdSyntax)identifier).Value.ValueText ?? string.Empty;
+
+        return entry.ObjectReference.GetText().ToString().Trim();
+    }
+
+    private static string NormalizePermissionChars(string chars)
+    {
+        return new string(chars
+            .Where(c => "rimdRIMD".Contains(c))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static string GetUsedChars(string declaredChars, DeclaredPermissionSet required)
+    {
+        return new string(declaredChars
+            .Where(c => "rimdRIMD".Contains(c) && required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static string GetUnusedChars(string declaredChars, DeclaredPermissionSet required)
+    {
+        return new string(declaredChars
+            .Where(c => "rimdRIMD".Contains(c) && !required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static ImmutableDictionary<string, string> BuildProperties(
+        string tableName, string unusedChars, string usedChars)
+    {
+        return ImmutableDictionary<string, string>.Empty
+            .Add("TableName", tableName)
+            .Add("UnusedChars", unusedChars)
+            .Add("UsedChars", usedChars);
+    }
+}

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -95,7 +95,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (!hasMatch)
         {
             // Table not accessed at all
-            var normalizedDeclared = NormalizePermissionChars(declaredChars);
+            var normalizedDeclared = GetUnusedChars(declaredChars, new DeclaredPermissionSet());
             var properties = BuildProperties(tableName, normalizedDeclared, string.Empty);
             reportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry,
@@ -318,33 +318,23 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         return entry.ObjectReference.GetText().ToString().Trim();
     }
 
-    private static string NormalizePermissionChars(string chars)
-    {
-        return new string(chars
-            .Where(c => "rimdRIMD".Contains(c))
-            .Select(c => char.ToLowerInvariant(c))
-            .Distinct()
-            .OrderBy(c => "rimd".IndexOf(c))
-            .ToArray());
-    }
-
     private static string GetUsedChars(string declaredChars, DeclaredPermissionSet required)
     {
         return new string(declaredChars
-            .Where(c => "rimdRIMD".Contains(c) && required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Where(c => MethodOperationMap.IsValidPermissionChar(c) && required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
             .Select(c => char.ToLowerInvariant(c))
             .Distinct()
-            .OrderBy(c => "rimd".IndexOf(c))
+            .OrderBy(c => MethodOperationMap.CanonicalOrder.IndexOf(c))
             .ToArray());
     }
 
     private static string GetUnusedChars(string declaredChars, DeclaredPermissionSet required)
     {
         return new string(declaredChars
-            .Where(c => "rimdRIMD".Contains(c) && !required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Where(c => MethodOperationMap.IsValidPermissionChar(c) && !required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
             .Select(c => char.ToLowerInvariant(c))
             .Distinct()
-            .OrderBy(c => "rimd".IndexOf(c))
+            .OrderBy(c => MethodOperationMap.CanonicalOrder.IndexOf(c))
             .ToArray());
     }
 

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -4,7 +4,6 @@ using ALCops.Common.Permissions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -31,6 +31,10 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         {
             ctx.CancellationToken.ThrowIfCancellationRequested();
 
+            if (obj.Kind == EnumProvider.SymbolKind.PermissionSet
+                || obj.Kind == EnumProvider.SymbolKind.PermissionSetExtension)
+                continue;
+
             if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(obj))
                 continue;
 

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -72,9 +72,6 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
     {
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
-        public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle =>
-            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
 
         public TableDataAccessRequiresPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -73,7 +73,8 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle => Title;
+        public override string? FixAllTitle =>
+            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
 
         public TableDataAccessRequiresPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -5,7 +5,6 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 
@@ -90,11 +89,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessRequiresPermissions.Id);
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-#if NET8_0_OR_GREATER
-        new PermissionsFixAllProvider();
-#else
         WellKnownFixAllProviders.BatchFixer;
-#endif
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
     {
@@ -125,17 +120,22 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         if (objectSyntax is ApplicationObjectExtensionSyntax)
             return;
 
+        // Capture the object's identity so we can re-find it in a (potentially modified) document.
+        // This is critical for FixAll: BatchFixer applies fixes sequentially, and each fix may
+        // modify the tree. Using a stale objectSyntax reference causes ReplaceNode to fail silently.
+        var objectIdentity = GetObjectIdentity(objectSyntax);
+
         // Resolve table name using C#-like namespace resolution
         var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
         var resolvedTableName = ResolveTableNameForFix(props.TableName, props.TableNamespace, compilationUnit);
 
         ctx.RegisterCodeFix(
-            CreateCodeAction(objectSyntax, resolvedTableName, props.PermissionChar, document, generateFixAll: true),
+            CreateCodeAction(objectIdentity, resolvedTableName, props.PermissionChar, document, generateFixAll: true),
             diagnostic);
     }
 
     private static TableDataAccessRequiresPermissionsCodeAction CreateCodeAction(
-        ObjectSyntax objectSyntax, string tableName, char permissionChar,
+        (SyntaxKind Kind, string? Name) objectIdentity, string tableName, char permissionChar,
         Document document, bool generateFixAll)
     {
         var title = string.Format(
@@ -145,15 +145,25 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         return new TableDataAccessRequiresPermissionsCodeAction(
             title,
-            ct => ApplyFix(document, objectSyntax, tableName, permissionChar, ct),
+            ct => ApplyFix(document, objectIdentity, tableName, permissionChar, ct),
             nameof(TableDataAccessRequiresPermissionsCodeFixProvider),
             generateFixAll);
     }
 
-    private static async Task<Document> ApplyFix(Document document, ObjectSyntax objectSyntax,
+    private static async Task<Document> ApplyFix(Document document,
+        (SyntaxKind Kind, string? Name) objectIdentity,
         string tableName, char permissionChar, CancellationToken cancellationToken)
     {
-        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+        var root = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        // Re-find the object in the current tree to avoid stale node references.
+        // BatchFixer applies fixes sequentially, modifying the document between each.
+        var objectSyntax = FindObjectByIdentity(root, objectIdentity);
+        if (objectSyntax is null)
+            return document;
 
         var propertyList = objectSyntax.PropertyList;
         PropertyListSyntax newPropertyList;
@@ -162,21 +172,38 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         if (permissionsProperty is null)
         {
-            // No Permissions property exists: create one from scratch
             newPropertyList = AddNewPermissionsProperty(propertyList, tableName, permissionChar);
         }
         else
         {
-            // Permissions property exists: add or merge
             newPropertyList = UpdateExistingPermissionsProperty(propertyList, permissionsProperty, tableName, permissionChar);
         }
 
-        var root = await syntaxRootTask.ConfigureAwait(false);
-        if (root is null)
-            return document;
-
         var newRoot = root.ReplaceNode(propertyList, newPropertyList);
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static (SyntaxKind Kind, string? Name) GetObjectIdentity(ObjectSyntax objectSyntax)
+    {
+        var name = objectSyntax.Name?.Identifier.ValueText;
+        return (objectSyntax.Kind, name);
+    }
+
+    private static ObjectSyntax? FindObjectByIdentity(SyntaxNode root,
+        (SyntaxKind Kind, string? Name) identity)
+    {
+        foreach (var node in root.DescendantNodes())
+        {
+            if (node is ObjectSyntax obj
+                && obj is not ApplicationObjectExtensionSyntax
+                && obj.Kind == identity.Kind
+                && string.Equals(obj.Name?.Identifier.ValueText, identity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return obj;
+            }
+        }
+
+        return null;
     }
 
     private static PropertyListSyntax AddNewPermissionsProperty(
@@ -285,180 +312,4 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         return PermissionTableNameResolver.ResolveTableName(
             tableName, tableNamespace, fileNamespace, importedNamespaces);
     }
-
-#if NET8_0_OR_GREATER
-    /// <summary>
-    /// Custom FixAll provider that applies all permission changes in a single tree transformation.
-    /// The default BatchFixer applies fixes sequentially, which can cause issues when multiple
-    /// diagnostics modify the same Permissions property (uppercase normalization, stale spans).
-    /// </summary>
-    private sealed class PermissionsFixAllProvider : DocumentBasedFixAllByDiagnosticsProvider
-    {
-        protected override string GetFixAllTitle(FixAllContext fixAllContext) =>
-            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
-
-        protected override async Task<Document?> FixAllAsync(
-            FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
-        {
-            if (diagnostics.IsEmpty)
-                return document;
-
-            var root = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken)
-                .ConfigureAwait(false);
-            if (root is null)
-                return document;
-
-            var tablePermissions = CollectTablePermissions(diagnostics);
-            if (tablePermissions.Count == 0)
-                return document;
-
-            var node = root.FindNode(diagnostics[0].Location.SourceSpan);
-            var objectSyntax = node?.FirstAncestorOrSelf<ObjectSyntax>();
-            if (objectSyntax is null || objectSyntax is ApplicationObjectExtensionSyntax)
-                return document;
-
-            var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
-            var propertyList = objectSyntax.PropertyList;
-            var newPropertyList = ApplyAllPermissionChanges(
-                propertyList, tablePermissions, compilationUnit);
-
-            var newRoot = root.ReplaceNode(propertyList, newPropertyList);
-            return document.WithSyntaxRoot(newRoot);
-        }
-
-        private static Dictionary<string, (string Namespace, HashSet<char> Chars)>
-            CollectTablePermissions(ImmutableArray<Diagnostic> diagnostics)
-        {
-            var result = new Dictionary<string, (string Namespace, HashSet<char> Chars)>(
-                StringComparer.OrdinalIgnoreCase);
-
-            foreach (var diagnostic in diagnostics)
-            {
-                var props = CodeFixProperties.TryParse(diagnostic.Properties);
-                if (props is null)
-                    continue;
-
-                if (!result.TryGetValue(props.TableName, out var entry))
-                {
-                    entry = (props.TableNamespace, new HashSet<char>());
-                    result[props.TableName] = entry;
-                }
-                entry.Chars.Add(props.PermissionChar);
-            }
-
-            return result;
-        }
-
-        private static PropertyListSyntax ApplyAllPermissionChanges(
-            PropertyListSyntax propertyList,
-            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
-            CompilationUnitSyntax? compilationUnit)
-        {
-            var permissionsProperty = FindPermissionsProperty(propertyList);
-
-            if (permissionsProperty is null)
-                return CreateNewPermissionsPropertyForAll(
-                    propertyList, tablePermissions, compilationUnit);
-
-            if (permissionsProperty.Value is not PermissionPropertyValueSyntax permissionValue)
-                return propertyList;
-
-            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
-            {
-                var resolvedName = ResolveTableNameForFix(
-                    tableName, tableNamespace, compilationUnit);
-
-                var existingEntry = PermissionSyntaxHelper.FindExistingEntry(
-                    permissionValue, resolvedName);
-
-                if (existingEntry is not null)
-                    permissionValue = MergeAllChars(
-                        permissionValue, existingEntry, chars);
-                else
-                    permissionValue = AddNewEntryWithAllChars(
-                        permissionValue, resolvedName, chars);
-            }
-
-            var newProperty = permissionsProperty.WithValue(permissionValue);
-            return propertyList.WithProperties(
-                propertyList.Properties.Replace(permissionsProperty, newProperty));
-        }
-
-        private static PropertyListSyntax CreateNewPermissionsPropertyForAll(
-            PropertyListSyntax propertyList,
-            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
-            CompilationUnitSyntax? compilationUnit)
-        {
-            var permissionValue = SyntaxFactory.PermissionPropertyValue();
-
-            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
-            {
-                var resolvedName = ResolveTableNameForFix(
-                    tableName, tableNamespace, compilationUnit);
-                var permChars = BuildCanonicalPermissionString(chars);
-                var entry = PermissionSyntaxHelper.CreatePermissionSyntax(
-                    resolvedName, permChars);
-                permissionValue = permissionValue.AddPermissionProperties(entry);
-            }
-
-            var property = SyntaxFactory.Property(
-                EnumProvider.PropertyKind.Permissions,
-                (PropertyValueSyntax)permissionValue);
-
-            return propertyList.AddProperties(property);
-        }
-
-        private static PermissionPropertyValueSyntax MergeAllChars(
-            PermissionPropertyValueSyntax permissionValue,
-            PermissionSyntax existingEntry, HashSet<char> chars)
-        {
-            var currentPerms = existingEntry.Permissions.ValueText ?? string.Empty;
-            var merged = currentPerms;
-            foreach (var c in chars)
-                merged = PermissionSyntaxHelper.NormalizePermissionString(merged, c);
-
-            var newToken = SyntaxFactory.Identifier(merged);
-            var updatedEntry = existingEntry.WithPermissions(newToken);
-
-            return permissionValue.WithPermissionProperties(
-                permissionValue.PermissionProperties.Replace(existingEntry, updatedEntry));
-        }
-
-        private static PermissionPropertyValueSyntax AddNewEntryWithAllChars(
-            PermissionPropertyValueSyntax permissionValue, string tableName, HashSet<char> chars)
-        {
-            var permissions = permissionValue.PermissionProperties;
-            var isSorted = PermissionSyntaxHelper.ArePermissionsSorted(permissions);
-            var isMultiLine = PermissionSyntaxHelper.IsMultiLineFormat(permissionValue);
-            var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(
-                permissions, tableName, isSorted);
-            var permChars = BuildCanonicalPermissionString(chars);
-
-            var newEntry = PermissionSyntaxHelper.CreatePermissionSyntax(tableName, permChars);
-
-            if (isMultiLine)
-            {
-                if (insertIndex > 0)
-                {
-                    var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
-                    newEntry = newEntry.WithLeadingTrivia(
-                        SyntaxFactory.ParseLeadingTrivia(indentation));
-                }
-                return PermissionSyntaxHelper.InsertIntoMultiLineList(
-                    permissionValue, permissions, insertIndex, newEntry);
-            }
-
-            var newPermissions = permissions.Insert(insertIndex, newEntry);
-            return permissionValue.WithPermissionProperties(newPermissions);
-        }
-
-        private static string BuildCanonicalPermissionString(HashSet<char> chars)
-        {
-            var result = string.Empty;
-            foreach (var c in chars)
-                result = PermissionSyntaxHelper.NormalizePermissionString(result, c);
-            return result;
-        }
-    }
-#endif
 }

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -5,6 +5,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 
@@ -89,7 +90,11 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessRequiresPermissions.Id);
 
     public sealed override FixAllProvider GetFixAllProvider() =>
+#if NET8_0_OR_GREATER
+        new PermissionsFixAllProvider();
+#else
         WellKnownFixAllProviders.BatchFixer;
+#endif
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
     {
@@ -240,8 +245,13 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         SeparatedSyntaxList<PermissionSyntax> newPermissions;
         if (isMultiLine)
         {
-            var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
-            newEntry = newEntry.WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(indentation));
+            // Only add indentation trivia when inserting at index > 0.
+            // Index 0 is on the same line as "Permissions = " and needs no indentation.
+            if (insertIndex > 0)
+            {
+                var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
+                newEntry = newEntry.WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(indentation));
+            }
             return PermissionSyntaxHelper.InsertIntoMultiLineList(permissionValue, permissions, insertIndex, newEntry);
         }
         else
@@ -275,4 +285,180 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         return PermissionTableNameResolver.ResolveTableName(
             tableName, tableNamespace, fileNamespace, importedNamespaces);
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Custom FixAll provider that applies all permission changes in a single tree transformation.
+    /// The default BatchFixer applies fixes sequentially, which can cause issues when multiple
+    /// diagnostics modify the same Permissions property (uppercase normalization, stale spans).
+    /// </summary>
+    private sealed class PermissionsFixAllProvider : DocumentBasedFixAllByDiagnosticsProvider
+    {
+        protected override string GetFixAllTitle(FixAllContext fixAllContext) =>
+            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
+
+        protected override async Task<Document?> FixAllAsync(
+            FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+        {
+            if (diagnostics.IsEmpty)
+                return document;
+
+            var root = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken)
+                .ConfigureAwait(false);
+            if (root is null)
+                return document;
+
+            var tablePermissions = CollectTablePermissions(diagnostics);
+            if (tablePermissions.Count == 0)
+                return document;
+
+            var node = root.FindNode(diagnostics[0].Location.SourceSpan);
+            var objectSyntax = node?.FirstAncestorOrSelf<ObjectSyntax>();
+            if (objectSyntax is null || objectSyntax is ApplicationObjectExtensionSyntax)
+                return document;
+
+            var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
+            var propertyList = objectSyntax.PropertyList;
+            var newPropertyList = ApplyAllPermissionChanges(
+                propertyList, tablePermissions, compilationUnit);
+
+            var newRoot = root.ReplaceNode(propertyList, newPropertyList);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static Dictionary<string, (string Namespace, HashSet<char> Chars)>
+            CollectTablePermissions(ImmutableArray<Diagnostic> diagnostics)
+        {
+            var result = new Dictionary<string, (string Namespace, HashSet<char> Chars)>(
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var props = CodeFixProperties.TryParse(diagnostic.Properties);
+                if (props is null)
+                    continue;
+
+                if (!result.TryGetValue(props.TableName, out var entry))
+                {
+                    entry = (props.TableNamespace, new HashSet<char>());
+                    result[props.TableName] = entry;
+                }
+                entry.Chars.Add(props.PermissionChar);
+            }
+
+            return result;
+        }
+
+        private static PropertyListSyntax ApplyAllPermissionChanges(
+            PropertyListSyntax propertyList,
+            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
+            CompilationUnitSyntax? compilationUnit)
+        {
+            var permissionsProperty = FindPermissionsProperty(propertyList);
+
+            if (permissionsProperty is null)
+                return CreateNewPermissionsPropertyForAll(
+                    propertyList, tablePermissions, compilationUnit);
+
+            if (permissionsProperty.Value is not PermissionPropertyValueSyntax permissionValue)
+                return propertyList;
+
+            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
+            {
+                var resolvedName = ResolveTableNameForFix(
+                    tableName, tableNamespace, compilationUnit);
+
+                var existingEntry = PermissionSyntaxHelper.FindExistingEntry(
+                    permissionValue, resolvedName);
+
+                if (existingEntry is not null)
+                    permissionValue = MergeAllChars(
+                        permissionValue, existingEntry, chars);
+                else
+                    permissionValue = AddNewEntryWithAllChars(
+                        permissionValue, resolvedName, chars);
+            }
+
+            var newProperty = permissionsProperty.WithValue(permissionValue);
+            return propertyList.WithProperties(
+                propertyList.Properties.Replace(permissionsProperty, newProperty));
+        }
+
+        private static PropertyListSyntax CreateNewPermissionsPropertyForAll(
+            PropertyListSyntax propertyList,
+            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
+            CompilationUnitSyntax? compilationUnit)
+        {
+            var permissionValue = SyntaxFactory.PermissionPropertyValue();
+
+            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
+            {
+                var resolvedName = ResolveTableNameForFix(
+                    tableName, tableNamespace, compilationUnit);
+                var permChars = BuildCanonicalPermissionString(chars);
+                var entry = PermissionSyntaxHelper.CreatePermissionSyntax(
+                    resolvedName, permChars);
+                permissionValue = permissionValue.AddPermissionProperties(entry);
+            }
+
+            var property = SyntaxFactory.Property(
+                EnumProvider.PropertyKind.Permissions,
+                (PropertyValueSyntax)permissionValue);
+
+            return propertyList.AddProperties(property);
+        }
+
+        private static PermissionPropertyValueSyntax MergeAllChars(
+            PermissionPropertyValueSyntax permissionValue,
+            PermissionSyntax existingEntry, HashSet<char> chars)
+        {
+            var currentPerms = existingEntry.Permissions.ValueText ?? string.Empty;
+            var merged = currentPerms;
+            foreach (var c in chars)
+                merged = PermissionSyntaxHelper.NormalizePermissionString(merged, c);
+
+            var newToken = SyntaxFactory.Identifier(merged);
+            var updatedEntry = existingEntry.WithPermissions(newToken);
+
+            return permissionValue.WithPermissionProperties(
+                permissionValue.PermissionProperties.Replace(existingEntry, updatedEntry));
+        }
+
+        private static PermissionPropertyValueSyntax AddNewEntryWithAllChars(
+            PermissionPropertyValueSyntax permissionValue, string tableName, HashSet<char> chars)
+        {
+            var permissions = permissionValue.PermissionProperties;
+            var isSorted = PermissionSyntaxHelper.ArePermissionsSorted(permissions);
+            var isMultiLine = PermissionSyntaxHelper.IsMultiLineFormat(permissionValue);
+            var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(
+                permissions, tableName, isSorted);
+            var permChars = BuildCanonicalPermissionString(chars);
+
+            var newEntry = PermissionSyntaxHelper.CreatePermissionSyntax(tableName, permChars);
+
+            if (isMultiLine)
+            {
+                if (insertIndex > 0)
+                {
+                    var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
+                    newEntry = newEntry.WithLeadingTrivia(
+                        SyntaxFactory.ParseLeadingTrivia(indentation));
+                }
+                return PermissionSyntaxHelper.InsertIntoMultiLineList(
+                    permissionValue, permissions, insertIndex, newEntry);
+            }
+
+            var newPermissions = permissions.Insert(insertIndex, newEntry);
+            return permissionValue.WithPermissionProperties(newPermissions);
+        }
+
+        private static string BuildCanonicalPermissionString(HashSet<char> chars)
+        {
+            var result = string.Empty;
+            foreach (var c in chars)
+                result = PermissionSyntaxHelper.NormalizePermissionString(result, c);
+            return result;
+        }
+    }
+#endif
 }

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -70,9 +70,6 @@ public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixPro
     {
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
-        public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle =>
-            ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsFixAllCodeAction;
 
         public TableDataAccessUnusedPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -71,7 +71,8 @@ public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixPro
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle => Title;
+        public override string? FixAllTitle =>
+            ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsFixAllCodeAction;
 
         public TableDataAccessUnusedPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,
@@ -124,8 +125,12 @@ public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixPro
         PermissionSyntax permissionNode, CodeFixProperties props,
         Document document, bool generateFixAll)
     {
-        return new TableDataAccessUnusedPermissionsCodeAction(
+        var title = string.Format(
             ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsCodeAction,
+            props.TableName);
+
+        return new TableDataAccessUnusedPermissionsCodeAction(
+            title,
             ct => ApplyFix(document, permissionNode, props, ct),
             nameof(TableDataAccessUnusedPermissionsCodeFixProvider),
             generateFixAll);

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using ALCops.Common.Permissions;
-using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -1,0 +1,208 @@
+using System.Collections.Immutable;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.ApplicationCop.CodeFixes;
+
+[CodeFixProvider(nameof(TableDataAccessUnusedPermissionsCodeFixProvider))]
+public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixProvider
+{
+#if NETSTANDARD2_1
+    private sealed class CodeFixProperties
+    {
+        public string TableName { get; }
+        public string UnusedChars { get; }
+        public string UsedChars { get; }
+
+        private CodeFixProperties(string tableName, string unusedChars, string usedChars)
+        {
+            TableName = tableName;
+            UnusedChars = unusedChars;
+            UsedChars = usedChars;
+        }
+
+        public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+        {
+            if (properties is null)
+                return null;
+
+            if (!properties.TryGetValue(nameof(TableName), out var tableName) || string.IsNullOrEmpty(tableName))
+                return null;
+
+            if (!properties.TryGetValue(nameof(UnusedChars), out var unusedChars) || string.IsNullOrEmpty(unusedChars))
+                return null;
+
+            properties.TryGetValue(nameof(UsedChars), out var usedChars);
+
+            return new CodeFixProperties(tableName, unusedChars, usedChars ?? string.Empty);
+        }
+    }
+#endif
+
+#if NET8_0_OR_GREATER
+    private sealed record CodeFixProperties(string TableName, string UnusedChars, string UsedChars)
+    {
+        public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+        {
+            if (properties is null)
+                return null;
+
+            if (!properties.TryGetValue(nameof(TableName), out var tableName) || string.IsNullOrEmpty(tableName))
+                return null;
+
+            if (!properties.TryGetValue(nameof(UnusedChars), out var unusedChars) || string.IsNullOrEmpty(unusedChars))
+                return null;
+
+            properties.TryGetValue(nameof(UsedChars), out var usedChars);
+
+            return new CodeFixProperties(tableName, unusedChars, usedChars ?? string.Empty);
+        }
+    }
+#endif
+
+    private class TableDataAccessUnusedPermissionsCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public TableDataAccessUnusedPermissionsCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(CodeFixContext ctx, SyntaxNode syntaxRoot,
+        TextSpan span, Document document)
+    {
+        var diagnostic = ctx.Diagnostics[0];
+        var props = CodeFixProperties.TryParse(diagnostic.Properties);
+        if (props is null)
+            return;
+
+        var node = syntaxRoot.FindNode(span);
+        var permissionNode = node as PermissionSyntax
+            ?? node.FirstAncestorOrSelf<PermissionSyntax>()
+            ?? node.DescendantNodes().OfType<PermissionSyntax>().FirstOrDefault();
+        if (permissionNode is null)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(permissionNode, props, document, generateFixAll: true),
+            diagnostic);
+    }
+
+    private static TableDataAccessUnusedPermissionsCodeAction CreateCodeAction(
+        PermissionSyntax permissionNode, CodeFixProperties props,
+        Document document, bool generateFixAll)
+    {
+        return new TableDataAccessUnusedPermissionsCodeAction(
+            ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsCodeAction,
+            ct => ApplyFix(document, permissionNode, props, ct),
+            nameof(TableDataAccessUnusedPermissionsCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(Document document, PermissionSyntax permissionNode,
+        CodeFixProperties props, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        var permissionValue = permissionNode.Parent as PermissionPropertyValueSyntax;
+        if (permissionValue is null)
+            return document;
+
+        var propertySyntax = permissionValue.Parent as PropertySyntax;
+        if (propertySyntax is null)
+            return document;
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        SyntaxNode newRoot;
+
+        if (string.IsNullOrEmpty(props.UsedChars))
+        {
+            // Entire entry is unused: remove the entry or the whole property
+            newRoot = RemovePermissionEntry(root, permissionValue, propertySyntax, permissionNode);
+        }
+        else
+        {
+            // Partial chars unused: reduce the permission chars
+            newRoot = ReducePermissionChars(root, permissionNode, props.UsedChars);
+        }
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static SyntaxNode RemovePermissionEntry(
+        SyntaxNode root,
+        PermissionPropertyValueSyntax permissionValue,
+        PropertySyntax propertySyntax,
+        PermissionSyntax permissionNode)
+    {
+        var permissions = permissionValue.PermissionProperties;
+
+        if (permissions.Count <= 1)
+        {
+            // Last entry: remove the entire Permissions property
+            return root.RemoveNode(propertySyntax, SyntaxRemoveOptions.KeepNoTrivia)
+                ?? root;
+        }
+
+        int index = permissions.IndexOf(permissionNode);
+        var newPermissions = permissions.Remove(permissionNode);
+
+        // When removing a non-last entry, the entry that slides into its position
+        // retains stale leading trivia (e.g. newline+indent from multi-line layout).
+        // Normalize it to a single space so that `Permissions = <remaining entries>` reads cleanly.
+        if (index < newPermissions.Count)
+        {
+            var shifted = newPermissions[index];
+            var normalized = shifted.WithLeadingTrivia(SyntaxFactory.TriviaList());
+            newPermissions = newPermissions.Replace(shifted, normalized);
+        }
+
+        var newPermissionValue = permissionValue.WithPermissionProperties(newPermissions);
+        return root.ReplaceNode(permissionValue, newPermissionValue);
+    }
+
+    private static SyntaxNode ReducePermissionChars(
+        SyntaxNode root,
+        PermissionSyntax permissionNode,
+        string usedChars)
+    {
+        var newPermissionsToken = SyntaxFactory.Identifier(usedChars);
+        var newPermissionNode = permissionNode.WithPermissions(newPermissionsToken);
+        return root.ReplaceNode(permissionNode, newPermissionNode);
+    }
+}

--- a/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
@@ -305,6 +305,26 @@ public static class DiagnosticDescriptors
         description: ApplicationCopAnalyzers.UseReturnValueForDatabaseReadMethodsDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseReturnValueForDatabaseReadMethods));
 
+    public static readonly DiagnosticDescriptor TableDataAccessUnusedPermissionsEntireEntry = new(
+        id: DiagnosticIds.TableDataAccessUnusedPermissions,
+        title: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsTitle,
+        messageFormat: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsEntireEntryMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.TableDataAccessUnusedPermissions));
+
+    public static readonly DiagnosticDescriptor TableDataAccessUnusedPermissionsPartialChars = new(
+        id: DiagnosticIds.TableDataAccessUnusedPermissions,
+        title: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsTitle,
+        messageFormat: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsPartialCharsMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.TableDataAccessUnusedPermissions));
+
     public static readonly DiagnosticDescriptor ZeroEnumValueReservedForEmpty = new(
         id: DiagnosticIds.ZeroEnumValueReservedForEmpty,
         title: ApplicationCopAnalyzers.ZeroEnumValueReservedForEmptyTitle,

--- a/src/ALCops.ApplicationCop/DiagnosticIds.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticIds.cs
@@ -33,4 +33,5 @@ public static class DiagnosticIds
     public static readonly string DuplicateToolTipBetweenPageAndTable = "AC0029";
     public static readonly string UseReturnValueForDatabaseReadMethods = "AC0030";
     public static readonly string TableDataAccessRequiresPermissions = "AC0031";
+    public static readonly string TableDataAccessUnusedPermissions = "AC0032";
 }

--- a/src/ALCops.Common/Permissions/MethodOperationMap.cs
+++ b/src/ALCops.Common/Permissions/MethodOperationMap.cs
@@ -37,6 +37,14 @@ public static class MethodOperationMap
     public static DatabaseOperation GetOperation(string methodName) =>
         Map.TryGetValue(methodName, out var op) ? op : DatabaseOperation.None;
 
+    /// <summary>
+    /// The canonical ordering of permission characters: read, insert, modify, delete.
+    /// </summary>
+    public const string CanonicalOrder = "rimd";
+
+    public static bool IsValidPermissionChar(char c) =>
+        FromPermissionChar(c) != DatabaseOperation.None;
+
     public static char ToPermissionChar(DatabaseOperation operation) =>
         operation switch
         {

--- a/src/ALCops.Common/Permissions/PermissionResolver.cs
+++ b/src/ALCops.Common/Permissions/PermissionResolver.cs
@@ -1,8 +1,6 @@
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -14,8 +14,8 @@ public static class PermissionSyntaxHelper
     private const string CanonicalOrder = "rimd";
 
     /// <summary>
-    /// Checks whether the permission entries in a PermissionPropertyValueSyntax are sorted
-    /// alphabetically by table name (case-insensitive).
+    /// Checks whether the permission entries are sorted alphabetically by
+    /// (type keyword, object name), both case-insensitive.
     /// Returns true if 0 or 1 entries (trivially sorted).
     /// </summary>
     public static bool ArePermissionsSorted(SeparatedSyntaxList<PermissionSyntax> permissions)
@@ -23,17 +23,26 @@ public static class PermissionSyntaxHelper
         if (permissions.Count <= 1)
             return true;
 
+        string? previousType = null;
         string? previousName = null;
         foreach (var permission in permissions)
         {
-            var name = GetTableNameFromPermission(permission);
-            if (name is null)
+            var type = GetPermissionTypeText(permission);
+            var name = GetObjectNameFromPermission(permission);
+            if (name is null || type is null)
                 continue;
 
-            if (previousName is not null &&
-                string.Compare(previousName, name, StringComparison.OrdinalIgnoreCase) > 0)
-                return false;
+            if (previousType is not null && previousName is not null)
+            {
+                int typeCompare = string.Compare(previousType, type, StringComparison.OrdinalIgnoreCase);
+                if (typeCompare > 0)
+                    return false;
+                if (typeCompare == 0 &&
+                    string.Compare(previousName, name, StringComparison.OrdinalIgnoreCase) > 0)
+                    return false;
+            }
 
+            previousType = type;
             previousName = name;
         }
 
@@ -118,7 +127,9 @@ public static class PermissionSyntaxHelper
     }
 
     /// <summary>
-    /// Finds the insertion index for a new entry in a sorted permission list.
+    /// Finds the insertion index for a new entry in a sorted permission list,
+    /// comparing by (type keyword, object name). The new entry type defaults to "tabledata"
+    /// since AC0031 only inserts tabledata entries.
     /// If not sorted, returns the count (append).
     /// </summary>
     public static int FindInsertionIndex(SeparatedSyntaxList<PermissionSyntax> permissions, string tableName, bool isSorted)
@@ -126,10 +137,18 @@ public static class PermissionSyntaxHelper
         if (!isSorted)
             return permissions.Count;
 
+        const string newType = "tabledata";
         for (int i = 0; i < permissions.Count; i++)
         {
-            var name = GetTableNameFromPermission(permissions[i]);
-            if (name is not null && string.Compare(name, tableName, StringComparison.OrdinalIgnoreCase) > 0)
+            var entryType = GetPermissionTypeText(permissions[i]);
+            var entryName = GetObjectNameFromPermission(permissions[i]);
+            if (entryType is null || entryName is null)
+                continue;
+
+            int typeCompare = string.Compare(newType, entryType, StringComparison.OrdinalIgnoreCase);
+            if (typeCompare < 0)
+                return i;
+            if (typeCompare == 0 && string.Compare(tableName, entryName, StringComparison.OrdinalIgnoreCase) < 0)
                 return i;
         }
 
@@ -147,7 +166,7 @@ public static class PermissionSyntaxHelper
             if (!permission.ObjectType.IsKind(EnumProvider.SyntaxKind.TableDataKeyword))
                 continue;
 
-            var name = GetTableNameFromPermission(permission);
+            var name = GetObjectNameFromPermission(permission);
             if (name is not null && string.Equals(name, tableName, StringComparison.OrdinalIgnoreCase))
                 return permission;
         }
@@ -189,7 +208,20 @@ public static class PermissionSyntaxHelper
         return null;
     }
 
-    private static string? GetTableNameFromPermission(PermissionSyntax permission)
+    /// <summary>
+    /// Gets the type keyword text from a PermissionSyntax (e.g. "tabledata", "codeunit", "page").
+    /// </summary>
+    public static string? GetPermissionTypeText(PermissionSyntax permission)
+    {
+        var objectType = permission.ObjectType;
+        return objectType.ValueText?.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Gets the object name from a PermissionSyntax entry.
+    /// Works for any permission type (tabledata, codeunit, page, etc.).
+    /// </summary>
+    public static string? GetObjectNameFromPermission(PermissionSyntax permission)
     {
         var identifier = permission.ObjectReference?.Identifier;
         if (identifier is null)
@@ -283,5 +315,82 @@ public static class PermissionSyntaxHelper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Sorts the permission entries by (type keyword, object name), both case-insensitive.
+    /// Returns a new list with the entries in sorted order, stripping leading trivia from
+    /// all entries (callers are responsible for applying formatting).
+    /// </summary>
+    public static List<PermissionSyntax> GetSortedPermissions(SeparatedSyntaxList<PermissionSyntax> permissions)
+    {
+        var entries = new List<PermissionSyntax>(permissions.Count);
+        foreach (var permission in permissions)
+            entries.Add(permission);
+
+        entries.Sort((a, b) =>
+        {
+            var typeA = GetPermissionTypeText(a) ?? string.Empty;
+            var typeB = GetPermissionTypeText(b) ?? string.Empty;
+            int typeCompare = string.Compare(typeA, typeB, StringComparison.OrdinalIgnoreCase);
+            if (typeCompare != 0)
+                return typeCompare;
+
+            var nameA = GetObjectNameFromPermission(a) ?? string.Empty;
+            var nameB = GetObjectNameFromPermission(b) ?? string.Empty;
+            return string.Compare(nameA, nameB, StringComparison.OrdinalIgnoreCase);
+        });
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Builds a multi-line PermissionPropertyValueSyntax from an ordered list of entries.
+    /// The first entry has no leading trivia (it shares the line with "Permissions = ").
+    /// Subsequent entries are indented and preceded by a newline.
+    /// </summary>
+    public static PermissionPropertyValueSyntax BuildMultiLinePermissionValue(
+        List<PermissionSyntax> sortedEntries,
+        string indentation)
+    {
+        if (sortedEntries.Count == 0)
+            return SyntaxFactory.PermissionPropertyValue();
+
+        // Strip trivia from all entries, then apply formatting
+        var formatted = new List<PermissionSyntax>(sortedEntries.Count);
+        for (int i = 0; i < sortedEntries.Count; i++)
+        {
+            var entry = sortedEntries[i]
+                .WithLeadingTrivia(SyntaxFactory.TriviaList())
+                .WithTrailingTrivia(SyntaxFactory.TriviaList());
+
+            if (i > 0)
+                entry = entry.WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(indentation));
+
+            formatted.Add(entry);
+        }
+
+        // Build the list with comma separators that have newline trailing trivia
+        var result = SyntaxFactory.PermissionPropertyValue()
+            .AddPermissionProperties(formatted[0]);
+
+        for (int i = 1; i < formatted.Count; i++)
+        {
+            var currentList = result.PermissionProperties;
+            var newList = currentList.Add(formatted[i]);
+            result = result.WithPermissionProperties(newList);
+
+            // Fix the separator trivia: the newly added separator needs newline trailing trivia
+            var separators = result.PermissionProperties.GetSeparators().ToList();
+            var lastSeparator = separators[separators.Count - 1];
+            if (!HasNewlineTrivia(lastSeparator.TrailingTrivia))
+            {
+                var newlineTrivia = SyntaxFactory.ParseTrailingTrivia("\n");
+                var fixedSeparator = lastSeparator.WithTrailingTrivia(newlineTrivia);
+                result = (PermissionPropertyValueSyntax)result.ReplaceToken(lastSeparator, fixedSeparator);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -11,7 +11,7 @@ namespace ALCops.Common.Permissions;
 /// </summary>
 public static class PermissionSyntaxHelper
 {
-    private const string CanonicalOrder = "rimd";
+    private const string CanonicalOrder = MethodOperationMap.CanonicalOrder;
 
     /// <summary>
     /// Checks whether the permission entries are sorted alphabetically by

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -136,7 +136,8 @@ public static class PermissionSyntaxHelper
 
     /// <summary>
     /// Gets the indentation string for multi-line formatting by examining existing entries.
-    /// Returns the leading whitespace of the first tabledata keyword.
+    /// In multi-line format, the first entry shares the line with "Permissions = " and has
+    /// no indentation trivia, so entries at index &gt; 0 are checked first.
     /// </summary>
     public static string GetEntryIndentation(PermissionPropertyValueSyntax permissionValue)
     {
@@ -144,8 +145,19 @@ public static class PermissionSyntaxHelper
         if (permissions.Count == 0)
             return "                  ";
 
-        var firstEntry = permissions[0];
-        var leadingTrivia = firstEntry.GetLeadingTrivia();
+        for (int i = 1; i < permissions.Count; i++)
+        {
+            var indentation = GetWhitespaceOnlyTrivia(permissions[i].GetLeadingTrivia());
+            if (indentation is not null)
+                return indentation;
+        }
+
+        var firstIndentation = GetWhitespaceOnlyTrivia(permissions[0].GetLeadingTrivia());
+        return firstIndentation ?? "                  ";
+    }
+
+    private static string? GetWhitespaceOnlyTrivia(SyntaxTriviaList leadingTrivia)
+    {
         foreach (var trivia in leadingTrivia)
         {
             var text = trivia.ToString();
@@ -153,7 +165,7 @@ public static class PermissionSyntaxHelper
                 return text;
         }
 
-        return "                  ";
+        return null;
     }
 
     private static string? GetTableNameFromPermission(PermissionSyntax permission)
@@ -195,6 +207,8 @@ public static class PermissionSyntaxHelper
     /// <summary>
     /// Inserts a permission entry into a multi-line permission list, preserving
     /// the multi-line format by fixing separator trivia after insertion.
+    /// When inserting at index 0, the displaced first entry receives indentation trivia
+    /// since it moves from position 0 (same line as "Permissions = ") to position 1 (own line).
     /// </summary>
     public static PermissionPropertyValueSyntax InsertIntoMultiLineList(
         PermissionPropertyValueSyntax permissionValue,
@@ -204,6 +218,18 @@ public static class PermissionSyntaxHelper
     {
         var newPermissions = existing.Insert(insertIndex, newEntry);
         var result = permissionValue.WithPermissionProperties(newPermissions);
+
+        // When inserting at index 0, the displaced first entry (now at index 1) was on
+        // the same line as "Permissions = " and has no indentation trivia. Add it.
+        if (insertIndex == 0 && existing.Count > 0)
+        {
+            var indentation = GetEntryIndentation(permissionValue);
+            var displacedEntry = result.PermissionProperties[1];
+            var indentedEntry = displacedEntry.WithLeadingTrivia(
+                SyntaxFactory.ParseLeadingTrivia(indentation));
+            result = result.WithPermissionProperties(
+                result.PermissionProperties.Replace(displacedEntry, indentedEntry));
+        }
 
         // Insert() creates a new comma separator without newline trailing trivia.
         // Copy the trivia pattern from an existing separator to fix multi-line formatting.

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -63,9 +63,13 @@ public static class PermissionSyntaxHelper
     /// <summary>
     /// Merges a new permission char into an existing permission string,
     /// returning the result in canonical 'rimd' order.
+    /// Preserves the casing convention of the existing string: if existing chars
+    /// are uppercase, the new char is added as uppercase (and vice versa).
     /// </summary>
     public static string NormalizePermissionString(string existing, char newChar)
     {
+        var useUpperCase = IsUpperCaseConvention(existing);
+
         var chars = new HashSet<char>();
         foreach (var c in existing)
             chars.Add(char.ToLowerInvariant(c));
@@ -77,10 +81,27 @@ public static class PermissionSyntaxHelper
         foreach (var c in CanonicalOrder)
         {
             if (chars.Contains(c))
-                result[count++] = c;
+                result[count++] = useUpperCase ? char.ToUpperInvariant(c) : c;
         }
 
         return new string(result, 0, count);
+    }
+
+    /// <summary>
+    /// Detects whether the existing permission string uses uppercase convention.
+    /// Returns true if the majority of non-empty chars are uppercase.
+    /// Defaults to false (lowercase) for empty strings.
+    /// </summary>
+    private static bool IsUpperCaseConvention(string permissions)
+    {
+        int upper = 0, lower = 0;
+        foreach (var c in permissions)
+        {
+            if (char.IsUpper(c)) upper++;
+            else if (char.IsLower(c)) lower++;
+        }
+
+        return upper > lower;
     }
 
     /// <summary>

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -1,4 +1,3 @@
-using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;

--- a/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
+++ b/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
@@ -1,6 +1,4 @@
 using ALCops.Common.Extensions;
-using ALCops.Common.Reflection;
-using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace ALCops.Common.Permissions;

--- a/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
+++ b/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
@@ -1,0 +1,149 @@
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+
+namespace ALCops.Common.Permissions;
+
+/// <summary>
+/// Detects required database permissions from code constructs.
+/// Shared between AC0031 (missing permissions) and AC0032 (unused permissions).
+/// </summary>
+public static class RequiredPermissionDetector
+{
+    /// <summary>
+    /// Determines if an invocation expression requires a database permission.
+    /// Returns null if the invocation doesn't require a permission (not a DB method, temporary record, system table, etc.).
+    /// </summary>
+    public static RequiredPermission? TryGetFromInvocation(
+        IInvocationExpression invocation,
+        ISymbol containingSymbol)
+    {
+        if (invocation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
+            return null;
+
+        var operation = MethodOperationMap.GetOperation(invocation.TargetMethod.Name);
+        if (operation == DatabaseOperation.None)
+            return null;
+
+        IRecordTypeSymbol? recordType;
+
+        if (invocation.Instance is not null)
+            recordType = invocation.Instance.Type as IRecordTypeSymbol;
+        else
+            recordType = containingSymbol.ContainingType as IRecordTypeSymbol;
+
+        if (recordType is null || recordType.Temporary)
+            return null;
+
+        var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
+        if (tableType is null || IsSystemTable(tableType))
+            return null;
+
+        return new RequiredPermission(tableType, recordType, operation, invocation.Syntax.GetLocation());
+    }
+
+    /// <summary>
+    /// Determines if a report data item requires a database permission.
+    /// Returns null if it doesn't (temporary record, system table, wrong symbol type, etc.).
+    /// </summary>
+    public static RequiredPermission? TryGetFromReportDataItem(ISymbol symbol)
+    {
+        if (symbol.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is true)
+            return null;
+
+        if (symbol is not IReportDataItemSymbol reportDataItem)
+            return null;
+
+        if (reportDataItem.GetTypeSymbol() is not IRecordTypeSymbol recordType)
+            return null;
+
+        if (recordType.Temporary)
+            return null;
+
+        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+            return null;
+
+        return new RequiredPermission(tableType, recordType, DatabaseOperation.Read, symbol.GetLocation());
+    }
+
+    /// <summary>
+    /// Determines if a query data item requires a database permission.
+    /// Returns null if the underlying table is a system table.
+    /// </summary>
+    public static RequiredPermission? TryGetFromQueryDataItem(ISymbol symbol)
+    {
+        var targetSymbol = ((IQueryDataItemSymbol)symbol).GetTypeSymbol();
+        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+            return null;
+
+        return new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Read, symbol.GetLocation());
+    }
+
+    /// <summary>
+    /// Gets required permissions for an xmlport table node.
+    /// May yield multiple permissions depending on direction and auto-save/replace/update properties.
+    /// </summary>
+    public static IEnumerable<RequiredPermission> GetFromXmlPortNode(ISymbol symbol)
+    {
+        var nodeSymbol = (IXmlPortNodeSymbol)symbol.OriginalDefinition;
+        if (nodeSymbol.SourceTypeKind != EnumProvider.XmlPortSourceTypeKind.Table)
+            yield break;
+
+        var targetSymbol = nodeSymbol.GetTypeSymbol();
+        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+            yield break;
+
+        var xmlPort = (IXmlPortTypeSymbol)symbol.GetContainingObjectTypeSymbol();
+        var direction = ResolveXmlPortDirection(xmlPort);
+        var autoReplace = GetXmlPortNodeBoolProperty(symbol, EnumProvider.PropertyKind.AutoReplace) ?? true;
+        var autoUpdate = GetXmlPortNodeBoolProperty(symbol, EnumProvider.PropertyKind.AutoUpdate) ?? true;
+        var autoSave = GetXmlPortNodeBoolProperty(symbol, EnumProvider.PropertyKind.AutoSave) ?? true;
+
+        var location = symbol.GetLocation();
+
+        if (direction == EnumProvider.DirectionKind.Import || direction == EnumProvider.DirectionKind.Both)
+        {
+            if (autoReplace || autoUpdate)
+                yield return new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Modify, location);
+            if (autoSave)
+                yield return new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Insert, location);
+        }
+
+        if (direction == EnumProvider.DirectionKind.Export || direction == EnumProvider.DirectionKind.Both)
+            yield return new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Read, location);
+    }
+
+    /// <summary>
+    /// Returns true if the table is a system table (ID > 2,000,000,000).
+    /// </summary>
+    public static bool IsSystemTable(ITableTypeSymbol table) => table.Id > 2000000000;
+
+    /// <summary>
+    /// Returns true if the object is a test codeunit with TestPermissions = Disabled.
+    /// </summary>
+    public static bool IsTestCodeunitWithPermissionsDisabled(IApplicationObjectTypeSymbol? containingObject)
+    {
+        if (containingObject is not ICodeunitTypeSymbol codeunit)
+            return false;
+
+        var subtype = codeunit.GetEnumPropertyValue<CodeunitSubtypeKind>(EnumProvider.PropertyKind.Subtype);
+        if (subtype is null || subtype != EnumProvider.CodeunitSubtypeKind.Test)
+            return false;
+
+        var testPermissions = codeunit.GetEnumPropertyValue<TestPermissionsKind>(EnumProvider.PropertyKind.TestPermissions);
+        return testPermissions is not null && testPermissions == EnumProvider.TestPermissionsKind.Disabled;
+    }
+
+    private static DirectionKind ResolveXmlPortDirection(IXmlPortTypeSymbol xmlPort)
+    {
+        var direction = xmlPort.GetEnumPropertyValue<DirectionKind>(EnumProvider.PropertyKind.Direction);
+        return direction ?? EnumProvider.DirectionKind.Both;
+    }
+
+    private static bool? GetXmlPortNodeBoolProperty(ISymbol nodeSymbol, PropertyKind propertyKind)
+    {
+        return (bool?)nodeSymbol.Properties
+            .FirstOrDefault(p => p.PropertyKind == propertyKind)?.Value;
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedCodeunit.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedCodeunit.al
@@ -1,0 +1,21 @@
+codeunit 50100 "Alpha Codeunit"
+{
+}
+
+codeunit 50101 "Bravo Codeunit"
+{
+}
+
+page 50100 "Alpha Page"
+{
+}
+
+permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    [|Permissions = page "Alpha Page" = X,
+                  codeunit "Bravo Codeunit" = X,
+                  codeunit "Alpha Codeunit" = X|];
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedMixedTypes.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedMixedTypes.al
@@ -1,0 +1,31 @@
+codeunit 50100 "My Codeunit"
+{
+}
+
+page 50100 "My Page"
+{
+}
+
+report 50100 "My Report"
+{
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    [|Permissions = tabledata "My Table" = R,
+                  codeunit "My Codeunit" = X,
+                  page "My Page" = X,
+                  report "My Report" = X|];
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedSingleType.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedSingleType.al
@@ -1,0 +1,33 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Charlie = R,
+                  tabledata Alpha = R,
+                  tabledata Bravo = R|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedTabledata.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasDiagnostic/UnsortedTabledata.al
@@ -1,0 +1,43 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata "My Table" = R,
+                  tabledata "Purchase Document" = R,
+                  tabledata "Dimension Set Entry" = r,
+                  tabledata "My Other Table" = R|];
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 "Dimension Set Entry"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 "My Other Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50103 "Purchase Document"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/PreserveCasing/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/PreserveCasing/current.al
@@ -1,0 +1,33 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Charlie = rImd,
+                  tabledata Alpha = RIMD,
+                  tabledata Bravo = Ri|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/PreserveCasing/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/PreserveCasing/expected.al
@@ -1,0 +1,33 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = RIMD,
+                  tabledata Bravo = Ri,
+                  tabledata Charlie = rImd;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderMixedTypes/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderMixedTypes/current.al
@@ -1,0 +1,31 @@
+codeunit 50100 "My Codeunit"
+{
+}
+
+page 50100 "My Page"
+{
+}
+
+report 50100 "My Report"
+{
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    [|Permissions = tabledata "My Table" = R,
+                  codeunit "My Codeunit" = X,
+                  page "My Page" = X,
+                  report "My Report" = X|];
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderMixedTypes/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderMixedTypes/expected.al
@@ -1,0 +1,31 @@
+codeunit 50100 "My Codeunit"
+{
+}
+
+page 50100 "My Page"
+{
+}
+
+report 50100 "My Report"
+{
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    Permissions = codeunit "My Codeunit" = X,
+                  page "My Page" = X,
+                  report "My Report" = X,
+                  tabledata "My Table" = R;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderTabledata/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderTabledata/current.al
@@ -1,0 +1,43 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata "My Table" = R,
+                  tabledata "Purchase Document" = R,
+                  tabledata "Dimension Set Entry" = r,
+                  tabledata "My Other Table" = R|];
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 "Dimension Set Entry"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 "My Other Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50103 "Purchase Document"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderTabledata/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/ReorderTabledata/expected.al
@@ -1,0 +1,43 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata "Dimension Set Entry" = r,
+                  tabledata "My Other Table" = R,
+                  tabledata "My Table" = R,
+                  tabledata "Purchase Document" = R;
+}
+
+table 50100 "My Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 "Dimension Set Entry"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 "My Other Table"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50103 "Purchase Document"
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/SingleLineToMultiLine/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/SingleLineToMultiLine/current.al
@@ -1,0 +1,22 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Bravo = R, tabledata Alpha = R|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/SingleLineToMultiLine/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/HasFix/SingleLineToMultiLine/expected.al
@@ -1,0 +1,23 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = R,
+                  tabledata Bravo = R;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/AlreadySorted.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/AlreadySorted.al
@@ -1,0 +1,31 @@
+[||]codeunit 50100 "My Codeunit"
+{
+}
+
+page 50100 "My Page"
+{
+}
+
+report 50100 "My Report"
+{
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    Permissions = codeunit "My Codeunit" = X,
+                  page "My Page" = X,
+                  report "My Report" = X,
+                  tabledata Alpha = R;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/NoPermissionsProperty.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/NoPermissionsProperty.al
@@ -1,0 +1,3 @@
+[||]codeunit 50100 "My Codeunit"
+{
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/SingleEntry.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/SingleEntry.al
@@ -1,0 +1,13 @@
+[||]codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = R;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/SortedTabledata.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/NoDiagnostic/SortedTabledata.al
@@ -1,0 +1,33 @@
+[||]codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = R,
+                  tabledata Bravo = R,
+                  tabledata Charlie = R;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/PermissionDeclarationOrder.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionDeclarationOrder/PermissionDeclarationOrder.cs
@@ -1,0 +1,71 @@
+using ALCops.FormattingCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.FormattingCop.Test
+{
+    public class PermissionDeclarationOrder : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.PermissionDeclarationOrder _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.PermissionDeclarationOrder>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(PermissionDeclarationOrder)));
+        }
+
+        [Test]
+        [TestCase("UnsortedTabledata")]
+        [TestCase("UnsortedMixedTypes")]
+        [TestCase("UnsortedSingleType")]
+        [TestCase("UnsortedCodeunit")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionDeclarationOrder);
+        }
+
+        [Test]
+        [TestCase("AlreadySorted")]
+        [TestCase("SingleEntry")]
+        [TestCase("NoPermissionsProperty")]
+        [TestCase("SortedTabledata")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionDeclarationOrder);
+        }
+
+        [Test]
+        [TestCase("ReorderTabledata")]
+        [TestCase("ReorderMixedTypes")]
+        [TestCase("SingleLineToMultiLine")]
+        [TestCase("PreserveCasing")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<PermissionDeclarationOrderCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.PermissionDeclarationOrder);
+        }
+    }
+}

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -150,4 +150,16 @@
   <data name="UseParenthesisForFunctionCallCodeAction" xml:space="preserve">
     <value>Add parenthesis</value>
   </data>
+  <data name="PermissionDeclarationOrderTitle" xml:space="preserve">
+    <value>Permission declarations should be ordered alphabetically</value>
+  </data>
+  <data name="PermissionDeclarationOrderMessageFormat" xml:space="preserve">
+    <value>The Permissions property entries are not ordered alphabetically by type and name.</value>
+  </data>
+  <data name="PermissionDeclarationOrderDescription" xml:space="preserve">
+    <value>Permission entries in the Permissions property should be ordered alphabetically, first by object type (codeunit, page, report, table, tabledata, etc.) and then by object name. Consistent ordering improves readability and reduces merge conflicts.</value>
+  </data>
+  <data name="PermissionDeclarationOrderCodeAction" xml:space="preserve">
+    <value>ALCops: Sort permission declarations alphabetically</value>
+  </data>
 </root>

--- a/src/ALCops.FormattingCop/Analyzers/PermissionDeclarationOrder.cs
+++ b/src/ALCops.FormattingCop/Analyzers/PermissionDeclarationOrder.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.FormattingCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public class PermissionDeclarationOrder : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.PermissionDeclarationOrder);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    private void AnalyzeCompilation(CompilationAnalysisContext ctx)
+    {
+        var compilation = ctx.Compilation;
+
+        foreach (var obj in compilation.GetDeclaredApplicationObjectSymbols())
+        {
+            ctx.CancellationToken.ThrowIfCancellationRequested();
+
+            var permissionsProperty = obj.GetProperty(EnumProvider.PropertyKind.Permissions);
+            if (permissionsProperty is null)
+                continue;
+
+            var permissionsSyntax = permissionsProperty.GetPropertyValueSyntax<PermissionPropertyValueSyntax>();
+            if (permissionsSyntax is null)
+                continue;
+
+            var declaredEntries = permissionsSyntax.PermissionProperties;
+            if (declaredEntries.Count <= 1)
+                continue;
+
+            if (PermissionSyntaxHelper.ArePermissionsSorted(declaredEntries))
+                continue;
+
+            // Report on the PropertySyntax so the CodeFix can find it
+            var location = permissionsSyntax.Parent?.GetLocation() ?? permissionsProperty.GetLocation();
+            if (location is null)
+                continue;
+
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.PermissionDeclarationOrder,
+                location));
+        }
+    }
+}

--- a/src/ALCops.FormattingCop/CodeFixes/PermissionDeclarationOrderCodeFixProvider.cs
+++ b/src/ALCops.FormattingCop/CodeFixes/PermissionDeclarationOrderCodeFixProvider.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using ALCops.Common.Permissions;
-using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;

--- a/src/ALCops.FormattingCop/CodeFixes/PermissionDeclarationOrderCodeFixProvider.cs
+++ b/src/ALCops.FormattingCop/CodeFixes/PermissionDeclarationOrderCodeFixProvider.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.FormattingCop.CodeFixes;
+
+[CodeFixProvider(nameof(PermissionDeclarationOrderCodeFixProvider))]
+public sealed class PermissionDeclarationOrderCodeFixProvider : CodeFixProvider
+{
+    private class PermissionDeclarationOrderCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+
+        public PermissionDeclarationOrderCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.PermissionDeclarationOrder.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(CodeFixContext ctx, SyntaxNode syntaxRoot,
+        TextSpan span, Document document)
+    {
+        var node = syntaxRoot.FindNode(span);
+        var propertySyntax = node as PropertySyntax
+            ?? node.FirstAncestorOrSelf<PropertySyntax>()
+            ?? node.DescendantNodes().OfType<PropertySyntax>().FirstOrDefault();
+        if (propertySyntax is null)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(propertySyntax, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static PermissionDeclarationOrderCodeAction CreateCodeAction(
+        PropertySyntax propertySyntax, Document document, bool generateFixAll)
+    {
+        return new PermissionDeclarationOrderCodeAction(
+            FormattingCopAnalyzers.PermissionDeclarationOrderCodeAction,
+            ct => ApplyFix(document, propertySyntax, ct),
+            nameof(PermissionDeclarationOrderCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(Document document,
+        PropertySyntax propertySyntax, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        if (propertySyntax.Value is not PermissionPropertyValueSyntax permissionValue)
+            return document;
+
+        var permissions = permissionValue.PermissionProperties;
+        if (permissions.Count <= 1)
+            return document;
+
+        var sorted = PermissionSyntaxHelper.GetSortedPermissions(permissions);
+        var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
+
+        PermissionPropertyValueSyntax newPermissionValue;
+        if (sorted.Count >= 2)
+        {
+            // Always use multi-line format for 2+ entries
+            newPermissionValue = PermissionSyntaxHelper.BuildMultiLinePermissionValue(sorted, indentation);
+        }
+        else
+        {
+            newPermissionValue = permissionValue;
+        }
+
+        var newProperty = propertySyntax.WithValue(newPermissionValue);
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var newRoot = root.ReplaceNode(propertySyntax, newProperty);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
@@ -36,6 +36,16 @@ public static class DiagnosticDescriptors
         description: FormattingCopAnalyzers.UseParenthesisForFunctionCallDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseParenthesisForFunctionCall));
 
+    public static readonly DiagnosticDescriptor PermissionDeclarationOrder = new(
+        id: DiagnosticIds.PermissionDeclarationOrder,
+        title: FormattingCopAnalyzers.PermissionDeclarationOrderTitle,
+        messageFormat: FormattingCopAnalyzers.PermissionDeclarationOrderMessageFormat,
+        category: Category.Style,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: FormattingCopAnalyzers.PermissionDeclarationOrderDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.PermissionDeclarationOrder));
+
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/ALCops.FormattingCop/DiagnosticIds.cs
+++ b/src/ALCops.FormattingCop/DiagnosticIds.cs
@@ -5,4 +5,5 @@ public static class DiagnosticIds
     public static readonly string SemicolonAfterMethodOrTriggerDeclaration = "FC0001";
     public static readonly string CasingMismatch = "FC0002";
     public static readonly string UseParenthesisForFunctionCall = "FC0003";
+    public static readonly string PermissionDeclarationOrder = "FC0004";
 }


### PR DESCRIPTION
## Summary

This PR introduces two new analyzer rules (AC0032 and FC0004) and refactors the permission detection infrastructure to support them. The scope grew beyond the original extraction refactor into a full permissions analysis feature set.

## New rules

### AC0032: Table Data Access Unused Permissions (ApplicationCop)
Detects `Permissions` property entries that declare table data access not used by any code in the object. Reports two variants:
- **Entire entry unused**: the table is never accessed at all (e.g., `tabledata "Customer" = R` but no code reads Customer)
- **Partial chars unused**: the declared permissions exceed what the code actually needs (e.g., `RIMD` declared but only `R` is used)

Includes a CodeFix that removes unused entries entirely or reduces permission chars to match actual usage.

**Category**: Design | **Severity**: Info | **ID**: `AC0032`

### FC0004: Permission Declaration Order (FormattingCop)
Enforces alphabetical ordering of entries in the `Permissions` property, sorted first by object type (codeunit, page, report, table, tabledata, etc.) then by object name.

Includes a CodeFix that reorders entries alphabetically, preserving original casing and converting single-line declarations to multi-line when needed.

**Category**: Style | **Severity**: Info | **ID**: `FC0004`

## Refactoring

### RequiredPermissionDetector (extracted from AC0031)
Shared permission detection logic moved from `TableDataAccessRequiresPermissions` into `ALCops.Common/Permissions/RequiredPermissionDetector.cs`. Both AC0031 and AC0032 now consume this helper.

Methods: `TryGetFromInvocation`, `TryGetFromReportDataItem`, `TryGetFromQueryDataItem`, `GetFromXmlPortNode`, `IsSystemTable`, `IsTestCodeunitWithPermissionsDisabled`.

AC0031 reduced from 235 to ~127 lines with zero behavior change.

### MethodOperationMap (magic string cleanup)
Replaced magic permission strings (`"rimdRIMD"`, `"rimd"`) with shared `MethodOperationMap` abstractions (`IsValidPermissionChar`, `CanonicalOrder`). Removed redundant `NormalizePermissionChars` method.

### PermissionSyntaxHelper (expanded)
Extended with new capabilities to support the AC0032 CodeFix and FC0004 rule: permission entry parsing, sorting, and syntax node manipulation.

### RecordMethodClassification (removed)
Replaced by the more capable `RequiredPermissionDetector`. Consumers (`ExplicitlySetRunTrigger`, `PartialRecordOperations`, `TemporaryRecordTriggerInvocation`) updated.

## Performance

### AC0032: optimized from 15.4s to 0.76s on Base Application
Rewrote `TableDataAccessUnusedPermissions` to use `CompilationStartAction` with `RegisterCompilationEndAction` closure pattern, replacing per-invocation `RegisterOperationAction` with `RegisterCodeBlockAction` + `OperationWalker`.

Key optimizations:
- One `GetOperation()` call per method body instead of per invocation node
- Syntax-level pre-filter skips `GetOperation` for methods without DB calls
- Early exit for objects without `Permissions` property (~70% of callbacks)
- Shared state via closures instead of `ConditionalWeakTable`

## Bug fixes
- **AC0031 CodeFix**: Fixed FixAll producing uppercase/phantom entries, stale node references, and index-0 indentation issues
- **AC0031 & AC0032**: Skip `permissionset` and `permissionsetextension` objects (they declare permissions structurally, not for access control)
- **PC0030**: Removed false positive on `GetBySystemId` (not a partial-record-relevant method)

## Test coverage
- **AC0032**: 8 HasDiagnostic, 7 NoDiagnostic, 3 HasFix test cases
- **FC0004**: 4 HasDiagnostic, 4 NoDiagnostic, 4 HasFix test cases
- **AC0031**: 1 new HasFix test case (AddEntryAlphabeticalFirst)

## Stats
- 67 files changed, +3223 / -203 lines
- 17 commits