### PR TITLE
feat(PC0014): add support for SelectTokens on all Json types

### DIFF
--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasDiagnostic/SelectTokens.al
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasDiagnostic/SelectTokens.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens([|'$.custom_attributes[?(@.attribute_code == "activation_status")].value'|], Results);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasFix/SelectTokens/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasFix/SelectTokens/current.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens([|'$.custom_attributes[?(@.attribute_code == "activation_status")].value'|], Results);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasFix/SelectTokens/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/HasFix/SelectTokens/expected.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens('$.custom_attributes[?(@.attribute_code == ''activation_status'')].value', Results);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/JsonTokenJPathUsesDoubleQuotes.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/JsonTokenJPathUsesDoubleQuotes.cs
@@ -25,6 +25,13 @@ namespace ALCops.PlatformCop.Test
         [TestCase("SelectTokens")]
         public async Task HasDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["SelectTokens"],
+                testCase,
+                "17.0",
+                "SelectTokens is available with runtime version 17.0."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
@@ -36,6 +43,13 @@ namespace ALCops.PlatformCop.Test
         [TestCase("SelectTokens")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["SelectTokens"],
+                testCase,
+                "17.0",
+                "SelectTokens is available with runtime version 17.0."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
@@ -47,6 +61,13 @@ namespace ALCops.PlatformCop.Test
         [TestCase("SelectTokens")]
         public async Task HasFix(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["SelectTokens"],
+                testCase,
+                "17.0",
+                "SelectTokens is available with runtime version 17.0."
+            );
+
             var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/JsonTokenJPathUsesDoubleQuotes.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/JsonTokenJPathUsesDoubleQuotes.cs
@@ -22,6 +22,7 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("SelectToken")]
+        [TestCase("SelectTokens")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -32,6 +33,7 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("SelectToken")]
+        [TestCase("SelectTokens")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
@@ -42,6 +44,7 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("SelectToken")]
+        [TestCase("SelectTokens")]
         public async Task HasFix(string testCase)
         {
             var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/NoDiagnostic/SelectTokens.al
+++ b/src/ALCops.PlatformCop.Test/Rules/JsonTokenJPathUsesDoubleQuotes/NoDiagnostic/SelectTokens.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens([|'$.custom_attributes[?(@.attribute_code == ''activation_status'')].value'|], Results);
+    end;
+}

--- a/src/ALCops.PlatformCop/Analyzers/JsonTokenJPathUsesDoubleQuotes.cs
+++ b/src/ALCops.PlatformCop/Analyzers/JsonTokenJPathUsesDoubleQuotes.cs
@@ -9,8 +9,19 @@ namespace ALCops.PlatformCop.Analyzers;
 [DiagnosticAnalyzer]
 public sealed class JsonTokenJPathUsesDoubleQuotes : DiagnosticAnalyzer
 {
-    private const string JsonTokenTypeName = "JsonToken";
-    private const string SelectTokenMethodName = "SelectToken";
+    private static readonly HashSet<string> MethodNames = new(StringComparer.Ordinal)
+    {
+        "SelectToken",
+        "SelectTokens"
+    };
+
+    private static readonly HashSet<string> JsonTypeNames = new(StringComparer.Ordinal)
+    {
+        "JsonToken",
+        "JsonObject",
+        "JsonArray"
+    };
+
     private const string PathParameterName = "Path";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -35,10 +46,10 @@ public sealed class JsonTokenJPathUsesDoubleQuotes : DiagnosticAnalyzer
         if (method.MethodKind != MethodKind.BuiltInMethod)
             return;
 
-        if (!string.Equals(method.Name, SelectTokenMethodName, StringComparison.Ordinal))
+        if (!MethodNames.Contains(method.Name))
             return;
 
-        if (!string.Equals(method.ContainingSymbol?.Name, JsonTokenTypeName, StringComparison.Ordinal))
+        if (method.ContainingSymbol?.Name is not string containingName || !JsonTypeNames.Contains(containingName))
             return;
 
         List<StringLiteralValueSyntax>? stringLiterals = null;


### PR DESCRIPTION
## Summary

Expand PC0014 to detect double-quote usage in JPath expressions for:
- `SelectTokens` (new method) on `JsonToken`, `JsonObject`, `JsonArray`
- `SelectToken` on `JsonObject` and `JsonArray` (previously only `JsonToken`)

## Changes

- **Analyzer:** Replace hardcoded single-method/single-type checks with `HashSet<string>` lookups for method names (`SelectToken`, `SelectTokens`) and containing types (`JsonToken`, `JsonObject`, `JsonArray`)
- **Tests:** Add `SelectTokens` test cases for HasDiagnostic, NoDiagnostic, and HasFix
- **Docs:** Update PC0014.md on alcops.dev (separate commit in alcops.dev repo)

## CodeFix

No changes needed. The existing CodeFix already operates on the string literal node, so it works for `SelectTokens` automatically.

Closes #236