### PR TITLE
fix: keep last 3 alphas AND last 3 betas in cleanup

### DIFF
--- a/.github/instructions/release-strategy.instructions.md
+++ b/.github/instructions/release-strategy.instructions.md
@@ -16,7 +16,7 @@ ALCops Analyzers uses a three-channel release strategy with GitVersion auto-comp
 
 ### Alpha releases
 
-Every push to `main` that passes CI automatically publishes an alpha package to NuGet.org and GitHub Packages. No GitHub Release is created. A weekly cleanup job unlists old alphas from NuGet.org (keeping the last 3) to prevent clutter.
+Every push to `main` that passes CI automatically publishes an alpha package to NuGet.org and GitHub Packages. No GitHub Release is created. A weekly cleanup job unlists old alphas from NuGet.org (keeping the last 3 per channel) to prevent clutter.
 
 ### Beta releases
 
@@ -163,7 +163,7 @@ A weekly scheduled workflow (`scheduled-cleanup.yml`) runs every Sunday at 06:00
 ### What it does
 
 1. **Superseded pre-releases**: Unlists from NuGet.org and deletes from GitHub Packages all pre-release versions whose base version is at or below the latest stable (e.g., all `0.7.0-alpha.*` and `0.7.0-beta.*` after `0.7.0` is released)
-2. **Old current alphas**: For pre-releases above the latest stable, keeps the last 3 and unlists/deletes the rest
+2. **Old current pre-releases**: For pre-releases above the latest stable, keeps the last 3 per channel (alpha and beta independently) and unlists/deletes the rest. This prevents alphas (which have higher base versions) from pushing out betas.
 
 ### NuGet.org vs GitHub Packages cleanup
 

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -5,7 +5,7 @@ name: Cleanup Pre-release Packages
 #
 # Logic:
 #   1. Superseded pre-releases (base version <= latest stable): unlist/delete ALL
-#   2. Current pre-releases (base version > latest stable): keep last 3, unlist/delete the rest
+#   2. Current pre-releases (base version > latest stable): keep last 3 per channel (alpha/beta), unlist/delete the rest
 #
 # NuGet.org: unlists packages (still downloadable by exact version pin)
 # GitHub Packages: permanently deletes old versions
@@ -108,7 +108,7 @@ jobs:
             LATEST_STABLE=$(printf '%s\n' "${STABLE[@]}" | sort -V | tail -n1)
             echo "Latest stable: $LATEST_STABLE"
           else
-            echo "No stable versions found, will only trim current alphas"
+            echo "No stable versions found, will only trim current pre-releases"
           fi
 
           # Categorize pre-releases into superseded vs current
@@ -139,14 +139,30 @@ jobs:
             TO_UNLIST+=("$v")
           done
 
-          # Current pre-releases: keep last N (by SemVer sort)
-          if [ ${#CURRENT[@]} -gt "$KEEP_LAST_N" ]; then
-            mapfile -t SORTED_CURRENT < <(printf '%s\n' "${CURRENT[@]}" | sort -V)
-            REMOVE_COUNT=$(( ${#SORTED_CURRENT[@]} - KEEP_LAST_N ))
-            for ((i=0; i<REMOVE_COUNT; i++)); do
-              TO_UNLIST+=("${SORTED_CURRENT[$i]}")
-            done
-          fi
+          # Split current pre-releases by channel (alpha vs beta)
+          CURRENT_ALPHA=()
+          CURRENT_BETA=()
+          for v in "${CURRENT[@]}"; do
+            if [[ "$v" == *-beta.* ]]; then
+              CURRENT_BETA+=("$v")
+            else
+              CURRENT_ALPHA+=("$v")
+            fi
+          done
+
+          echo "Current alphas: ${#CURRENT_ALPHA[@]}, betas: ${#CURRENT_BETA[@]}"
+
+          # Keep last N per channel (by SemVer sort)
+          for channel_name in "alpha" "beta"; do
+            declare -n channel_arr="CURRENT_${channel_name^^}"
+            if [ ${#channel_arr[@]} -gt "$KEEP_LAST_N" ]; then
+              mapfile -t sorted < <(printf '%s\n' "${channel_arr[@]}" | sort -V)
+              remove_count=$(( ${#sorted[@]} - KEEP_LAST_N ))
+              for ((i=0; i<remove_count; i++)); do
+                TO_UNLIST+=("${sorted[$i]}")
+              done
+            fi
+          done
 
           echo ""
           echo "=== NuGet.org: unlisting ${#TO_UNLIST[@]} versions ==="
@@ -228,13 +244,30 @@ jobs:
             TO_DELETE+=("$v")
           done
 
-          if [ ${#CURRENT[@]} -gt "$KEEP_LAST_N" ]; then
-            mapfile -t SORTED_CURRENT < <(printf '%s\n' "${CURRENT[@]}" | sort -V)
-            REMOVE_COUNT=$(( ${#SORTED_CURRENT[@]} - KEEP_LAST_N ))
-            for ((i=0; i<REMOVE_COUNT; i++)); do
-              TO_DELETE+=("${SORTED_CURRENT[$i]}")
-            done
-          fi
+          # Split current pre-releases by channel (alpha vs beta)
+          CURRENT_ALPHA=()
+          CURRENT_BETA=()
+          for v in "${CURRENT[@]}"; do
+            if [[ "$v" == *-beta.* ]]; then
+              CURRENT_BETA+=("$v")
+            else
+              CURRENT_ALPHA+=("$v")
+            fi
+          done
+
+          echo "Current alphas: ${#CURRENT_ALPHA[@]}, betas: ${#CURRENT_BETA[@]}"
+
+          # Keep last N per channel (by SemVer sort)
+          for channel_name in "alpha" "beta"; do
+            declare -n channel_arr="CURRENT_${channel_name^^}"
+            if [ ${#channel_arr[@]} -gt "$KEEP_LAST_N" ]; then
+              mapfile -t sorted < <(printf '%s\n' "${channel_arr[@]}" | sort -V)
+              remove_count=$(( ${#sorted[@]} - KEEP_LAST_N ))
+              for ((i=0; i<remove_count; i++)); do
+                TO_DELETE+=("${sorted[$i]}")
+              done
+            fi
+          done
 
           echo ""
           echo "=== GitHub Packages: deleting ${#TO_DELETE[@]} versions ==="


### PR DESCRIPTION
## Problem

The cleanup workflow pooled all current pre-releases and kept the last 3 by semver sort. Since alphas have higher base versions than betas (e.g., `0.8.0-alpha.*` vs `0.7.0-beta.*`), having 3+ alphas caused all betas to be unlisted.

## Solution

Split current pre-releases into separate alpha and beta pools, applying `KEEP_LAST_N` independently to each channel. Both the NuGet.org and GitHub Packages cleanup steps are updated.

## Changes

- **`scheduled-cleanup.yml`**: After the superseded/current split, further split current into `CURRENT_ALPHA` and `CURRENT_BETA`, trim each independently.
- **`release-strategy.instructions.md`**: Updated cleanup documentation to reflect per-channel retention.