### PR TITLE
refactor: bypass reflection on net10.0 for StringHelper and SymbolHelper

### DIFF
--- a/.github/instructions/netstandard21-compatibility.instructions.md
+++ b/.github/instructions/netstandard21-compatibility.instructions.md
@@ -94,3 +94,19 @@ Use `set` instead of `init` on netstandard2.1:
 3. The netstandard2.1 block must use a regular `struct` or `class` with explicit constructor and get-only properties (no `init`).
 4. Search for `IFieldSymbol` `.Type` usage; use `OriginalDefinition.GetTypeSymbol()` on netstandard2.1 (requires `using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols`).
 5. When in doubt, look at existing examples listed above.
+
+## Reflection shims to clean up when dropping netstandard2.1 and net8.0
+
+The `ALCops.Common/Reflection/` folder contains helpers that use `System.Reflection` to handle SDK API differences. Some are only needed on older TFMs and have `#if NET10_0_OR_GREATER` guards that call the SDK directly on net10.0. Others are needed on ALL TFMs.
+
+When dropping netstandard2.1 and net8.0, grep for `COMPAT(netstandard2.1` to find all shims. Then:
+
+| File | Status | Action when dropping old TFMs |
+|---|---|---|
+| `Reflection/StringHelper.cs` | Bypassed on net10.0 via `#if` in `StringExtensions.cs` | Delete file. Replace `QuoteIdentifierIfNeededWithReflection()` calls with `Microsoft.Dynamics.Nav.CodeAnalysis.Utilities.StringExtensions.QuoteIdentifierIfNeeded()`. |
+| `Reflection/SymbolHelper.cs` (`GetContainingNamespaceQualifiedName`) | Bypassed on net10.0 via `#if` in `SymbolInterfaceExtensions.cs` | Delete method. Replace `GetContainingNamespaceQualifiedNameWithReflection()` calls with `symbol.ContainingNamespace?.QualifiedName`. |
+| `Reflection/SymbolHelper.cs` (`ToDisplayStringWithReflection`) | Already `#if NETSTANDARD2_1` only | Delete method. Remove `ToDisplayStringWithReflection()` calls and use `symbol.ToDisplayString()` directly. |
+| `Reflection/CompilationHelper.cs` | Accesses non-public SDK internals | **Keep** (reflection needed on all TFMs). |
+| `Reflection/EnumProvider.cs` | Runtime compat for enum value changes | **Keep** (reflection needed on all TFMs). |
+| `Reflection/VersionProvider.cs` | Forward-compat for future version fields | **Keep** (reflection needed on all TFMs). |
+| `Reflection/PropertyAccessor.cs` | Generic runtime compat utility | **Keep** (reflection needed on all TFMs). |

--- a/src/ALCops.Common/Extensions/StringExtensions.cs
+++ b/src/ALCops.Common/Extensions/StringExtensions.cs
@@ -1,16 +1,28 @@
+#if !NET10_0_OR_GREATER
 using ALCops.Common.Reflection;
+#endif
 
 namespace ALCops.Common.Extensions;
 
 public static class StringExtensions
 {
     /// <summary>
-    /// Quotes the identifier if needed, using reflection to handle breaking changes
-    /// between version 17.0.29.41701 and 17.0.29.44223 of Microsoft.Dynamics.Nav.CodeAnalysis 
+    /// Quotes the identifier if needed.
+    /// COMPAT(netstandard2.1, net8.0): Uses reflection to handle breaking changes
+    /// between version 17.0.29.41701 and 17.0.29.44223 of Microsoft.Dynamics.Nav.CodeAnalysis
+    /// where the useRelaxedIdentifierRules parameter was added.
+    /// On net10.0+, the SDK has the two-parameter overload so we call it directly.
+    /// TODO: When netstandard2.1 and net8.0 are dropped, replace all calls with
+    /// Microsoft.Dynamics.Nav.CodeAnalysis.Utilities.StringExtensions.QuoteIdentifierIfNeeded()
+    /// and delete Reflection/StringHelper.cs.
     /// </summary>
     /// <param name="value">The identifier value to quote if needed.</param>
     /// <param name="useRelaxedIdentifierRules">Whether to use relaxed identifier rules (only used in newer versions).</param>
     /// <returns>The quoted identifier if quoting is needed, otherwise the original value.</returns>
     public static string QuoteIdentifierIfNeededWithReflection(this string value, bool useRelaxedIdentifierRules = false)
+#if NET10_0_OR_GREATER
+        => Microsoft.Dynamics.Nav.CodeAnalysis.Utilities.StringExtensions.QuoteIdentifierIfNeeded(value, useRelaxedIdentifierRules);
+#else
         => StringHelper.QuoteIdentifierIfNeeded(value, useRelaxedIdentifierRules);
+#endif
 }

--- a/src/ALCops.Common/Extensions/SymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/SymbolInterfaceExtensions.cs
@@ -8,14 +8,21 @@ namespace ALCops.Common.Extensions;
 public static class SymbolInterfaceExtensions
 {
     /// <summary>
-    /// Gets the QualifiedName of the ContainingNamespace for a symbol using reflection.
-    /// This method handles breaking changes between versions where ContainingNamespace
-    /// may not exist in older versions of Microsoft.Dynamics.Nav.CodeAnalysis.
+    /// Gets the QualifiedName of the ContainingNamespace for a symbol.
+    /// COMPAT(netstandard2.1, net8.0): Uses reflection to handle versions where
+    /// ContainingNamespace or INamespaceSymbol.QualifiedName may not exist.
+    /// On net10.0+, calls the SDK directly.
+    /// TODO: When netstandard2.1 and net8.0 are dropped, inline as
+    /// symbol?.ContainingNamespace?.QualifiedName and delete SymbolHelper.GetContainingNamespaceQualifiedName.
     /// </summary>
     /// <param name="symbol">The symbol to get the containing namespace qualified name from.</param>
     /// <returns>The qualified name of the containing namespace, or null if not available.</returns>
     public static string? GetContainingNamespaceQualifiedNameWithReflection(this ISymbol? symbol)
+#if NET10_0_OR_GREATER
+        => symbol?.ContainingNamespace?.QualifiedName;
+#else
         => SymbolHelper.GetContainingNamespaceQualifiedName(symbol);
+#endif
 
     public static IPageTypeSymbol? GetPageTypeSymbol(this ISymbol symbol)
     {
@@ -46,6 +53,8 @@ public static class SymbolInterfaceExtensions
     }
 
     #region Obsolete Extension Methods
+    // COMPAT(netstandard2.1, net8.0): IsObsoletePendingMove and IsObsoleteMoved may not exist in older SDK versions.
+    // TODO: When netstandard2.1 and net8.0 are dropped, check if these properties are on ISymbol directly.
     private static readonly Lazy<PropertyInfo?> _isObsoletePendingMoveProperty =
         new(() => typeof(ISymbol).GetProperty("IsObsoletePendingMove"));
 

--- a/src/ALCops.Common/Reflection/CompilationHelper.cs
+++ b/src/ALCops.Common/Reflection/CompilationHelper.cs
@@ -4,6 +4,11 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 
 namespace ALCops.Common.Reflection;
 
+/// <summary>
+/// Reflection-based access to non-public Compilation properties.
+/// NOTE: This is NOT a backward-compat shim. These properties are internal to the SDK
+/// and require reflection on ALL target frameworks. Do not attempt to eliminate.
+/// </summary>
 public static class CompilationHelper
 {
     private static readonly BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic;

--- a/src/ALCops.Common/Reflection/PropertyAccessor.cs
+++ b/src/ALCops.Common/Reflection/PropertyAccessor.cs
@@ -4,8 +4,8 @@ namespace ALCops.Common.Reflection;
 
 /// <summary>
 /// Provides safe property access methods using reflection.
-/// These methods are designed to maintain compatibility across different API versions
-/// by safely accessing properties that may not exist in all versions.
+/// NOTE: This is a generic compat utility for runtime API differences across SDK versions.
+/// Required on ALL target frameworks. Do not attempt to eliminate.
 /// </summary>
 public static class PropertyAccessor
 {

--- a/src/ALCops.Common/Reflection/StringHelper.cs
+++ b/src/ALCops.Common/Reflection/StringHelper.cs
@@ -2,6 +2,14 @@ using System.Reflection;
 
 namespace ALCops.Common.Reflection;
 
+/// <summary>
+/// COMPAT(netstandard2.1, net8.0): Reflection-based wrapper for QuoteIdentifierIfNeeded.
+/// This file exists because the SDK method signature changed between versions:
+/// - Older SDKs: QuoteIdentifierIfNeeded(string)
+/// - Newer SDKs (net10.0+): QuoteIdentifierIfNeeded(string, bool)
+/// On net10.0+, StringExtensions.cs calls the SDK directly and this class is unused.
+/// TODO: Delete this file when netstandard2.1 and net8.0 TFMs are dropped.
+/// </summary>
 public static class StringHelper
 {
     // Cache the method info for QuoteIdentifierIfNeeded with the optional parameter >= 17.0.29.44223

--- a/src/ALCops.Common/Reflection/SymbolHelper.cs
+++ b/src/ALCops.Common/Reflection/SymbolHelper.cs
@@ -4,9 +4,12 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 namespace ALCops.Common.Reflection;
 
 /// <summary>
-/// Provides safe symbol property access methods using reflection.
-/// These methods are designed to maintain compatibility across different API versions
-/// where properties like ContainingNamespace may not exist in older versions.
+/// COMPAT(netstandard2.1, net8.0): Reflection-based symbol property access.
+/// Provides safe access to properties that may not exist in older SDK versions.
+/// On net10.0+, callers in SymbolInterfaceExtensions.cs bypass this class and call the SDK directly.
+/// TODO: When netstandard2.1 and net8.0 are dropped, delete GetContainingNamespaceQualifiedName
+/// and replace callers with symbol.ContainingNamespace?.QualifiedName.
+/// ToDisplayStringWithReflection is already netstandard2.1-only and will be removed with that TFM.
 /// </summary>
 public static class SymbolHelper
 {


### PR DESCRIPTION
## Summary

Adds `#if NET10_0_OR_GREATER` guards to call SDK APIs directly on net10.0, while keeping reflection-based fallbacks for netstandard2.1 and net8.0.

### Changes

- **`StringExtensions.cs`**: On net10.0, calls `QuoteIdentifierIfNeeded(string, bool)` directly (the two-parameter overload exists in the net10.0 SDK). On older TFMs, continues using `StringHelper` reflection.
- **`SymbolInterfaceExtensions.cs`**: On net10.0, accesses `symbol.ContainingNamespace?.QualifiedName` directly. On older TFMs, continues using `SymbolHelper` reflection.
- **COMPAT comments**: Added `// COMPAT(netstandard2.1, net8.0):` comments to all reflection shims so they're grep-able for future cleanup when old TFMs are dropped.
- **Instructions update**: Added a "Reflection shims to clean up" inventory table to `netstandard21-compatibility.instructions.md`, documenting which helpers can be deleted vs. must be kept.

### Design decision

The `#if` guards are placed in the **centralized wrapper methods** (StringExtensions.cs, SymbolInterfaceExtensions.cs), not at the ~20+ call sites. This means:
- Zero call-site changes
- Single point of change when dropping old TFMs
- Standard facade/shim pattern

### Testing

- Build: 0 warnings, 0 errors
- Tests: 949/949 passing