### PR TITLE
fix(AC0031): fix FixAll uppercase/phantom entries and index-0 indentation

### DIFF
--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -111,12 +111,14 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
 | `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
+| Custom `PermissionsFixAllProvider` replaces `BatchFixer` (net8.0+) | BatchFixer applies fixes sequentially, causing uppercase normalization and phantom entries when multiple diagnostics modify the same Permissions node. Custom provider collects all diagnostics and applies a single tree transformation. |
+| `insertIndex == 0` gets special trivia handling in multi-line lists | First entry sits on the `Permissions = ` line with no leading indentation; displaced entries need indentation added |
 
 ## Test coverage
 
 **HasDiagnostic (8 cases):** ProcedureCalls, ProcedureCallsExtended, GetBySystemId, Count, ImplicitSelfCallInTable, XmlPorts, Queries, Reports.
 **NoDiagnostic (21 cases):** ProcedureCallsPermissionsProperty, ProcedureCallsPermissionsPropertyFullyQualified, ProcedureCallsInherentPermissionsProperty, ProcedureCallsInherentPermissionsAttribute, PageSourceTable, PageExtensionSourceTable, XmlPortPermissionsProperty, XmlPortInherentPermissions, QueryPermissionsProperty, QueryInherentPermissions, ReportPermissionsProperty, ReportInherentPermissions, XMLPortWithTableElementProps, PermissionsAsObjectId, PermissionPropertyWithPragma, PermissionPropertyWithComment, MultiplePermissionsDifferentType, TestPermissionsDisabled, GetBySystemIdWithPermissions, CountWithPermissions, ImplicitSelfCallWithInherentPermissions.
-**HasFix (8 cases):** AddNewPermissionsProperty, AddNewTableEntry, MergePermissionChar, MergeCanonicalOrder, AddEntryMultiLine, AddEntrySingleLine, AddEntryAlphabetical, AddEntryAppend.
+**HasFix (9 cases):** AddNewPermissionsProperty, AddNewTableEntry, MergePermissionChar, MergeCanonicalOrder, AddEntryMultiLine, AddEntrySingleLine, AddEntryAlphabetical, AddEntryAppend, AddEntryAlphabeticalFirst.
 
 ## Known issues / future work
 
@@ -125,4 +127,5 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 - **CalcFields/CalcSums** are not yet covered (out of scope for initial implementation)
 - **CodeFix: blank line formatting** When creating a new Permissions property on an object that has no properties, no blank line is inserted between the new property and the first member (trigger/procedure)
 - **CodeFix: cross-namespace test** The single-file test framework cannot test qualified table name resolution; both objects must be in the same file
+- **CodeFix: FixAll not directly testable** RoslynTestKit has no FixAll test API; FixAll behavior can only be verified via VS Code
 - **Inverted rule** (permissions declared but not needed) is planned as a separate diagnostic

--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -77,6 +77,7 @@ Maps AL built-in record methods to `DatabaseOperation`:
 | `Rec.Modify()` in table objects detected via explicit Instance path | The AL compiler resolves `Rec.Modify()` with a non-null Instance |
 | InherentPermissions attribute parsed via syntax text splitting | The attribute's syntax is well-defined; avoids complex semantic analysis |
 | `TestPermissions = Disabled` suppresses diagnostic | Test codeunits with disabled permissions are intentionally testing without permission checks |
+| Skip permissionset/permissionsetextension objects | These objects declare permissions as their core purpose, not code that accesses tables; skipping improves performance |
 
 ## CodeFix
 

--- a/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
+++ b/.github/instructions/ac0031-table-data-access-requires-permissions.instructions.md
@@ -107,11 +107,11 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 | Decision | Rationale |
 |---|---|
 | Passes TableName, TableNamespace, PermissionChar via `ImmutableDictionary` properties | Standard CodeFix data passing pattern |
-| Permission chars are lowercase (`rimd`) | Consistent with AL conventions |
+| Permission chars preserve existing casing convention | If existing permissions use uppercase (e.g. `RM`), added chars match (`RIM`). Defaults to lowercase for new entries. |
+| `ApplyFix` re-finds ObjectSyntax by kind+name from current tree | BatchFixer applies fixes sequentially; using captured node references causes stale-reference bugs (phantom entries, wrong merges) |
 | Sorted detection uses case-insensitive string comparison | AL identifiers are case-insensitive |
 | Multi-line separator fix via `ReplaceToken` | Avoids need for internal `SeparatedSyntaxList` constructor |
 | `FixAllTitle` uses a separate generic resx string (`TableDataAccessRequiresPermissionsFixAllCodeAction`) | FixAll applies across multiple permissions/tables, so the title must not reference a specific permission or table |
-| Custom `PermissionsFixAllProvider` replaces `BatchFixer` (net8.0+) | BatchFixer applies fixes sequentially, causing uppercase normalization and phantom entries when multiple diagnostics modify the same Permissions node. Custom provider collects all diagnostics and applies a single tree transformation. |
 | `insertIndex == 0` gets special trivia handling in multi-line lists | First entry sits on the `Permissions = ` line with no leading indentation; displaced entries need indentation added |
 
 ## Test coverage
@@ -127,5 +127,4 @@ Uses C#-like namespace resolution (`PermissionTableNameResolver`):
 - **CalcFields/CalcSums** are not yet covered (out of scope for initial implementation)
 - **CodeFix: blank line formatting** When creating a new Permissions property on an object that has no properties, no blank line is inserted between the new property and the first member (trigger/procedure)
 - **CodeFix: cross-namespace test** The single-file test framework cannot test qualified table name resolution; both objects must be in the same file
-- **CodeFix: FixAll not directly testable** RoslynTestKit has no FixAll test API; FixAll behavior can only be verified via VS Code
 - **Inverted rule** (permissions declared but not needed) is planned as a separate diagnostic

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -71,6 +71,7 @@ Single-threaded. `RegisterCompilationAction` runs once after compilation complet
 | `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
 | Page SourceTable exemption | Pages implicitly need RIMD on their source table |
 | Temporary records NOT exempted | Declaring permissions on temp-only tables is dead code |
+| Skip permissionset/permissionsetextension objects | These objects declare permissions as their core purpose, not as code-access declarations; flagging them is always a false positive |
 | `DeclaredPermissionSet` reused for RIMD tracking | Existing type from AC0031's permission module |
 
 ## CodeFix
@@ -108,7 +109,7 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 ## Test coverage
 
 **HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
-**NoDiagnostic (6 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead.
+**NoDiagnostic (8 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension.
 **HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
 
 ## Known limitations

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/current.al
@@ -1,0 +1,36 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata Charlie = r,
+                  tabledata Delta = r;
+
+    procedure Test()
+    var
+        Alpha: Record Alpha;
+    begin
+        [|Alpha.FindFirst();|]
+    end;
+}
+
+table 50000 Alpha
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 Charlie
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50002 Delta
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddEntryAlphabeticalFirst/expected.al
@@ -1,0 +1,37 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata Alpha = r,
+                  tabledata Charlie = r,
+                  tabledata Delta = r;
+
+    procedure Test()
+    var
+        Alpha: Record Alpha;
+    begin
+        Alpha.FindFirst();
+    end;
+}
+
+table 50000 Alpha
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 Charlie
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50002 Delta
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
@@ -82,6 +82,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("AddEntryMultiLine")]
         [TestCase("AddEntrySingleLine")]
         [TestCase("AddEntryAlphabetical")]
+        [TestCase("AddEntryAlphabeticalFirst")]
         [TestCase("AddEntryAppend")]
         public async Task HasFix(string testCase)
         {

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSet.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSet.al
@@ -1,0 +1,36 @@
+permissionset 50000 MyPermissionSet
+{
+    Caption = '', Locked = true;
+    Assignable = true;
+    Permissions =
+        [|tabledata MyTable = RIMD|],
+        [|tabledata MyOtherTable = R|];
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 MyOtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSetExtension.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/PermissionSetExtension.al
@@ -1,0 +1,41 @@
+permissionsetextension 50000 MyPermissionSetExt extends MyPermissionSet
+{
+    Permissions =
+        [|tabledata MyOtherTable = RIMD|];
+}
+
+permissionset 50000 MyPermissionSet
+{
+    Caption = '', Locked = true;
+    Assignable = true;
+    Permissions =
+        tabledata MyTable = RIMD;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 MyOtherTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -44,6 +44,8 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("ReadUsed")]
         [TestCase("ReportDataItemRead")]
         [TestCase("QueryDataItemRead")]
+        [TestCase("PermissionSet")]
+        [TestCase("PermissionSetExtension")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -444,6 +444,9 @@
   <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Remove unused permission for table '{0}'</value>
   </data>
+  <data name="TableDataAccessUnusedPermissionsFixAllCodeAction" xml:space="preserve">
+    <value>ALCops: Remove all unused permissions</value>
+  </data>
   <data name="ZeroEnumValueReservedForEmptyTitle" xml:space="preserve">
     <value>Reserve Enum value zero (0) for empty value</value>
   </data>

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessRequiresPermissions.cs
@@ -36,14 +36,18 @@ public class TableDataAccessRequiresPermissions : DiagnosticAnalyzer
 
     private void AnalyzeInvocation(OperationAnalysisContext ctx)
     {
+        var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
+
+        if (containingObject?.Kind == EnumProvider.SymbolKind.PermissionSet
+            || containingObject?.Kind == EnumProvider.SymbolKind.PermissionSetExtension)
+            return;
+
         if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
             return;
 
         var required = RequiredPermissionDetector.TryGetFromInvocation(invocation, ctx.ContainingSymbol);
         if (required is null)
             return;
-
-        var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
 
         if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(containingObject))
             return;

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -31,6 +31,10 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         {
             ctx.CancellationToken.ThrowIfCancellationRequested();
 
+            if (obj.Kind == EnumProvider.SymbolKind.PermissionSet
+                || obj.Kind == EnumProvider.SymbolKind.PermissionSetExtension)
+                continue;
+
             if (RequiredPermissionDetector.IsTestCodeunitWithPermissionsDisabled(obj))
                 continue;
 

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -5,7 +5,6 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 
@@ -90,11 +89,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessRequiresPermissions.Id);
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-#if NET8_0_OR_GREATER
-        new PermissionsFixAllProvider();
-#else
         WellKnownFixAllProviders.BatchFixer;
-#endif
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
     {
@@ -125,17 +120,22 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         if (objectSyntax is ApplicationObjectExtensionSyntax)
             return;
 
+        // Capture the object's identity so we can re-find it in a (potentially modified) document.
+        // This is critical for FixAll: BatchFixer applies fixes sequentially, and each fix may
+        // modify the tree. Using a stale objectSyntax reference causes ReplaceNode to fail silently.
+        var objectIdentity = GetObjectIdentity(objectSyntax);
+
         // Resolve table name using C#-like namespace resolution
         var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
         var resolvedTableName = ResolveTableNameForFix(props.TableName, props.TableNamespace, compilationUnit);
 
         ctx.RegisterCodeFix(
-            CreateCodeAction(objectSyntax, resolvedTableName, props.PermissionChar, document, generateFixAll: true),
+            CreateCodeAction(objectIdentity, resolvedTableName, props.PermissionChar, document, generateFixAll: true),
             diagnostic);
     }
 
     private static TableDataAccessRequiresPermissionsCodeAction CreateCodeAction(
-        ObjectSyntax objectSyntax, string tableName, char permissionChar,
+        (SyntaxKind Kind, string? Name) objectIdentity, string tableName, char permissionChar,
         Document document, bool generateFixAll)
     {
         var title = string.Format(
@@ -145,15 +145,25 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         return new TableDataAccessRequiresPermissionsCodeAction(
             title,
-            ct => ApplyFix(document, objectSyntax, tableName, permissionChar, ct),
+            ct => ApplyFix(document, objectIdentity, tableName, permissionChar, ct),
             nameof(TableDataAccessRequiresPermissionsCodeFixProvider),
             generateFixAll);
     }
 
-    private static async Task<Document> ApplyFix(Document document, ObjectSyntax objectSyntax,
+    private static async Task<Document> ApplyFix(Document document,
+        (SyntaxKind Kind, string? Name) objectIdentity,
         string tableName, char permissionChar, CancellationToken cancellationToken)
     {
-        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+        var root = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        // Re-find the object in the current tree to avoid stale node references.
+        // BatchFixer applies fixes sequentially, modifying the document between each.
+        var objectSyntax = FindObjectByIdentity(root, objectIdentity);
+        if (objectSyntax is null)
+            return document;
 
         var propertyList = objectSyntax.PropertyList;
         PropertyListSyntax newPropertyList;
@@ -162,21 +172,38 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         if (permissionsProperty is null)
         {
-            // No Permissions property exists: create one from scratch
             newPropertyList = AddNewPermissionsProperty(propertyList, tableName, permissionChar);
         }
         else
         {
-            // Permissions property exists: add or merge
             newPropertyList = UpdateExistingPermissionsProperty(propertyList, permissionsProperty, tableName, permissionChar);
         }
 
-        var root = await syntaxRootTask.ConfigureAwait(false);
-        if (root is null)
-            return document;
-
         var newRoot = root.ReplaceNode(propertyList, newPropertyList);
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static (SyntaxKind Kind, string? Name) GetObjectIdentity(ObjectSyntax objectSyntax)
+    {
+        var name = objectSyntax.Name?.Identifier.ValueText;
+        return (objectSyntax.Kind, name);
+    }
+
+    private static ObjectSyntax? FindObjectByIdentity(SyntaxNode root,
+        (SyntaxKind Kind, string? Name) identity)
+    {
+        foreach (var node in root.DescendantNodes())
+        {
+            if (node is ObjectSyntax obj
+                && obj is not ApplicationObjectExtensionSyntax
+                && obj.Kind == identity.Kind
+                && string.Equals(obj.Name?.Identifier.ValueText, identity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return obj;
+            }
+        }
+
+        return null;
     }
 
     private static PropertyListSyntax AddNewPermissionsProperty(
@@ -285,180 +312,4 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         return PermissionTableNameResolver.ResolveTableName(
             tableName, tableNamespace, fileNamespace, importedNamespaces);
     }
-
-#if NET8_0_OR_GREATER
-    /// <summary>
-    /// Custom FixAll provider that applies all permission changes in a single tree transformation.
-    /// The default BatchFixer applies fixes sequentially, which can cause issues when multiple
-    /// diagnostics modify the same Permissions property (uppercase normalization, stale spans).
-    /// </summary>
-    private sealed class PermissionsFixAllProvider : DocumentBasedFixAllByDiagnosticsProvider
-    {
-        protected override string GetFixAllTitle(FixAllContext fixAllContext) =>
-            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
-
-        protected override async Task<Document?> FixAllAsync(
-            FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
-        {
-            if (diagnostics.IsEmpty)
-                return document;
-
-            var root = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken)
-                .ConfigureAwait(false);
-            if (root is null)
-                return document;
-
-            var tablePermissions = CollectTablePermissions(diagnostics);
-            if (tablePermissions.Count == 0)
-                return document;
-
-            var node = root.FindNode(diagnostics[0].Location.SourceSpan);
-            var objectSyntax = node?.FirstAncestorOrSelf<ObjectSyntax>();
-            if (objectSyntax is null || objectSyntax is ApplicationObjectExtensionSyntax)
-                return document;
-
-            var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
-            var propertyList = objectSyntax.PropertyList;
-            var newPropertyList = ApplyAllPermissionChanges(
-                propertyList, tablePermissions, compilationUnit);
-
-            var newRoot = root.ReplaceNode(propertyList, newPropertyList);
-            return document.WithSyntaxRoot(newRoot);
-        }
-
-        private static Dictionary<string, (string Namespace, HashSet<char> Chars)>
-            CollectTablePermissions(ImmutableArray<Diagnostic> diagnostics)
-        {
-            var result = new Dictionary<string, (string Namespace, HashSet<char> Chars)>(
-                StringComparer.OrdinalIgnoreCase);
-
-            foreach (var diagnostic in diagnostics)
-            {
-                var props = CodeFixProperties.TryParse(diagnostic.Properties);
-                if (props is null)
-                    continue;
-
-                if (!result.TryGetValue(props.TableName, out var entry))
-                {
-                    entry = (props.TableNamespace, new HashSet<char>());
-                    result[props.TableName] = entry;
-                }
-                entry.Chars.Add(props.PermissionChar);
-            }
-
-            return result;
-        }
-
-        private static PropertyListSyntax ApplyAllPermissionChanges(
-            PropertyListSyntax propertyList,
-            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
-            CompilationUnitSyntax? compilationUnit)
-        {
-            var permissionsProperty = FindPermissionsProperty(propertyList);
-
-            if (permissionsProperty is null)
-                return CreateNewPermissionsPropertyForAll(
-                    propertyList, tablePermissions, compilationUnit);
-
-            if (permissionsProperty.Value is not PermissionPropertyValueSyntax permissionValue)
-                return propertyList;
-
-            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
-            {
-                var resolvedName = ResolveTableNameForFix(
-                    tableName, tableNamespace, compilationUnit);
-
-                var existingEntry = PermissionSyntaxHelper.FindExistingEntry(
-                    permissionValue, resolvedName);
-
-                if (existingEntry is not null)
-                    permissionValue = MergeAllChars(
-                        permissionValue, existingEntry, chars);
-                else
-                    permissionValue = AddNewEntryWithAllChars(
-                        permissionValue, resolvedName, chars);
-            }
-
-            var newProperty = permissionsProperty.WithValue(permissionValue);
-            return propertyList.WithProperties(
-                propertyList.Properties.Replace(permissionsProperty, newProperty));
-        }
-
-        private static PropertyListSyntax CreateNewPermissionsPropertyForAll(
-            PropertyListSyntax propertyList,
-            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
-            CompilationUnitSyntax? compilationUnit)
-        {
-            var permissionValue = SyntaxFactory.PermissionPropertyValue();
-
-            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
-            {
-                var resolvedName = ResolveTableNameForFix(
-                    tableName, tableNamespace, compilationUnit);
-                var permChars = BuildCanonicalPermissionString(chars);
-                var entry = PermissionSyntaxHelper.CreatePermissionSyntax(
-                    resolvedName, permChars);
-                permissionValue = permissionValue.AddPermissionProperties(entry);
-            }
-
-            var property = SyntaxFactory.Property(
-                EnumProvider.PropertyKind.Permissions,
-                (PropertyValueSyntax)permissionValue);
-
-            return propertyList.AddProperties(property);
-        }
-
-        private static PermissionPropertyValueSyntax MergeAllChars(
-            PermissionPropertyValueSyntax permissionValue,
-            PermissionSyntax existingEntry, HashSet<char> chars)
-        {
-            var currentPerms = existingEntry.Permissions.ValueText ?? string.Empty;
-            var merged = currentPerms;
-            foreach (var c in chars)
-                merged = PermissionSyntaxHelper.NormalizePermissionString(merged, c);
-
-            var newToken = SyntaxFactory.Identifier(merged);
-            var updatedEntry = existingEntry.WithPermissions(newToken);
-
-            return permissionValue.WithPermissionProperties(
-                permissionValue.PermissionProperties.Replace(existingEntry, updatedEntry));
-        }
-
-        private static PermissionPropertyValueSyntax AddNewEntryWithAllChars(
-            PermissionPropertyValueSyntax permissionValue, string tableName, HashSet<char> chars)
-        {
-            var permissions = permissionValue.PermissionProperties;
-            var isSorted = PermissionSyntaxHelper.ArePermissionsSorted(permissions);
-            var isMultiLine = PermissionSyntaxHelper.IsMultiLineFormat(permissionValue);
-            var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(
-                permissions, tableName, isSorted);
-            var permChars = BuildCanonicalPermissionString(chars);
-
-            var newEntry = PermissionSyntaxHelper.CreatePermissionSyntax(tableName, permChars);
-
-            if (isMultiLine)
-            {
-                if (insertIndex > 0)
-                {
-                    var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
-                    newEntry = newEntry.WithLeadingTrivia(
-                        SyntaxFactory.ParseLeadingTrivia(indentation));
-                }
-                return PermissionSyntaxHelper.InsertIntoMultiLineList(
-                    permissionValue, permissions, insertIndex, newEntry);
-            }
-
-            var newPermissions = permissions.Insert(insertIndex, newEntry);
-            return permissionValue.WithPermissionProperties(newPermissions);
-        }
-
-        private static string BuildCanonicalPermissionString(HashSet<char> chars)
-        {
-            var result = string.Empty;
-            foreach (var c in chars)
-                result = PermissionSyntaxHelper.NormalizePermissionString(result, c);
-            return result;
-        }
-    }
-#endif
 }

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -5,6 +5,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 
@@ -89,7 +90,11 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         ImmutableArray.Create(DiagnosticDescriptors.TableDataAccessRequiresPermissions.Id);
 
     public sealed override FixAllProvider GetFixAllProvider() =>
+#if NET8_0_OR_GREATER
+        new PermissionsFixAllProvider();
+#else
         WellKnownFixAllProviders.BatchFixer;
+#endif
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
     {
@@ -240,8 +245,13 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         SeparatedSyntaxList<PermissionSyntax> newPermissions;
         if (isMultiLine)
         {
-            var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
-            newEntry = newEntry.WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(indentation));
+            // Only add indentation trivia when inserting at index > 0.
+            // Index 0 is on the same line as "Permissions = " and needs no indentation.
+            if (insertIndex > 0)
+            {
+                var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
+                newEntry = newEntry.WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(indentation));
+            }
             return PermissionSyntaxHelper.InsertIntoMultiLineList(permissionValue, permissions, insertIndex, newEntry);
         }
         else
@@ -275,4 +285,180 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         return PermissionTableNameResolver.ResolveTableName(
             tableName, tableNamespace, fileNamespace, importedNamespaces);
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Custom FixAll provider that applies all permission changes in a single tree transformation.
+    /// The default BatchFixer applies fixes sequentially, which can cause issues when multiple
+    /// diagnostics modify the same Permissions property (uppercase normalization, stale spans).
+    /// </summary>
+    private sealed class PermissionsFixAllProvider : DocumentBasedFixAllByDiagnosticsProvider
+    {
+        protected override string GetFixAllTitle(FixAllContext fixAllContext) =>
+            ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsFixAllCodeAction;
+
+        protected override async Task<Document?> FixAllAsync(
+            FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+        {
+            if (diagnostics.IsEmpty)
+                return document;
+
+            var root = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken)
+                .ConfigureAwait(false);
+            if (root is null)
+                return document;
+
+            var tablePermissions = CollectTablePermissions(diagnostics);
+            if (tablePermissions.Count == 0)
+                return document;
+
+            var node = root.FindNode(diagnostics[0].Location.SourceSpan);
+            var objectSyntax = node?.FirstAncestorOrSelf<ObjectSyntax>();
+            if (objectSyntax is null || objectSyntax is ApplicationObjectExtensionSyntax)
+                return document;
+
+            var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
+            var propertyList = objectSyntax.PropertyList;
+            var newPropertyList = ApplyAllPermissionChanges(
+                propertyList, tablePermissions, compilationUnit);
+
+            var newRoot = root.ReplaceNode(propertyList, newPropertyList);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static Dictionary<string, (string Namespace, HashSet<char> Chars)>
+            CollectTablePermissions(ImmutableArray<Diagnostic> diagnostics)
+        {
+            var result = new Dictionary<string, (string Namespace, HashSet<char> Chars)>(
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var props = CodeFixProperties.TryParse(diagnostic.Properties);
+                if (props is null)
+                    continue;
+
+                if (!result.TryGetValue(props.TableName, out var entry))
+                {
+                    entry = (props.TableNamespace, new HashSet<char>());
+                    result[props.TableName] = entry;
+                }
+                entry.Chars.Add(props.PermissionChar);
+            }
+
+            return result;
+        }
+
+        private static PropertyListSyntax ApplyAllPermissionChanges(
+            PropertyListSyntax propertyList,
+            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
+            CompilationUnitSyntax? compilationUnit)
+        {
+            var permissionsProperty = FindPermissionsProperty(propertyList);
+
+            if (permissionsProperty is null)
+                return CreateNewPermissionsPropertyForAll(
+                    propertyList, tablePermissions, compilationUnit);
+
+            if (permissionsProperty.Value is not PermissionPropertyValueSyntax permissionValue)
+                return propertyList;
+
+            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
+            {
+                var resolvedName = ResolveTableNameForFix(
+                    tableName, tableNamespace, compilationUnit);
+
+                var existingEntry = PermissionSyntaxHelper.FindExistingEntry(
+                    permissionValue, resolvedName);
+
+                if (existingEntry is not null)
+                    permissionValue = MergeAllChars(
+                        permissionValue, existingEntry, chars);
+                else
+                    permissionValue = AddNewEntryWithAllChars(
+                        permissionValue, resolvedName, chars);
+            }
+
+            var newProperty = permissionsProperty.WithValue(permissionValue);
+            return propertyList.WithProperties(
+                propertyList.Properties.Replace(permissionsProperty, newProperty));
+        }
+
+        private static PropertyListSyntax CreateNewPermissionsPropertyForAll(
+            PropertyListSyntax propertyList,
+            Dictionary<string, (string Namespace, HashSet<char> Chars)> tablePermissions,
+            CompilationUnitSyntax? compilationUnit)
+        {
+            var permissionValue = SyntaxFactory.PermissionPropertyValue();
+
+            foreach (var (tableName, (tableNamespace, chars)) in tablePermissions)
+            {
+                var resolvedName = ResolveTableNameForFix(
+                    tableName, tableNamespace, compilationUnit);
+                var permChars = BuildCanonicalPermissionString(chars);
+                var entry = PermissionSyntaxHelper.CreatePermissionSyntax(
+                    resolvedName, permChars);
+                permissionValue = permissionValue.AddPermissionProperties(entry);
+            }
+
+            var property = SyntaxFactory.Property(
+                EnumProvider.PropertyKind.Permissions,
+                (PropertyValueSyntax)permissionValue);
+
+            return propertyList.AddProperties(property);
+        }
+
+        private static PermissionPropertyValueSyntax MergeAllChars(
+            PermissionPropertyValueSyntax permissionValue,
+            PermissionSyntax existingEntry, HashSet<char> chars)
+        {
+            var currentPerms = existingEntry.Permissions.ValueText ?? string.Empty;
+            var merged = currentPerms;
+            foreach (var c in chars)
+                merged = PermissionSyntaxHelper.NormalizePermissionString(merged, c);
+
+            var newToken = SyntaxFactory.Identifier(merged);
+            var updatedEntry = existingEntry.WithPermissions(newToken);
+
+            return permissionValue.WithPermissionProperties(
+                permissionValue.PermissionProperties.Replace(existingEntry, updatedEntry));
+        }
+
+        private static PermissionPropertyValueSyntax AddNewEntryWithAllChars(
+            PermissionPropertyValueSyntax permissionValue, string tableName, HashSet<char> chars)
+        {
+            var permissions = permissionValue.PermissionProperties;
+            var isSorted = PermissionSyntaxHelper.ArePermissionsSorted(permissions);
+            var isMultiLine = PermissionSyntaxHelper.IsMultiLineFormat(permissionValue);
+            var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(
+                permissions, tableName, isSorted);
+            var permChars = BuildCanonicalPermissionString(chars);
+
+            var newEntry = PermissionSyntaxHelper.CreatePermissionSyntax(tableName, permChars);
+
+            if (isMultiLine)
+            {
+                if (insertIndex > 0)
+                {
+                    var indentation = PermissionSyntaxHelper.GetEntryIndentation(permissionValue);
+                    newEntry = newEntry.WithLeadingTrivia(
+                        SyntaxFactory.ParseLeadingTrivia(indentation));
+                }
+                return PermissionSyntaxHelper.InsertIntoMultiLineList(
+                    permissionValue, permissions, insertIndex, newEntry);
+            }
+
+            var newPermissions = permissions.Insert(insertIndex, newEntry);
+            return permissionValue.WithPermissionProperties(newPermissions);
+        }
+
+        private static string BuildCanonicalPermissionString(HashSet<char> chars)
+        {
+            var result = string.Empty;
+            foreach (var c in chars)
+                result = PermissionSyntaxHelper.NormalizePermissionString(result, c);
+            return result;
+        }
+    }
+#endif
 }

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessUnusedPermissionsCodeFixProvider.cs
@@ -71,7 +71,8 @@ public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixPro
         public override CodeActionKind Kind => CodeActionKind.QuickFix;
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
-        public override string? FixAllTitle => Title;
+        public override string? FixAllTitle =>
+            ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsFixAllCodeAction;
 
         public TableDataAccessUnusedPermissionsCodeAction(string title,
             Func<CancellationToken, Task<Document>> createChangedDocument,
@@ -124,8 +125,12 @@ public sealed class TableDataAccessUnusedPermissionsCodeFixProvider : CodeFixPro
         PermissionSyntax permissionNode, CodeFixProperties props,
         Document document, bool generateFixAll)
     {
-        return new TableDataAccessUnusedPermissionsCodeAction(
+        var title = string.Format(
             ApplicationCopAnalyzers.TableDataAccessUnusedPermissionsCodeAction,
+            props.TableName);
+
+        return new TableDataAccessUnusedPermissionsCodeAction(
+            title,
             ct => ApplyFix(document, permissionNode, props, ct),
             nameof(TableDataAccessUnusedPermissionsCodeFixProvider),
             generateFixAll);

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -136,7 +136,8 @@ public static class PermissionSyntaxHelper
 
     /// <summary>
     /// Gets the indentation string for multi-line formatting by examining existing entries.
-    /// Returns the leading whitespace of the first tabledata keyword.
+    /// In multi-line format, the first entry shares the line with "Permissions = " and has
+    /// no indentation trivia, so entries at index &gt; 0 are checked first.
     /// </summary>
     public static string GetEntryIndentation(PermissionPropertyValueSyntax permissionValue)
     {
@@ -144,8 +145,19 @@ public static class PermissionSyntaxHelper
         if (permissions.Count == 0)
             return "                  ";
 
-        var firstEntry = permissions[0];
-        var leadingTrivia = firstEntry.GetLeadingTrivia();
+        for (int i = 1; i < permissions.Count; i++)
+        {
+            var indentation = GetWhitespaceOnlyTrivia(permissions[i].GetLeadingTrivia());
+            if (indentation is not null)
+                return indentation;
+        }
+
+        var firstIndentation = GetWhitespaceOnlyTrivia(permissions[0].GetLeadingTrivia());
+        return firstIndentation ?? "                  ";
+    }
+
+    private static string? GetWhitespaceOnlyTrivia(SyntaxTriviaList leadingTrivia)
+    {
         foreach (var trivia in leadingTrivia)
         {
             var text = trivia.ToString();
@@ -153,7 +165,7 @@ public static class PermissionSyntaxHelper
                 return text;
         }
 
-        return "                  ";
+        return null;
     }
 
     private static string? GetTableNameFromPermission(PermissionSyntax permission)
@@ -195,6 +207,8 @@ public static class PermissionSyntaxHelper
     /// <summary>
     /// Inserts a permission entry into a multi-line permission list, preserving
     /// the multi-line format by fixing separator trivia after insertion.
+    /// When inserting at index 0, the displaced first entry receives indentation trivia
+    /// since it moves from position 0 (same line as "Permissions = ") to position 1 (own line).
     /// </summary>
     public static PermissionPropertyValueSyntax InsertIntoMultiLineList(
         PermissionPropertyValueSyntax permissionValue,
@@ -204,6 +218,18 @@ public static class PermissionSyntaxHelper
     {
         var newPermissions = existing.Insert(insertIndex, newEntry);
         var result = permissionValue.WithPermissionProperties(newPermissions);
+
+        // When inserting at index 0, the displaced first entry (now at index 1) was on
+        // the same line as "Permissions = " and has no indentation trivia. Add it.
+        if (insertIndex == 0 && existing.Count > 0)
+        {
+            var indentation = GetEntryIndentation(permissionValue);
+            var displacedEntry = result.PermissionProperties[1];
+            var indentedEntry = displacedEntry.WithLeadingTrivia(
+                SyntaxFactory.ParseLeadingTrivia(indentation));
+            result = result.WithPermissionProperties(
+                result.PermissionProperties.Replace(displacedEntry, indentedEntry));
+        }
 
         // Insert() creates a new comma separator without newline trailing trivia.
         // Copy the trivia pattern from an existing separator to fix multi-line formatting.

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -63,9 +63,13 @@ public static class PermissionSyntaxHelper
     /// <summary>
     /// Merges a new permission char into an existing permission string,
     /// returning the result in canonical 'rimd' order.
+    /// Preserves the casing convention of the existing string: if existing chars
+    /// are uppercase, the new char is added as uppercase (and vice versa).
     /// </summary>
     public static string NormalizePermissionString(string existing, char newChar)
     {
+        var useUpperCase = IsUpperCaseConvention(existing);
+
         var chars = new HashSet<char>();
         foreach (var c in existing)
             chars.Add(char.ToLowerInvariant(c));
@@ -77,10 +81,27 @@ public static class PermissionSyntaxHelper
         foreach (var c in CanonicalOrder)
         {
             if (chars.Contains(c))
-                result[count++] = c;
+                result[count++] = useUpperCase ? char.ToUpperInvariant(c) : c;
         }
 
         return new string(result, 0, count);
+    }
+
+    /// <summary>
+    /// Detects whether the existing permission string uses uppercase convention.
+    /// Returns true if the majority of non-empty chars are uppercase.
+    /// Defaults to false (lowercase) for empty strings.
+    /// </summary>
+    private static bool IsUpperCaseConvention(string permissions)
+    {
+        int upper = 0, lower = 0;
+        foreach (var c in permissions)
+        {
+            if (char.IsUpper(c)) upper++;
+            else if (char.IsLower(c)) lower++;
+        }
+
+        return upper > lower;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

Three bugs in the AC0031 CodeFix:

**Bug A: Uppercase permission letters in FixAll**
`FixAll` produced uppercase letters (`RIM` instead of `rim`). The `BatchFixer` re-parses documents between sequential applications, and the AL parser normalizes permission tokens to uppercase during re-parsing.

**Bug B: Phantom table entries in FixAll**
`FixAll` added permission entries for tables with no diagnostic. Stale diagnostic spans after earlier fixes modified the same Permissions node caused incorrect node resolution.

**Bug C: Wrong indentation at index 0**
Single CodeFix inserted at index 0 of a multi-line list with wrong indentation. The displaced first entry lost its leading whitespace.

## Solution

### Custom PermissionsFixAllProvider (Bugs A & B)
Replaced `BatchFixer` with a custom `DocumentBasedFixAllByDiagnosticsProvider` (net8.0+) that:
- Receives ALL diagnostics for a document at once
- Collects per-table permission chars from all diagnostics
- Merges chars and applies a single tree transformation
- Falls back to `BatchFixer` on netstandard2.1 (where the API is unavailable)

### Indentation fixes (Bug C)
- `GetEntryIndentation` now checks entries beyond index 0 (which have actual indentation trivia)
- `InsertIntoMultiLineList` adds indentation to the displaced first entry when `insertIndex == 0`
- `AddNewEntry` skips indentation trivia when `insertIndex == 0`

## Testing
- All 38 existing tests pass
- New `AddEntryAlphabeticalFirst` test case validates Bug C fix
- FixAll behavior cannot be unit tested (RoslynTestKit has no FixAll API); requires manual VS Code verification