### PR TITLE
feat: add PC0034 placeholder argument count mismatch

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -100,3 +100,4 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `pc0031-partial-records-before-write-operation` | rule-scoped | PC0031 rule |
 | `pc0032-report-layout-property-length` | rule-scoped | PC0032 rule |
 | `pc0033-duplicate-odata-entity-name` | rule-scoped | PC0033 rule |
+| `pc0034-placeholder-argument-count-mismatch` | rule-scoped | PC0034 rule |

--- a/.github/instructions/pc0034-placeholder-argument-count-mismatch.instructions.md
+++ b/.github/instructions/pc0034-placeholder-argument-count-mismatch.instructions.md
@@ -1,0 +1,57 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/PlaceholderArgumentCountMismatch*'
+---
+
+# PC0034: Placeholder Argument Count Mismatch
+
+## Purpose
+
+Detects mismatches between placeholder count in format strings and the number of substitution arguments passed to `StrSubstNo`, `Error`, `Message`, and `Confirm`. This rule extends CodeCop AA0131 to cover its gaps.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | PC0034 |
+| Title | Placeholder argument count mismatch |
+| Category | Usage |
+| Default severity | Warning |
+| Enabled by default | Yes |
+| Help URI | https://alcops.dev/docs/analyzers/platformcop/pc0034/ |
+
+## Relationship to CodeCop AA0131
+
+This rule is an **extension of CodeCop AA0131** ([docs](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0131)).
+
+AA0131 has two gaps:
+1. **Zero-args gap**: When `args.Length - 1 < 1`, AA0131 exits early without checking placeholder count
+2. **No Confirm coverage**: AA0131 only handles `StrSubstNo`, `Error`, `Message`
+
+PC0034 fires when:
+- For StrSubstNo/Error/Message: placeholders exist but zero substitution args are passed (gap #1)
+- For Confirm: any placeholder/argument mismatch (gap #2)
+
+PC0034 intentionally avoids overlap: for StrSubstNo/Error/Message with `argumentCount >= 1`, AA0131 already handles it.
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Text variable support | Bail out (no diagnostic) | Matches AA0131 behavior, avoids false positives |
+| TextConst support | Not implemented | Legacy type, NavTypeKind.TextConst not in EnumProvider |
+| Confirm default button | args[1] is always Boolean | Substitution args start at index 2 for Confirm |
+| Duplicate placeholder counting | HashSet-based (unique) | `%1 appears %1 twice` counts as 1 placeholder |
+| Regex pattern | `[#%](\d+)` | Both `%N` and `#N` are valid AL placeholder syntax |
+
+## Architecture
+
+- Registers for `OperationKind.InvocationExpression`
+- Matches built-in methods by name (case-insensitive)
+- Unwraps ConversionExpression chain to get the format string operand
+- Bails out if any unwrapped type is `NavTypeKind.Text` (runtime-determined string)
+- Extracts text from `ILabelTypeSymbol.Text` or `ConstantValue` for string literals
+
+## Test coverage
+
+**HasDiagnostic (7 cases):** StrSubstNoMissingArgs, ErrorMissingArgs, MessageMissingArgs, ConfirmMissingArgs, ConfirmTooManyArgs, MultiplePlaceholdersMissingArgs, StringLiteralMissingArgs.
+**NoDiagnostic (6 cases):** StrSubstNoCorrectArgs, ErrorNoPlaceholders, ConfirmCorrectArgs, TextVariable, EmptyLabel, StrSubstNoTooManyArgs.

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ConfirmMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ConfirmMissingArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ConfirmQst: Label 'Do you want to delete %1?', Comment = '%1=Record description';
+    begin
+        if Confirm([|ConfirmQst|]) then;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ConfirmTooManyArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ConfirmTooManyArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ConfirmQst: Label 'Do you want to continue?';
+    begin
+        if Confirm([|ConfirmQst|], true, 'Extra argument') then;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ErrorMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/ErrorMissingArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        UnexpectedErr: Label 'Unexpected error for %1.', Comment = '%1=Record ID';
+    begin
+        Error([|UnexpectedErr|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/MessageMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/MessageMissingArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ProcessedMsg: Label '%1 records have been processed.', Comment = '%1=Count';
+    begin
+        Message([|ProcessedMsg|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/MultiplePlaceholdersMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/MultiplePlaceholdersMissingArgs.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MultiMsg: Label '%1 of %2 records processed for %3.', Comment = '%1=Count,%2=Total,%3=Table name';
+        CompleteText: Text;
+    begin
+        CompleteText := StrSubstNo([|MultiMsg|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/StrSubstNoMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/StrSubstNoMissingArgs.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        TestMsg: Label 'It should give an error for this: %1', Comment = '%1=Any text that needs to be tested';
+        CompleteText: Text;
+    begin
+        CompleteText := StrSubstNo([|TestMsg|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/StringLiteralMissingArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/HasDiagnostic/StringLiteralMissingArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        CompleteText: Text;
+    begin
+        CompleteText := StrSubstNo([|'Hello %1'|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/ConfirmCorrectArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/ConfirmCorrectArgs.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ConfirmQst: Label 'Do you want to delete %1?', Comment = '%1=Record description';
+    begin
+        if Confirm([|ConfirmQst|], true, 'Sales Order 1001') then;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/EmptyLabel.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/EmptyLabel.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        EmptyLbl: Label 'No placeholders here.';
+        CompleteText: Text;
+    begin
+        CompleteText := StrSubstNo([|EmptyLbl|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/ErrorNoPlaceholders.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/ErrorNoPlaceholders.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SimpleErr: Label 'An unexpected error occurred.';
+    begin
+        Error([|SimpleErr|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/StrSubstNoCorrectArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/StrSubstNoCorrectArgs.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        TestMsg: Label 'Hello %1, welcome to %2!', Comment = '%1=User name,%2=Company name';
+        CompleteText: Text;
+    begin
+        CompleteText := StrSubstNo([|TestMsg|], 'World', 'Contoso');
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/StrSubstNoTooManyArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/StrSubstNoTooManyArgs.al
@@ -1,0 +1,11 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SimpleMsg: Label 'Hello %1', Comment = '%1=Name';
+        CompleteText: Text;
+    begin
+        // AA0131 handles this case (too many args with at least 1 arg passed)
+        CompleteText := StrSubstNo([|SimpleMsg|], 'World', 'Extra');
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/TextVariable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/NoDiagnostic/TextVariable.al
@@ -1,0 +1,11 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyText: Text;
+        CompleteText: Text;
+    begin
+        MyText := 'Hello %1';
+        CompleteText := StrSubstNo([|MyText|]);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/PlaceholderArgumentCountMismatch.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/PlaceholderArgumentCountMismatch/PlaceholderArgumentCountMismatch.cs
@@ -1,0 +1,51 @@
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test;
+
+public class PlaceholderArgumentCountMismatch : NavCodeAnalysisBase
+{
+    private AnalyzerTestFixture _fixture;
+    private string _testCasePath;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fixture = RoslynFixtureFactory.Create<Analyzers.PlaceholderArgumentCountMismatch>();
+
+        _testCasePath = Path.Combine(
+            Directory.GetParent(
+                Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                Path.Combine("Rules", nameof(PlaceholderArgumentCountMismatch)));
+    }
+
+    [Test]
+    [TestCase("StrSubstNoMissingArgs")]
+    [TestCase("ErrorMissingArgs")]
+    [TestCase("MessageMissingArgs")]
+    [TestCase("ConfirmMissingArgs")]
+    [TestCase("ConfirmTooManyArgs")]
+    [TestCase("MultiplePlaceholdersMissingArgs")]
+    [TestCase("StringLiteralMissingArgs")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.PlaceholderArgumentCountMismatch);
+    }
+
+    [Test]
+    [TestCase("StrSubstNoCorrectArgs")]
+    [TestCase("ErrorNoPlaceholders")]
+    [TestCase("ConfirmCorrectArgs")]
+    [TestCase("TextVariable")]
+    [TestCase("EmptyLabel")]
+    [TestCase("StrSubstNoTooManyArgs")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PlaceholderArgumentCountMismatch);
+    }
+}

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -453,4 +453,13 @@
   <data name="DuplicateODataEntityNameDescription" xml:space="preserve">
     <value>Page controls are exposed as OData properties with transformed names (dots removed, spaces replaced by underscores, parentheses removed, slashes replaced by underscores, apostrophes replaced by _x0027_, percent signs replaced by Percent). When two or more controls produce the same OData EntityName after transformation, 'Edit in Excel' and other OData integrations fail at runtime. Primary key fields are automatically included in the OData metadata even if not on the page, so control names must also be unique relative to primary key field names.</value>
   </data>
+  <data name="PlaceholderArgumentCountMismatchTitle" xml:space="preserve">
+    <value>Placeholder argument count mismatch</value>
+  </data>
+  <data name="PlaceholderArgumentCountMismatchMessageFormat" xml:space="preserve">
+    <value>The format string contains {0} placeholder(s), but {1} argument(s) were provided.</value>
+  </data>
+  <data name="PlaceholderArgumentCountMismatchDescription" xml:space="preserve">
+    <value>When calling StrSubstNo, Error, Message, or Confirm with a format string containing placeholders (%1, %2, #1, etc.), the number of substitution arguments must match the number of unique placeholders. A mismatch means either placeholders will remain unsubstituted at runtime or arguments will be silently ignored. This rule extends CodeCop AA0131 to cover cases it misses: the zero-arguments gap and the Confirm method.</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+/// <summary>
+/// Reports when the number of substitution arguments does not match the number of
+/// unique placeholders in the format string of StrSubstNo, Error, Message, or Confirm.
+/// This rule extends CodeCop AA0131 to cover its gaps:
+/// - Zero substitution arguments when placeholders exist (AA0131 exits early)
+/// - The Confirm method (AA0131 does not handle it)
+/// </summary>
+[DiagnosticAnalyzer]
+public sealed class PlaceholderArgumentCountMismatch : DiagnosticAnalyzer
+{
+    private static readonly Regex PlaceholderPattern = new("[#%](\\d+)", RegexOptions.Compiled);
+
+    private static readonly HashSet<string> MethodsCoveredByAA0131 = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "StrSubstNo",
+        "Message",
+        "Error"
+    };
+
+    private static readonly HashSet<string> AllTargetMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "StrSubstNo",
+        "Message",
+        "Error",
+        "Confirm"
+    };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.PlaceholderArgumentCountMismatch);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterOperationAction(
+            AnalyzeInvocation,
+            EnumProvider.OperationKind.InvocationExpression);
+
+    private static void AnalyzeInvocation(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
+            return;
+
+        IMethodSymbol targetMethod = invocation.TargetMethod;
+        if (targetMethod is null ||
+            targetMethod.ContainingSymbol?.Kind != EnumProvider.SymbolKind.Class ||
+            invocation.Arguments.IsEmpty)
+            return;
+
+        if (!AllTargetMethods.Contains(targetMethod.Name))
+            return;
+
+        string? formatString = GetFormatStringValue(invocation.Arguments[0].Value);
+        if (string.IsNullOrEmpty(formatString))
+            return;
+
+        int placeholderCount = CountUniquePlaceholders(formatString);
+        int argumentCount = GetSubstitutionArgumentCount(targetMethod.Name, invocation.Arguments.Length);
+
+        if (placeholderCount == argumentCount)
+            return;
+
+        // For methods covered by AA0131, only report the gap it misses (zero args with placeholders).
+        // AA0131 already handles the case where argumentCount >= 1.
+        if (MethodsCoveredByAA0131.Contains(targetMethod.Name) && argumentCount >= 1)
+            return;
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.PlaceholderArgumentCountMismatch,
+            invocation.Arguments[0].Syntax.GetLocation(),
+            placeholderCount,
+            argumentCount));
+    }
+
+    /// <summary>
+    /// Gets the number of substitution arguments (excluding the format string and,
+    /// for Confirm, the optional default button parameter).
+    /// Confirm signature: Confirm(String [, Default: Boolean] [, Value1] ...)
+    /// Others: Method(String [, Value1] [, Value2] ...)
+    /// </summary>
+    private static int GetSubstitutionArgumentCount(string methodName, int totalArguments)
+    {
+        if (string.Equals(methodName, "Confirm", StringComparison.OrdinalIgnoreCase))
+        {
+            // Confirm: args[0]=format, args[1]=default button (Boolean, required if subs present)
+            // If only 1 arg (format only) or 2 args (format + default): 0 subs
+            return totalArguments <= 2 ? 0 : totalArguments - 2;
+        }
+
+        // StrSubstNo, Error, Message: args[0]=format, args[1..N]=substitution values
+        return totalArguments - 1;
+    }
+
+    private static string? GetFormatStringValue(IOperation operation)
+    {
+        // Unwrap conversion expressions, bail out if we hit a Text variable
+        while (operation.Kind == EnumProvider.OperationKind.ConversionExpression)
+        {
+            if (operation is not IConversionExpression conversion)
+                break;
+
+            operation = conversion.Operand;
+            if (operation.Type?.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Text)
+                return null;
+        }
+
+        if (operation.Type is null || !operation.Type.IsTextType())
+            return null;
+
+        switch (operation.Type.GetNavTypeKindSafe())
+        {
+            case var kind when kind == EnumProvider.NavTypeKind.Label:
+                if (operation.Type is ILabelTypeSymbol labelTypeSymbol)
+                    return labelTypeSymbol.Text;
+                break;
+
+            case var kind when kind == EnumProvider.NavTypeKind.String:
+                if (operation.ConstantValue.HasValue)
+                    return operation.ConstantValue.Value?.ToString();
+                break;
+        }
+
+        return null;
+    }
+
+    private static int CountUniquePlaceholders(string formatString)
+    {
+        MatchCollection matches = PlaceholderPattern.Matches(formatString);
+        if (matches.Count == 0)
+            return 0;
+
+        HashSet<string> unique = new();
+        foreach (Match match in matches)
+            unique.Add(match.Value);
+
+        return unique.Count;
+    }
+}

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -325,6 +325,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.DuplicateODataEntityNameDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.DuplicateODataEntityName));
 
+    public static readonly DiagnosticDescriptor PlaceholderArgumentCountMismatch = new(
+        id: DiagnosticIds.PlaceholderArgumentCountMismatch,
+        title: PlatformCopAnalyzers.PlaceholderArgumentCountMismatchTitle,
+        messageFormat: PlatformCopAnalyzers.PlaceholderArgumentCountMismatchMessageFormat,
+        category: Category.Usage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.PlaceholderArgumentCountMismatchDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.PlaceholderArgumentCountMismatch));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -34,4 +34,5 @@ public static class DiagnosticIds
     public static readonly string PartialRecordsBeforeWriteOperation = "PC0031";
     public static readonly string ReportLayoutPropertyLength = "PC0032";
     public static readonly string DuplicateODataEntityName = "PC0033";
+    public static readonly string PlaceholderArgumentCountMismatch = "PC0034";
 }


### PR DESCRIPTION
## Summary

Adds PC0034, a new PlatformCop analyzer that detects mismatches between placeholder count in format strings and substitution arguments passed to `StrSubstNo`, `Error`, `Message`, and `Confirm`.

## Relationship to CodeCop AA0131

This rule is an **extension of [CodeCop AA0131](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0131)** and covers its gaps:

1. **Zero-args gap**: AA0131 exits early (`if (num < 1) break`) when no substitution args are passed, even if the format string has placeholders
2. **Confirm method**: AA0131 only handles `StrSubstNo`, `Error`, `Message`

For `StrSubstNo`/`Error`/`Message`, PC0034 only fires when `argumentCount == 0` and placeholders exist (avoiding overlap with AA0131). For `Confirm`, it reports any mismatch.

## Test coverage

- **7 HasDiagnostic** cases: StrSubstNoMissingArgs, ErrorMissingArgs, MessageMissingArgs, ConfirmMissingArgs, ConfirmTooManyArgs, MultiplePlaceholdersMissingArgs, StringLiteralMissingArgs
- **6 NoDiagnostic** cases: StrSubstNoCorrectArgs, ErrorNoPlaceholders, ConfirmCorrectArgs, TextVariable, EmptyLabel, StrSubstNoTooManyArgs

All 388 PlatformCop tests pass.

Closes #194