### PR TITLE
feat: AC0032 Unused Permissions analyzer and CodeFix

### DIFF
--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -110,6 +110,7 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Permission chars are lowercase (`rimd`) | Consistent with AL conventions |
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
+| `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
 
 ## Test coverage
 

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -1,0 +1,119 @@
+---
+applyTo: 'src/ALCops.ApplicationCop/**/TableDataAccessUnusedPermissions*'
+---
+
+# AC0032: Unused Permissions
+
+## Purpose
+
+Detects `Permissions` property entries that have no corresponding table data access in the object. This is the inverse of AC0031 (which detects missing permissions). Reports an Info-level diagnostic per unused permission entry. Unused permissions are dead code because the `Permissions` property only applies to the object that directly accesses the table (no call-stack inheritance).
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | AC0032 |
+| Category | Design |
+| Severity | Info |
+| Help URI | https://alcops.dev/docs/analyzers/applicationcop/ac0032/ |
+
+Two `DiagnosticDescriptor` instances share the same ID but have different message formats:
+- `TableDataAccessUnusedPermissionsEntireEntry`: table not accessed at all
+- `TableDataAccessUnusedPermissionsPartialChars`: table accessed but not all declared RIMD chars are needed
+
+## Architecture
+
+Uses `RegisterCompilationAction` (whole-object analysis) because `CompilationStartAnalysisContext` does not expose `RegisterOperationAction`.
+
+```
+src/ALCops.ApplicationCop/
+├── Analyzers/
+│   └── TableDataAccessUnusedPermissions.cs           # Analyzer (CompilationAction)
+└── CodeFixes/
+    └── TableDataAccessUnusedPermissionsCodeFixProvider.cs  # CodeFix (remove entry / reduce chars / remove property)
+
+src/ALCops.Common/
+└── Permissions/
+    └── RequiredPermissionDetector.cs   # Shared detection logic (also used by AC0031)
+```
+
+### Analysis flow
+
+1. Iterate all objects via `compilation.GetDeclaredApplicationObjectSymbols()`
+2. Skip test codeunits with `TestPermissions = Disabled`
+3. For each object with a `Permissions` property:
+   a. Collect all required permissions (invocations, data items, xmlport nodes)
+   b. Get page SourceTable context (implicit RIMD exemption)
+   c. For each declared `tabledata` entry, check if the table is accessed
+4. Report per-entry diagnostics with properties for the CodeFix
+
+### Key methods
+
+| Method | Purpose |
+|---|---|
+| `AnalyzeCompilation` | Entry point; iterates objects |
+| `CollectRequiredPermissions` | Aggregates all table accesses in the object |
+| `CollectFromInvocations` | Walks syntax tree for `InvocationExpression` nodes, bridges to `SemanticModel.GetOperation()` |
+| `AnalyzePermissionEntry` | Compares one declared entry against collected required permissions |
+| `PermissionMatchesTable` | Matches identifier/qualified/objectId syntax against `ITableTypeSymbol` |
+
+### Threading model
+
+Single-threaded. `RegisterCompilationAction` runs once after compilation completes. No `ConcurrentDictionary` needed (unlike the earlier CompilationStart+End design).
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| `RegisterCompilationAction` instead of CompilationStart+End | `CompilationStartAnalysisContext` lacks `RegisterOperationAction` |
+| Whole-object analysis (not per-invocation collection) | Simpler, no thread-safety concerns, single pass |
+| Two descriptors sharing one ID | Same conceptual rule, different message clarity |
+| `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
+| Page SourceTable exemption | Pages implicitly need RIMD on their source table |
+| Temporary records NOT exempted | Declaring permissions on temp-only tables is dead code |
+| `DeclaredPermissionSet` reused for RIMD tracking | Existing type from AC0031's permission module |
+
+## CodeFix
+
+The `TableDataAccessUnusedPermissionsCodeFixProvider` removes or reduces unused permission entries. Supports FixAll.
+
+### Scenarios
+
+| Scenario | Behavior |
+|---|---|
+| Entire entry unused, other entries remain | Remove the entry from the permission list |
+| Entire entry unused, only entry | Remove the entire `Permissions` property |
+| Partial chars unused | Replace permission chars with only the used subset |
+
+### Data passing (analyzer -> CodeFix)
+
+`ImmutableDictionary<string, string>` properties on the diagnostic:
+- `TableName`: table name as written in the permission declaration
+- `UnusedChars`: chars to remove (e.g., "imd")
+- `UsedChars`: chars to keep (e.g., "r"); empty string when entire entry is unused
+
+### Node finding
+
+`syntaxRoot.FindNode(span)` may return `PermissionPropertyValueSyntax` instead of `PermissionSyntax` when there is only one entry (identical spans). The code fix handles this by searching descendants:
+```csharp
+var permissionNode = node as PermissionSyntax
+    ?? node.FirstAncestorOrSelf<PermissionSyntax>()
+    ?? node.DescendantNodes().OfType<PermissionSyntax>().FirstOrDefault();
+```
+
+### Trivia handling
+
+When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remove` preserves the second entry's leading trivia (newline + indent). The code fix strips this trivia to avoid `Permissions =\n              tabledata ...` artifacts.
+
+## Test coverage
+
+**HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
+**NoDiagnostic (6 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead.
+**HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
+
+## Known limitations
+
+1. **Extension objects**: Cannot see base object code; may flag permissions needed by the base as unused
+2. **CalcFields/CalcSums**: Indirect table access through FlowFields is not traced
+3. **InherentPermissions overlap**: Table-level `InherentPermissions` may make an object-level entry redundant, but the analyzer does not flag this (different concern from unused)
+4. **Cross-object calls**: If codeunit A calls codeunit B, and B accesses a table, A's permission for that table appears unused (correct, because permissions don't flow through the call stack)

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -88,6 +88,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0013-field-groups-required` | rule-scoped | AC0013 rule |
 | `ac0026-allow-in-customizations-for-omitted-fields` | rule-scoped | AC0026 rule |
 | `ac0031-table-data-access-requires-permissions` | rule-scoped | AC0031 rule |
+| `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/ac0045-unused-permissions.instructions.md
+++ b/ac0045-unused-permissions.instructions.md
@@ -1,0 +1,270 @@
+# AC0045: Unused Permissions (Inverse of AC0031)
+
+## Goal
+
+Create a new diagnostic rule that detects **declared permissions that are not needed** by any code in the object. This is the inverse of AC0031 (TableDataAccessRequiresPermissions), which detects table data access not covered by permissions. AC0045 detects permissions that have no corresponding table data access.
+
+The diagnostic ID AC0045 is a placeholder. Check `DiagnosticIds.cs` for the next available ID before implementation.
+
+## Example
+
+```AL
+codeunit 50100 MyCodeunit
+{
+    Permissions = tabledata Customer = rimd,    // ← AC0045: 'i', 'm', 'd' are unused (only Read is needed)
+                  tabledata "Sales Header" = r;  // ← AC0045: no code accesses Sales Header at all
+
+    procedure DoSomething()
+    var
+        Cust: Record Customer;
+    begin
+        Cust.FindFirst(); // Read only
+    end;
+}
+```
+
+## Shared infrastructure in ALCops.Common/Permissions/
+
+The AC0031 rewrite moved all permission logic to `ALCops.Common/Permissions/`. This module is designed for reuse by the inverse rule:
+
+| File | Purpose | Reuse for AC0045 |
+|---|---|---|
+| `DatabaseOperation.cs` | Enum: None, Read, Insert, Modify, Delete | Direct reuse |
+| `MethodOperationMap.cs` | Maps AL method names (Find, Insert, Modify, Delete, etc.) to `DatabaseOperation` | Direct reuse: same method-to-operation mapping |
+| `RequiredPermission.cs` | Record struct: Table + VariableType + Operation + Location | Direct reuse: collect all required permissions |
+| `DeclaredPermissionSet.cs` | Tracks granted RIMD per table | May need extension: track which chars are *used* |
+| `PermissionResolver.cs` | `IsCovered()` checks if a required permission is covered by declarations | **Inverse needed**: collect all *declared* permissions, then diff against *required* |
+| `PermissionSyntaxHelper.cs` | Syntax helpers for multi-line format, sorted insertion, etc. | Reuse for CodeFix (removing entries) |
+| `PermissionTableNameResolver.cs` | Namespace resolution for table names in CodeFix | Reuse for CodeFix |
+
+### PermissionResolver resolution order (AC0031)
+
+AC0031 checks these sources in order when determining if a required permission is covered:
+
+1. **Page SourceTable exemption**: All CRUD on the page's own source table is always exempt
+2. **Table-level `InherentPermissions` property**: Permission granted on the table definition itself
+3. **Method-level `[InherentPermissions]` attribute**: Permission granted per-method
+4. **Object-level `Permissions` property**: The `Permissions = tabledata ...` property
+
+For the inverse rule (AC0045), only source #4 (object-level `Permissions` property) matters. Sources #1-#3 are "implicit" permissions that don't appear in the `Permissions` property, so they can't be "unused" in the same way.
+
+## Architecture approach
+
+### Key difference from AC0031
+
+AC0031 uses **per-invocation analysis** (RegisterOperationAction on each method call). It checks: "does this single call have permission?" and reports immediately if not.
+
+AC0045 requires **whole-object analysis**: collect ALL required permissions across the entire object, then compare against ALL declared permissions. You can't determine if a permission is unused by looking at one call site.
+
+### Recommended analysis strategy
+
+```
+1. Register a CompilationAction or SymbolAction on the object level (codeunit, report, xmlport, query)
+2. For the object:
+   a. Parse the Permissions property → get all declared tabledata entries
+   b. Walk all code in the object → collect all required permissions (table + operation)
+   c. For each declared permission entry:
+      - If the table is not accessed at all → report "entire entry unused"
+      - If the table is accessed but some RIMD chars aren't needed → report "specific chars unused"
+```
+
+### What to collect as "required permissions"
+
+Reuse the same detection logic as AC0031's four analysis callbacks:
+
+| Source | What it detects | Operation |
+|---|---|---|
+| `AnalyzeInvocation` | `Record.Find()`, `Record.Insert()`, etc. | Per method name via `MethodOperationMap` |
+| `AnalyzeReportDataItem` | Report DataItem referencing a table | Read |
+| `AnalyzeQueryDataItem` | Query DataItem referencing a table | Read |
+| `AnalyzeXmlPortNode` | XmlPort table node | Read/Insert/Modify based on Direction + Auto* properties |
+
+Consider extracting the "collect required permissions" logic into a shared helper in `ALCops.Common/Permissions/` so both AC0031 and AC0045 can use it. AC0031 currently reports per-invocation, so this may require refactoring AC0031 to share the collection phase, or AC0045 can duplicate the collection independently.
+
+### Exemptions to carry over from AC0031
+
+- **System tables** (ID > 2,000,000,000): Skip
+- **Temporary records**: Skip (no real DB access)
+- **Test codeunits with `TestPermissions = Disabled`**: Skip
+- **Obsolete symbols**: Skip
+- **Page SourceTable**: The page's own source table implicitly requires RIMD, so `Permissions` entries for it are NOT unused
+- **InherentPermissions**: If a method has `[InherentPermissions(..., Database::"Customer", 'r')]`, that doesn't mean the object-level `Permissions` entry for Customer Read is unused. The object-level entry may still be needed for other methods without the attribute.
+
+### Edge cases to consider
+
+1. **Permissions inherited from base objects**: A page extension might declare permissions for tables accessed in the base page. These are not "unused" but the analyzer can't see the base page's code. Consider skipping extension objects initially (AC0031 CodeFix already skips `ApplicationObjectExtensionSyntax`).
+
+2. **Permissions for indirect access**: A codeunit might declare permissions for tables accessed by called codeunits. The analyzer can only see direct code, not cross-object calls. This is a known limitation. Consider making the severity Info (not Warning) to account for this.
+
+3. **Permission sets referenced via PermissionSet objects**: Out of scope. Only analyze the object's `Permissions` property.
+
+4. **CalcFields/CalcSums**: These access FlowField source tables indirectly. AC0031 doesn't cover these yet either. Track as a known limitation.
+
+5. **Multiple variables of the same table type**: A codeunit might have `Cust1: Record Customer` and `Cust2: Record Customer`. The required operations should be unioned across all variables of the same table.
+
+## Diagnostic properties
+
+| Property | Suggested value |
+|---|---|
+| ID | AC0045 (placeholder, check `DiagnosticIds.cs`) |
+| Category | Design |
+| Severity | Info (not Warning, because of indirect access limitations) |
+| Help URI | `https://alcops.dev/docs/analyzers/applicationcop/ac0045/` |
+
+### Message format options
+
+Two scenarios need different messages:
+
+1. **Entire entry unused**: `Permission 'tabledata {TableName}' is declared but no code accesses this table.`
+2. **Specific chars unused**: `Permission '{UnusedChars}' on 'tabledata {TableName}' is declared but not needed. Only '{UsedChars}' is required.`
+
+## CodeFix
+
+### Scenario 1: Remove entire unused permission entry
+
+Remove the `tabledata "Sales Header" = r` entry from the Permissions list. Reuse `PermissionSyntaxHelper` for format-aware removal (preserve multi-line/single-line style).
+
+### Scenario 2: Reduce permission chars
+
+Change `tabledata Customer = rimd` to `tabledata Customer = r`. Reuse `PermissionSyntaxHelper.NormalizePermissionString()` for canonical ordering.
+
+### Scenario 3: Remove entire Permissions property
+
+If ALL entries are unused, remove the entire `Permissions = ...;` property. This is the simplest case syntactically.
+
+### CodeFix data passing (analyzer → CodeFix)
+
+Use the `CodeFixProperties` record pattern (see `codefix-development.instructions.md`):
+
+```csharp
+#if NET8_0_OR_GREATER
+private sealed record CodeFixProperties(string TableName, string UnusedChars, string UsedChars)
+{
+    public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties) { ... }
+}
+#endif
+```
+
+The analyzer should pass:
+- `TableName`: The table name as it appears in the Permissions property
+- `UnusedChars`: The permission chars to remove (e.g., "imd")
+- `UsedChars`: The permission chars to keep (e.g., "r"), empty if entire entry is unused
+
+## Test scenarios
+
+### HasDiagnostic (permission IS unused)
+
+| Test case | Description |
+|---|---|
+| EntireEntryUnused | `Permissions = tabledata Customer = r` but no code accesses Customer |
+| PartialCharsUnused | `Permissions = tabledata Customer = rimd` but only Read used |
+| MultipleUnusedEntries | Multiple tabledata entries, some used, some not |
+| SingleCharUnused | `tabledata Customer = ri` but only Read used (single 'i' unused) |
+| NoCodeInCodeunit | Empty codeunit with Permissions declared |
+| UnusedOnReport | Report with permissions for table not in any DataItem |
+| UnusedOnXmlPort | XmlPort with permissions for table not accessed |
+| UnusedOnQuery | Query with permissions for table not in any DataItem |
+
+### NoDiagnostic (permission IS needed)
+
+| Test case | Description |
+|---|---|
+| AllPermissionsUsed | All declared RIMD chars have corresponding code |
+| PageSourceTable | Permission for the page's own SourceTable (implicitly needed) |
+| InherentPermissionsOnTable | Table has InherentPermissions, but object-level entry still used by other paths |
+| TemporaryRecord | Temporary record, permissions should be ignored entirely |
+| SystemTable | System table (ID > 2B), no diagnostic |
+| TestCodeunitDisabled | Test codeunit with TestPermissions = Disabled |
+| ReadFromFind | Basic `Record.FindFirst()` matches `= r` |
+| InsertUsed | `Record.Insert()` matches `= i` |
+| ModifyUsed | `Record.Modify()` matches `= m` |
+| DeleteUsed | `Record.Delete()` matches `= d` |
+| MultipleMethodsSameTable | Multiple different operations on same table, all covered |
+| ReportDataItemRead | Report DataItem counts as Read |
+| QueryDataItemRead | Query DataItem counts as Read |
+| XmlPortImport | XmlPort import direction uses Insert+Modify |
+| XmlPortExport | XmlPort export direction uses Read |
+
+### HasFix (CodeFix scenarios)
+
+| Test case | Description |
+|---|---|
+| RemoveEntireEntry | Remove one unused tabledata entry from multi-entry list |
+| RemoveEntireEntryLastItem | Remove the last entry (handle trailing comma) |
+| ReduceChars | Change `= rimd` to `= r` |
+| RemoveEntireProperty | All entries unused, remove entire `Permissions = ...;` |
+| RemoveEntryMultiLine | Multi-line format, remove one entry, preserve formatting |
+| RemoveEntrySingleLine | Single-line format, remove one entry |
+
+## Lessons learned from AC0031
+
+These are patterns and pitfalls discovered during the AC0031 rewrite that apply directly:
+
+### Enum-based comparisons, not string comparisons
+
+Never use `string.Equals(property.Name, "Subtype")`. Always use:
+- `EnumProvider.PropertyKind.Subtype` for property kinds
+- `GetEnumPropertyValue<CodeunitSubtypeKind>()` for property values
+- `EnumProvider.SyntaxKind.*` for syntax kinds
+- See `analyzer-development.instructions.md` for the full list
+
+### SeparatedSyntaxList.Insert() trivia bug
+
+`SeparatedSyntaxList<T>.Insert()` creates comma separators with **default trivia** (space only). For multi-line permission lists, the comma needs trailing `\n` trivia. The fix: after `Insert()`, find the separator missing newline trivia and replace it with a template from an existing separator. See `PermissionSyntaxHelper.InsertIntoMultiLineList()`.
+
+This applies to the CodeFix for AC0045 as well if you need to modify entries in-place.
+
+### PropertySyntax has no PropertyKind enum
+
+At the **syntax** level, `PropertySyntax` only has `.Name.Identifier.ValueText` (string). The `PropertyKind` enum is only on `IPropertySymbol` (semantic/symbol level). In CodeFixes that work with syntax trees, use `nameof(PropertyKind.Permissions)` for compile-time safety.
+
+### Test fixture naming
+
+Use names that sort correctly for alphabetical tests. Avoid MyTableOne/Two/Three (Three < Two alphabetically). Use Alpha/Bravo/Charlie or similar.
+
+### ApprovalTests masking real errors
+
+`RoslynTestKit.Verify.CodeAction` tries to load `ApprovalTests` assembly for diff reporting. If missing, `FileNotFoundException` is thrown BEFORE the actual test error. If CodeFix tests fail with assembly errors, temporarily add `ApprovalTests 3.0.0` NuGet to see real diffs, then remove it.
+
+### netstandard2.1 compatibility
+
+- Records need `#if NETSTANDARD2_1` / `#if NET8_0_OR_GREATER` dual definitions
+- `System.Text.Json` unavailable on netstandard2.1 (use `Newtonsoft.Json`)
+- `System.Collections.Immutable` needs explicit NuGet reference
+- See `netstandard21-compatibility.instructions.md`
+
+## Files to create/modify
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `src/ALCops.ApplicationCop/Analyzers/UnusedPermissions.cs` | Analyzer |
+| `src/ALCops.ApplicationCop/CodeFixes/UnusedPermissions.cs` | CodeFix |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/UnusedPermissions.cs` | Test class |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/HasDiagnostic/*/current.al` | Test fixtures |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/NoDiagnostic/*.al` | Test fixtures |
+| `src/ALCops.ApplicationCop.Test/Rules/UnusedPermissions/HasFix/*/current.al` + `expected.al` | Test fixtures |
+| `.github/instructions/ac0045-unused-permissions.instructions.md` | Rule instruction file |
+| `../alcops.dev/content/docs/analyzers/ApplicationCop/AC0045.md` | Documentation page |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/ALCops.ApplicationCop/DiagnosticIds.cs` | Add `UnusedPermissions = "AC0045"` |
+| `src/ALCops.ApplicationCop/DiagnosticDescriptors.cs` | Add descriptor |
+| `src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx` | Add Title, MessageFormat, Description, CodeAction strings |
+| `ALCops.Common/Permissions/` | Possibly extract shared "collect required permissions" helper |
+
+## Open questions to discuss before implementation
+
+1. **Should the analyzer scan the whole object in one pass, or use per-invocation collection with a final symbol-level check?** A CompilationEndAction could aggregate per-invocation results, but this adds complexity. A single SymbolAction on the object that walks all descendants may be simpler.
+
+2. **How to handle extension objects?** The extension can't see what the base object accesses. Options: skip extensions entirely (simplest), or only flag permissions for tables the extension itself declares variables for.
+
+3. **Should we refactor AC0031 to share the "collect required permissions" logic, or let AC0045 have its own collection?** Sharing reduces duplication but risks coupling. AC0031's per-invocation model is different from AC0045's whole-object model.
+
+4. **Should we report one diagnostic per unused char, or one diagnostic per unused entry?** Per-entry with the full list of unused chars seems cleaner (fewer diagnostics, one CodeFix per entry).
+
+5. **What about permissions for tables accessed via Codeunit.Run or Event subscribers?** These are indirect and the analyzer can't trace them. Accept this as a known limitation and use Info severity.

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/EntireEntryUnused.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/EntireEntryUnused.al
@@ -1,0 +1,22 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/MultipleUnusedEntries.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/MultipleUnusedEntries.al
@@ -1,0 +1,37 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|],
+                  [|tabledata OtherTable = r|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/NoCodeInCodeunit.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/NoCodeInCodeunit.al
@@ -1,0 +1,18 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/PartialCharsUnused.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/PartialCharsUnused.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/TemporaryRecord.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/TemporaryRecord.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnQuery.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnQuery.al
@@ -1,0 +1,42 @@
+query 50000 MyQuery
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    elements
+    {
+        dataitem(MyTable; MyTable)
+        {
+            column(MyField; MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnReport.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnReport.al
@@ -1,0 +1,39 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnXmlPort.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/UnusedOnXmlPort.al
@@ -1,0 +1,45 @@
+xmlport 50000 MyXmlPort
+{
+    Permissions = [|tabledata OtherTable = r|];
+
+    schema
+    {
+        textelement(Root)
+        {
+            tableelement(MyTable; MyTable)
+            {
+                fieldelement(MyField; MyTable.MyField)
+                {
+                }
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/current.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/ReduceChars/expected.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata MyTable = r;
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/current.al
@@ -1,0 +1,40 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|],
+                  tabledata OtherTable = r;
+
+    trigger OnRun()
+    var
+        OtherTable: Record OtherTable;
+    begin
+        OtherTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireEntry/expected.al
@@ -1,0 +1,39 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata OtherTable = r;
+
+    trigger OnRun()
+    var
+        OtherTable: Record OtherTable;
+    begin
+        OtherTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 OtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/current.al
@@ -1,0 +1,22 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasFix/RemoveEntireProperty/expected.al
@@ -1,0 +1,21 @@
+codeunit 50000 MyCodeunit
+{
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/AllPermissionsUsed.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/AllPermissionsUsed.al
@@ -1,0 +1,28 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+        MyTable.Insert();
+        MyTable.Modify();
+        MyTable.Delete();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PageSourceTable.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PageSourceTable.al
@@ -1,0 +1,29 @@
+page 50000 MyPage
+{
+    SourceTable = MyTable;
+    Permissions = [|tabledata MyTable = rimd|];
+
+    layout
+    {
+        area(Content)
+        {
+            field(MyField; Rec.MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/QueryDataItemRead.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/QueryDataItemRead.al
@@ -1,0 +1,28 @@
+query 50000 MyQuery
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    elements
+    {
+        dataitem(MyTable; MyTable)
+        {
+            column(MyField; MyField)
+            {
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReadUsed.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReadUsed.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemRead.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemRead.al
@@ -1,0 +1,25 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/TestCodeunitDisabled.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/TestCodeunitDisabled.al
@@ -1,0 +1,24 @@
+codeunit 50000 MyCodeunit
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+    Permissions = [|tabledata MyTable = rimd|];
+
+    trigger OnRun()
+    begin
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -1,0 +1,98 @@
+using ALCops.ApplicationCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.ApplicationCop.Test
+{
+    public class TableDataAccessUnusedPermissions : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.TableDataAccessUnusedPermissions _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.TableDataAccessUnusedPermissions>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(TableDataAccessUnusedPermissions)));
+        }
+
+        [Test]
+        [TestCase("EntireEntryUnused")]
+        [TestCase("PartialCharsUnused")]
+        [TestCase("MultipleUnusedEntries")]
+        [TestCase("NoCodeInCodeunit")]
+        [TestCase("UnusedOnReport")]
+        [TestCase("UnusedOnQuery")]
+        [TestCase("UnusedOnXmlPort")]
+        [TestCase("TemporaryRecord")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataAccessUnusedPermissions);
+        }
+
+        [Test]
+        [TestCase("AllPermissionsUsed")]
+        [TestCase("PageSourceTable")]
+        [TestCase("TestCodeunitDisabled")]
+        [TestCase("ReadUsed")]
+        [TestCase("ReportDataItemRead")]
+        [TestCase("QueryDataItemRead")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataAccessUnusedPermissions);
+        }
+
+        [Test]
+        [TestCase("RemoveEntireEntry")]
+        [TestCase("RemoveEntireProperty")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<TableDataAccessUnusedPermissionsCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry);
+        }
+
+        [Test]
+        [TestCase("ReduceChars")]
+        public async Task HasFixPartialChars(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<TableDataAccessUnusedPermissionsCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars);
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -426,6 +426,21 @@
   <data name="UseReturnValueForDatabaseReadMethodsDescription" xml:space="preserve">
     <value>Database read methods, like Record.Get(), returns a boolean indicating whether the record was successfully retrieved. Failing to use this return value can lead to uncaught errors, poor error handling, and a lack of actionable feedback for users when something goes wrong.</value>
   </data>
+  <data name="TableDataAccessUnusedPermissionsTitle" xml:space="preserve">
+    <value>Unused permission declared</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsEntireEntryMessageFormat" xml:space="preserve">
+    <value>Permission 'tabledata {0}' is declared but no code in this object accesses table '{0}'.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsPartialCharsMessageFormat" xml:space="preserve">
+    <value>Permission '{0}' on 'tabledata {1}' is not needed. Only '{2}' is required.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsDescription" xml:space="preserve">
+    <value>The Permissions property declares table data access that is not used by any code in this object. Unused permissions are dead code and should be removed or reduced to match actual usage. The Permissions property only applies to direct table access within the object itself; it does not flow through to called objects.</value>
+  </data>
+  <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
+    <value>ALCops: Remove unused permission for table '{0}'</value>
+  </data>
   <data name="ZeroEnumValueReservedForEmptyTitle" xml:space="preserve">
     <value>Reserve Enum value zero (0) for empty value</value>
   </data>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -363,6 +363,9 @@
   <data name="TableDataAccessRequiresPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Add missing permission '{0}' for table '{1}'</value>
   </data>
+  <data name="TableDataAccessRequiresPermissionsFixAllCodeAction" xml:space="preserve">
+    <value>ALCops: Add all missing permissions</value>
+  </data>
   <data name="TableDataPerCompanyDeclarationTitle" xml:space="preserve">
     <value>DataPerCompany must be explicitly set on table objects</value>
   </data>

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -1,0 +1,355 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
+
+namespace ALCops.ApplicationCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(
+            DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry,
+            DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    private void AnalyzeCompilation(CompilationAnalysisContext ctx)
+    {
+        var compilation = ctx.Compilation;
+
+        foreach (var obj in compilation.GetDeclaredApplicationObjectSymbols())
+        {
+            ctx.CancellationToken.ThrowIfCancellationRequested();
+
+            if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(obj))
+                continue;
+
+            var permissionsProperty = obj.GetProperty(EnumProvider.PropertyKind.Permissions);
+            if (permissionsProperty is null)
+                continue;
+
+            var permissionsSyntax = permissionsProperty.GetPropertyValueSyntax<PermissionPropertyValueSyntax>();
+            if (permissionsSyntax is null)
+                continue;
+
+            var declaredEntries = permissionsSyntax.PermissionProperties;
+            if (declaredEntries.Count == 0)
+                continue;
+
+            var requiredPermissions = CollectRequiredPermissions(obj, compilation, ctx.CancellationToken);
+            var pageContext = PermissionResolver.GetPageContext(obj);
+
+            foreach (var entry in declaredEntries)
+            {
+                if (!entry.ObjectType.IsKind(EnumProvider.SyntaxKind.TableDataKeyword))
+                    continue;
+
+                AnalyzePermissionEntry(entry, requiredPermissions, pageContext, ctx.ReportDiagnostic);
+            }
+        }
+    }
+
+    private static void AnalyzePermissionEntry(
+        PermissionSyntax entry,
+        List<RequiredPermission> requiredPermissions,
+        IPageBaseTypeSymbol? pageContext,
+        Action<Diagnostic> reportDiagnostic)
+    {
+        var identifier = entry.ObjectReference.Identifier;
+
+        // Page SourceTable exemption: the page's own source table implicitly needs permissions
+        if (pageContext?.RelatedTable is not null
+            && PermissionMatchesTable(identifier, pageContext.RelatedTable))
+            return;
+
+        // Find all required permissions that match this declared entry
+        var matchingOps = new DeclaredPermissionSet();
+        bool hasMatch = false;
+
+        foreach (var required in requiredPermissions)
+        {
+            if (PermissionMatchesTable(identifier, required.Table))
+            {
+                matchingOps.Grant(required.Operation);
+                hasMatch = true;
+            }
+        }
+
+        var declaredChars = entry.Permissions.ValueText ?? string.Empty;
+        var tableName = GetDisplayTableName(entry);
+
+        if (!hasMatch)
+        {
+            // Table not accessed at all
+            var normalizedDeclared = NormalizePermissionChars(declaredChars);
+            var properties = BuildProperties(tableName, normalizedDeclared, string.Empty);
+            reportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry,
+                entry.GetLocation(),
+                properties,
+                tableName));
+            return;
+        }
+
+        var unusedChars = GetUnusedChars(declaredChars, matchingOps);
+        if (unusedChars.Length > 0)
+        {
+            var usedChars = GetUsedChars(declaredChars, matchingOps);
+            var properties = BuildProperties(tableName, unusedChars, usedChars);
+            reportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.TableDataAccessUnusedPermissionsPartialChars,
+                entry.GetLocation(),
+                properties,
+                unusedChars,
+                tableName,
+                usedChars));
+        }
+    }
+
+    /// <summary>
+    /// Matches a permission entry's table reference against a table type symbol.
+    /// Handles IdentifierNameSyntax, QualifiedNameSyntax, and ObjectIdSyntax.
+    /// </summary>
+    private static bool PermissionMatchesTable(SyntaxNode identifier, ITableTypeSymbol table)
+    {
+        if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
+        {
+            var name = ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier();
+            return name is not null && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
+        {
+            if (int.TryParse(((ObjectIdSyntax)identifier).Value.ValueText, out var objectId))
+                return objectId == table.Id;
+            return false;
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.QualifiedName)
+        {
+            var qualified = (QualifiedNameSyntax)identifier;
+            var qualifier = qualified.Left.GetText().ToString();
+            var name = qualified.Right.Identifier.ValueText?.UnquoteIdentifier();
+
+            if (name is null)
+                return false;
+
+            var tableNamespace = table.OriginalDefinition.GetContainingNamespaceQualifiedNameWithReflection();
+            return qualifier.Equals(tableNamespace, StringComparison.OrdinalIgnoreCase)
+                && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Walks all code in the object and collects required database permissions.
+    /// </summary>
+    private static List<RequiredPermission> CollectRequiredPermissions(
+        IApplicationObjectTypeSymbol obj,
+        Compilation compilation,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<RequiredPermission>();
+
+        CollectFromInvocations(obj, compilation, result, cancellationToken);
+        CollectFromReportDataItems(obj, result);
+        CollectFromQueryDataItems(obj, result);
+        CollectFromXmlPortNodes(obj, result);
+
+        return result;
+    }
+
+    private static void CollectFromInvocations(
+        IApplicationObjectTypeSymbol obj,
+        Compilation compilation,
+        List<RequiredPermission> result,
+        CancellationToken cancellationToken)
+    {
+        var syntaxRef = obj.DeclaringSyntaxReference;
+        if (syntaxRef is null)
+            return;
+
+        var syntaxNode = syntaxRef.GetSyntax();
+        var syntaxTree = syntaxNode.SyntaxTree;
+        if (syntaxTree is null)
+            return;
+
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        syntaxNode.WalkDescendantsAndPerformAction(node =>
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
+                return;
+
+            var operation = semanticModel.GetOperation(node, cancellationToken) as IInvocationExpression;
+            if (operation is null)
+                return;
+
+            var containingSymbol = semanticModel.GetDeclaredSymbol(
+                FindContainingMethodOrTrigger(node), cancellationToken);
+
+            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, containingSymbol ?? obj);
+            if (required is not null)
+                result.Add(required.Value);
+        });
+    }
+
+    private static SyntaxNode FindContainingMethodOrTrigger(SyntaxNode node)
+    {
+        var current = node.Parent;
+        while (current is not null)
+        {
+            if (current.IsKind(EnumProvider.SyntaxKind.MethodDeclaration)
+                || current.IsKind(EnumProvider.SyntaxKind.TriggerDeclaration))
+                return current;
+            current = current.Parent;
+        }
+
+        return node;
+    }
+
+    private static void CollectFromReportDataItems(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IReportTypeSymbol report)
+            return;
+
+        var dataItems = new List<ISymbol>();
+        CollectReportDataItemsRecursively(report, dataItems);
+
+        foreach (var dataItem in dataItems)
+        {
+            var required = RequiredPermissionDetector.TryGetFromReportDataItem(dataItem);
+            if (required is not null)
+                result.Add(required.Value);
+        }
+    }
+
+    /// <summary>
+    /// Recursively collects all report data item symbols, including nested ones.
+    /// </summary>
+    private static void CollectReportDataItemsRecursively(IContainerSymbol container, List<ISymbol> result)
+    {
+        foreach (var member in container.GetMembers())
+        {
+            if (member.Kind == EnumProvider.SymbolKind.ReportDataItem)
+            {
+                result.Add(member);
+                if (member is IContainerSymbol nestedContainer)
+                    CollectReportDataItemsRecursively(nestedContainer, result);
+            }
+        }
+    }
+
+    private static void CollectFromQueryDataItems(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IQueryTypeSymbol query)
+            return;
+
+        foreach (var member in query.GetMembers())
+        {
+            if (member.Kind != EnumProvider.SymbolKind.QueryDataItem)
+                continue;
+
+            var required = RequiredPermissionDetector.TryGetFromQueryDataItem(member);
+            if (required is not null)
+                result.Add(required.Value);
+        }
+    }
+
+    private static void CollectFromXmlPortNodes(
+        IApplicationObjectTypeSymbol obj,
+        List<RequiredPermission> result)
+    {
+        if (obj is not IXmlPortTypeSymbol xmlPort)
+            return;
+
+        foreach (var member in xmlPort.GetMembers())
+        {
+            if (member.Kind != EnumProvider.SymbolKind.XmlPortNode)
+                continue;
+
+            foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(member))
+                result.Add(required);
+        }
+    }
+
+    /// <summary>
+    /// Gets a display name for the table from a permission entry.
+    /// Uses the original text as written in the permission declaration.
+    /// </summary>
+    private static string GetDisplayTableName(PermissionSyntax entry)
+    {
+        var identifier = entry.ObjectReference.Identifier;
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
+            return ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier() ?? string.Empty;
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.QualifiedName)
+        {
+            var qualified = (QualifiedNameSyntax)identifier;
+            return qualified.Right.Identifier.ValueText?.UnquoteIdentifier() ?? string.Empty;
+        }
+
+        if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
+            return ((ObjectIdSyntax)identifier).Value.ValueText ?? string.Empty;
+
+        return entry.ObjectReference.GetText().ToString().Trim();
+    }
+
+    private static string NormalizePermissionChars(string chars)
+    {
+        return new string(chars
+            .Where(c => "rimdRIMD".Contains(c))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static string GetUsedChars(string declaredChars, DeclaredPermissionSet required)
+    {
+        return new string(declaredChars
+            .Where(c => "rimdRIMD".Contains(c) && required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static string GetUnusedChars(string declaredChars, DeclaredPermissionSet required)
+    {
+        return new string(declaredChars
+            .Where(c => "rimdRIMD".Contains(c) && !required.HasPermission(MethodOperationMap.FromPermissionChar(c)))
+            .Select(c => char.ToLowerInvariant(c))
+            .Distinct()
+            .OrderBy(c => "rimd".IndexOf(c))
+            .ToArray());
+    }
+
+    private static ImmutableDictionary<string, string> BuildProperties(
+        string tableName, string unusedChars, string usedChars)
+    {
+        return ImmutableDictionary<string, string>.Empty
+            .Add("TableName", tableName)
+            .Add("UnusedChars", unusedChars)
+            .Add("UsedChars", usedChars);
+    }
+}

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -73,7 +73,8 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle => Title;
+        public override string? FixAllTitle =>
+            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
 
         public TableDataAccessRequiresPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -1,0 +1,208 @@
+using System.Collections.Immutable;
+using ALCops.Common.Permissions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.ApplicationCop.CodeFixes;
+
+[CodeFixProvider(nameof(TableDataAccessUnusedPermissionsCodeFixProvider))]
+public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixProvider
+{
+#if NETSTANDARD2_1
+    private sealed class CodeFixProperties
+    {
+        public string TableName { get; }
+        public string UnusedChars { get; }
+        public string UsedChars { get; }
+
+        private CodeFixProperties(string tableName, string unusedChars, string usedChars)
+        {
+            TableName = tableName;
+            UnusedChars = unusedChars;
+            UsedChars = usedChars;
+        }
+
+        public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+        {
+            if (properties is null)
+                return null;
+
+            if (!properties.TryGetValue(nameof(TableName), out var tableName) || string.IsNullOrEmpty(tableName))
+                return null;
+
+            if (!properties.TryGetValue(nameof(UnusedChars), out var unusedChars) || string.IsNullOrEmpty(unusedChars))
+                return null;
+
+            properties.TryGetValue(nameof(UsedChars), out var usedChars);
+
+            return new CodeFixProperties(tableName, unusedChars, usedChars ?? string.Empty);
+        }
+    }
+#endif
+
+#if NET8_0_OR_GREATER
+    private sealed record CodeFixProperties(string TableName, string UnusedChars, string UsedChars)
+    {
+        public static CodeFixProperties? TryParse(ImmutableDictionary<string, string>? properties)
+        {
+            if (properties is null)
+                return null;
+
+            if (!properties.TryGetValue(nameof(TableName), out var tableName) || string.IsNullOrEmpty(tableName))
+                return null;
+
+            if (!properties.TryGetValue(nameof(UnusedChars), out var unusedChars) || string.IsNullOrEmpty(unusedChars))
+                return null;
+
+            properties.TryGetValue(nameof(UsedChars), out var usedChars);
+
+            return new CodeFixProperties(tableName, unusedChars, usedChars ?? string.Empty);
+        }
+    }
+#endif
+
+    private class TableDataAccessUnusedPermissionsCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public TableDataAccessUnusedPermissionsCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessUnusedPermissionsEntireEntry.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(CodeFixContext ctx, SyntaxNode syntaxRoot,
+        TextSpan span, Document document)
+    {
+        var diagnostic = ctx.Diagnostics[0];
+        var props = CodeFixProperties.TryParse(diagnostic.Properties);
+        if (props is null)
+            return;
+
+        var node = syntaxRoot.FindNode(span);
+        var permissionNode = node as PermissionSyntax
+            ?? node.FirstAncestorOrSelf<PermissionSyntax>()
+            ?? node.DescendantNodes().OfType<PermissionSyntax>().FirstOrDefault();
+        if (permissionNode is null)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(permissionNode, props, document, generateFixAll: true),
+            diagnostic);
+    }
+
+    private static TableDataAccessUnusedPermissionsCodeAction CreateCodeAction(
+        PermissionSyntax permissionNode, CodeFixProperties props,
+        Document document, bool generateFixAll)
+    {
+        return new TableDataAccessUnusedPermissionsCodeAction(
+            ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsCodeAction,
+            ct => ApplyFix(document, permissionNode, props, ct),
+            nameof(TableDataAccessUnusedPermissionsCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(Document document, PermissionSyntax permissionNode,
+        CodeFixProperties props, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        var permissionValue = permissionNode.Parent as PermissionPropertyValueSyntax;
+        if (permissionValue is null)
+            return document;
+
+        var propertySyntax = permissionValue.Parent as PropertySyntax;
+        if (propertySyntax is null)
+            return document;
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        SyntaxNode newRoot;
+
+        if (string.IsNullOrEmpty(props.UsedChars))
+        {
+            // Entire entry is unused: remove the entry or the whole property
+            newRoot = RemovePermissionEntry(root, permissionValue, propertySyntax, permissionNode);
+        }
+        else
+        {
+            // Partial chars unused: reduce the permission chars
+            newRoot = ReducePermissionChars(root, permissionNode, props.UsedChars);
+        }
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static SyntaxNode RemovePermissionEntry(
+        SyntaxNode root,
+        PermissionPropertyValueSyntax permissionValue,
+        PropertySyntax propertySyntax,
+        PermissionSyntax permissionNode)
+    {
+        var permissions = permissionValue.PermissionProperties;
+
+        if (permissions.Count <= 1)
+        {
+            // Last entry: remove the entire Permissions property
+            return root.RemoveNode(propertySyntax, SyntaxRemoveOptions.KeepNoTrivia)
+                ?? root;
+        }
+
+        int index = permissions.IndexOf(permissionNode);
+        var newPermissions = permissions.Remove(permissionNode);
+
+        // When removing a non-last entry, the entry that slides into its position
+        // retains stale leading trivia (e.g. newline+indent from multi-line layout).
+        // Normalize it to a single space so that `Permissions = <remaining entries>` reads cleanly.
+        if (index < newPermissions.Count)
+        {
+            var shifted = newPermissions[index];
+            var normalized = shifted.WithLeadingTrivia(SyntaxFactory.TriviaList());
+            newPermissions = newPermissions.Replace(shifted, normalized);
+        }
+
+        var newPermissionValue = permissionValue.WithPermissionProperties(newPermissions);
+        return root.ReplaceNode(permissionValue, newPermissionValue);
+    }
+
+    private static SyntaxNode ReducePermissionChars(
+        SyntaxNode root,
+        PermissionSyntax permissionNode,
+        string usedChars)
+    {
+        var newPermissionsToken = SyntaxFactory.Identifier(usedChars);
+        var newPermissionNode = permissionNode.WithPermissions(newPermissionsToken);
+        return root.ReplaceNode(permissionNode, newPermissionNode);
+    }
+}

--- a/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
@@ -305,6 +305,26 @@ public static class DiagnosticDescriptors
         description: ApplicationCopAnalyzers.UseReturnValueForDatabaseReadMethodsDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseReturnValueForDatabaseReadMethods));
 
+    public static readonly DiagnosticDescriptor TableDataAccessUnusedPermissionsEntireEntry = new(
+        id: DiagnosticIds.TableDataAccessUnusedPermissions,
+        title: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsTitle,
+        messageFormat: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsEntireEntryMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.TableDataAccessUnusedPermissions));
+
+    public static readonly DiagnosticDescriptor TableDataAccessUnusedPermissionsPartialChars = new(
+        id: DiagnosticIds.TableDataAccessUnusedPermissions,
+        title: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsTitle,
+        messageFormat: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsPartialCharsMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.TableDataAccessUnusedPermissions));
+
     public static readonly DiagnosticDescriptor ZeroEnumValueReservedForEmpty = new(
         id: DiagnosticIds.ZeroEnumValueReservedForEmpty,
         title: ApplicationCopAnalyzers.ZeroEnumValueReservedForEmptyTitle,

--- a/src/ALCops.ApplicationCop/DiagnosticIds.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticIds.cs
@@ -33,4 +33,5 @@ public static class DiagnosticIds
     public static readonly string DuplicateToolTipBetweenPageAndTable = "AC0029";
     public static readonly string UseReturnValueForDatabaseReadMethods = "AC0030";
     public static readonly string TableDataAccessRequiresPermissions = "AC0031";
+    public static readonly string TableDataAccessUnusedPermissions = "AC0032";
 }


### PR DESCRIPTION
## Summary

Implements AC0032, the inverse of AC0031. Detects `Permissions` property entries with no corresponding table data access in the object.

Depends on PR #224 (refactor: extract RequiredPermissionDetector).

## Analyzer

- Uses `RegisterCompilationAction` for whole-object analysis
- Walks all objects via `GetDeclaredApplicationObjectSymbols()`
- Bridges syntax to operations via `SemanticModel.GetOperation()`
- Two diagnostic variants: entirely unused entry, partially unused chars
- Handles page SourceTable exemption, test codeunit suppression
- Reuses `RequiredPermissionDetector` from `ALCops.Common`

## CodeFix (3 scenarios)

- Remove single entry from multi-entry Permissions list
- Remove entire Permissions property when last entry removed
- Reduce permission chars (e.g. `rimd` → `r`)

## Tests

- 8 HasDiagnostic cases (EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord)
- 6 NoDiagnostic cases (AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead)
- 3 HasFix cases (RemoveEntireEntry, ReduceChars, RemoveEntireProperty)
- All 931 tests pass across the full solution

## Known limitations

- Extension objects: cannot see base object code, may flag permissions needed by the base as unused
- CalcFields/CalcSums: indirect table access through FlowFields is not traced
- InherentPermissions overlap: table-level InherentPermissions making an object-level entry redundant is not flagged (different concern)