### PR TITLE
fix(ci): skip TargetFramework.json cache save when unchanged

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,6 +63,7 @@ jobs:
           fi
 
       - name: Save TargetFramework.json cache
+        if: steps.restore-tfm-cache.outputs.cache-matched-key != format('tfm-json-{0}', steps.hash-tfm.outputs.hash)
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/TargetFramework.json

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,6 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/TargetFramework.json
-          # Content-based key: only creates a new entry when the file actually changed
           key: tfm-json-${{ steps.hash-tfm.outputs.hash }}
 
       - name: Setup matrix for test


### PR DESCRIPTION
## Problem

The "Save TargetFramework.json cache" step in `build-test.yml` runs unconditionally. When `TargetFramework.json` hasn't changed (the common "up to date" case), `actions/cache/save` attempts to save with a key that already exists, producing:

```
Failed to save: Unable to reserve cache with key tfm-json-..., another job may be creating this cache.
Warning: Cache save failed.
```

See [run #24962396379](https://github.com/ALCops/Analyzers/actions/runs/24962396379/job/73091188780) for an example.

## Fix

Add an `if` condition comparing the restored cache key (`cache-matched-key`) against the new content-based save key. The save step now only runs when the file actually changed.

| Scenario | Save runs? |
|---|---|
| File unchanged (most common) | No (skip) |
| File changed | Yes |
| No prior cache | Yes |
