### PR TITLE
fix(AC0031): use generic title for FixAll code action

### DIFF
--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -110,6 +110,7 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Permission chars are lowercase (`rimd`) | Consistent with AL conventions |
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
+| `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
 
 ## Test coverage
 

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -363,6 +363,9 @@
   <data name="TableDataAccessRequiresPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Add missing permission '{0}' for table '{1}'</value>
   </data>
+  <data name="TableDataAccessRequiresPermissionsFixAllCodeAction" xml:space="preserve">
+    <value>ALCops: Add all missing permissions</value>
+  </data>
   <data name="TableDataPerCompanyDeclarationTitle" xml:space="preserve">
     <value>DataPerCompany must be explicitly set on table objects</value>
   </data>

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -73,7 +73,8 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle => Title;
+        public override string? FixAllTitle =>
+            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
 
         public TableDataAccessRequiresPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,


### PR DESCRIPTION
The FixAll action applies fixes across multiple permissions and tables, so its title should not reference a specific permission char or table name. Added a separate resx entry for the FixAll title.