### PR TITLE
feat(PC0035): Use SetAutoCalcFields for loops

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -101,4 +101,5 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `pc0032-report-layout-property-length` | rule-scoped | PC0032 rule |
 | `pc0033-duplicate-odata-entity-name` | rule-scoped | PC0033 rule |
 | `pc0034-placeholder-argument-count-mismatch` | rule-scoped | PC0034 rule |
+| `pc0035-use-set-auto-calc-fields-for-loops` | rule-scoped | PC0035 rule |
 | `lc0095-parameter-not-referenced` | rule-scoped | LC0095 rule |

--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -1,0 +1,73 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/UseSetAutoCalcFieldsForLoops*'
+---
+
+# PC0035: UseSetAutoCalcFieldsForLoops
+
+## Purpose
+
+Detects `CalcFields` calls inside loop bodies and recommends using `SetAutoCalcFields` before the loop instead. Each `CalcFields` inside a loop generates a separate SQL query per FlowField per iteration, while `SetAutoCalcFields` bundles FlowField calculation into the main SELECT query.
+
+**References:**
+- [Discussion #74](https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/74)
+- [MS Docs: Record.SetAutoCalcFields](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/record/record-setautocalcfields-method)
+- [CalcFields vs SetAutoCalcFields](https://www.kauffmann.nl/2014/04/04/calcfields-vs-setautocalcfields/)
+
+## Diagnostic properties
+
+**PC0035** · Category: Performance · Severity: Warning · Enabled: true
+Message: `Use '{0}.SetAutoCalcFields()' before the loop instead of '{0}.CalcFields()' inside the loop to avoid repeated FlowField calculations.`
+Version gate: None (SetAutoCalcFields available since runtime 1.0)
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Loop types | FindSet/Find + repeat-until, while-do, report OnAfterGetRecord | All patterns that iterate over records |
+| Variable matching | Only flag CalcFields on the variable driving the loop | Avoids false positives (Example #2 from spec) |
+| Cross-method tracking | Out of scope v1 | Complex, may lack source code for dependencies |
+| RecordRef | N/A | RecordRef does not have a CalcFields method in the SDK |
+| ForEach loop | N/A | AL foreach only works with List/Array, not Record |
+| SetAutoCalcFields suppression | No | Always flag CalcFields in loop even if SetAutoCalcFields exists |
+| Severity | Warning | Stronger than Info because the perf impact in loops is significant |
+| CodeFix | Yes | Insert SetAutoCalcFields before loop, remove CalcFields from body |
+
+## Architecture
+
+### Registration strategy
+
+Uses `RegisterCodeBlockAction` to analyze entire method/trigger bodies. A custom `CalcFieldsInLoopWalker` (extending `OperationWalker`) walks the IOperation tree.
+
+### Loop variable identification
+
+- **repeat-until**: Extract variable name from `Next()` call in the until-condition
+- **while-do**: Extract variable name from `FindSet()`/`Find()` in the while-condition
+- **Report OnAfterGetRecord**: The DataItem name is the implicit loop variable
+
+### Stack-based tracking
+
+A `Stack<ImmutableHashSet<string>>` tracks loop variables at each nesting level. When entering a loop, the set of active loop variables is pushed. When exiting, it's popped. This correctly handles nested loops.
+
+### CalcFields detection
+
+`VisitInvocationExpression` checks if the method name is `CalcFields` and if the instance variable is in the current set of loop variables (at any nesting level).
+
+### CodeFix strategy
+
+1. Find the `ExpressionStatementSyntax` containing the CalcFields invocation
+2. Find the insertion target (FindSet statement before repeat, or the loop statement itself)
+3. Remove the CalcFields statement from the tree
+4. Insert `SetAutoCalcFields(fields)` before the insertion target
+5. Arguments are passed through directly from CalcFields (unqualified field names)
+
+## Test coverage
+
+**HasDiagnostic (6 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop.
+**NoDiagnostic (4 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord.
+**HasFix (2 cases):** FindSetRepeatUntil, MultipleFields.
+
+## Known limitations
+
+- Cross-method CalcFields calls (passed record variable) are not detected
+- Multiple CalcFields in the same loop are reported individually (not merged by the analyzer)
+- The CodeFix handles one CalcFields at a time; use Fix All for multiple occurrences

--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -25,6 +25,7 @@ Version gate: None (SetAutoCalcFields available since runtime 1.0)
 |---|---|---|
 | Loop types | FindSet/Find + repeat-until, while-do, report OnAfterGetRecord | All patterns that iterate over records |
 | Variable matching | Only flag CalcFields on the variable driving the loop | Avoids false positives (Example #2 from spec) |
+| Conditional paths | Skip entirely (if/case) | Cannot guarantee conditional CalcFields always executes; avoids false positives |
 | Cross-method tracking | Out of scope v1 | Complex, may lack source code for dependencies |
 | RecordRef | N/A | RecordRef does not have a CalcFields method in the SDK |
 | ForEach loop | N/A | AL foreach only works with List/Array, not Record |
@@ -48,9 +49,15 @@ Uses `RegisterCodeBlockAction` to analyze entire method/trigger bodies. A custom
 
 A `Stack<ImmutableHashSet<string>>` tracks loop variables at each nesting level. When entering a loop, the set of active loop variables is pushed. When exiting, it's popped. This correctly handles nested loops.
 
+### Conditional path skipping
+
+`VisitIfStatement` and `VisitCaseStatement` are overridden to increment a `_conditionalDepth` counter when inside a loop. CalcFields is only flagged when `_conditionalDepth == 0`. When entering a new loop (`PushLoop`), `_conditionalDepth` is saved and reset to 0, so CalcFields inside a nested loop (even one inside a conditional branch) is correctly flagged as unconditional relative to that inner loop. On `PopLoop`, the saved depth is restored.
+
+This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (PC0030/PC0031), adapted with save/restore semantics for loop nesting.
+
 ### CalcFields detection
 
-`VisitInvocationExpression` checks if the method name is `CalcFields` and if the instance variable is in the current set of loop variables (at any nesting level).
+`VisitInvocationExpression` checks: `IsInLoop() && _conditionalDepth == 0 && IsCalcFieldsCall(...)` and verifies the instance variable is in the current set of loop variables (at any nesting level).
 
 ### CodeFix strategy
 
@@ -62,8 +69,8 @@ A `Stack<ImmutableHashSet<string>>` tracks loop variables at each nesting level.
 
 ## Test coverage
 
-**HasDiagnostic (6 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop.
-**NoDiagnostic (4 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord.
+**HasDiagnostic (7 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop, NestedLoopInConditional.
+**NoDiagnostic (7 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord, CalcFieldsInIfBlock, CalcFieldsInCaseBlock, CalcFieldsInIfElseBlock.
 **HasFix (2 cases):** FindSetRepeatUntil, MultipleFields.
 
 ## Known limitations
@@ -71,3 +78,4 @@ A `Stack<ImmutableHashSet<string>>` tracks loop variables at each nesting level.
 - Cross-method CalcFields calls (passed record variable) are not detected
 - Multiple CalcFields in the same loop are reported individually (not merged by the analyzer)
 - The CodeFix handles one CalcFields at a time; use Fix All for multiple occurrences
+- CalcFields inside conditional branches (if/case) within loops are intentionally not flagged, even if all branches call CalcFields (accepted false negative for zero false positives)

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -316,9 +316,13 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.BuiltInMethod)));
         private static readonly Lazy<NavCodeAnalysis.MethodKind> _method =
             new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.Method)));
+       private static readonly Lazy<NavCodeAnalysis.MethodKind> _trigger =
+            new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.Trigger)));
 
-        public static NavCodeAnalysis.MethodKind Method => _method.Value;
+
         public static NavCodeAnalysis.MethodKind BuiltInMethod => _builtInMethod.Value;
+        public static NavCodeAnalysis.MethodKind Method => _method.Value;
+        public static NavCodeAnalysis.MethodKind Trigger => _trigger.Value;
     }
     /// <summary>
     /// NavTypeKind enum values

--- a/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
@@ -87,7 +88,7 @@ public sealed class ParameterNotReferenced : DiagnosticAnalyzer
             return false;
 
         // Triggers have platform-defined signatures
-        if (method.MethodKind == MethodKind.Trigger)
+        if (method.MethodKind == EnumProvider.MethodKind.Trigger)
             return false;
 
         // Event declarations define the subscriber contract

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/FindRepeatUntil.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/FindRepeatUntil.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Find('-');
+        repeat
+            [|MyTable.CalcFields(MyFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/FindSetRepeatUntil.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/FindSetRepeatUntil.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyTable.CalcFields(MyFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/MultipleCalcFields.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/MultipleCalcFields.al
@@ -1,0 +1,36 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyTable.CalcFields(MyFlowField)|];
+            [|MyTable.CalcFields(MyOtherFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+        field(3; MyOtherFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/NestedLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/NestedLoop.al
@@ -1,0 +1,34 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        OuterTable: Record MyTable;
+        InnerTable: Record MyTable;
+    begin
+        OuterTable.FindSet();
+        repeat
+            InnerTable.FindSet();
+            repeat
+                [|OuterTable.CalcFields(MyFlowField)|];
+            until InnerTable.Next() = 0;
+        until OuterTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/NestedLoopInConditional.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/NestedLoopInConditional.al
@@ -1,0 +1,34 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        OuterTable: Record MyTable;
+        InnerTable: Record MyTable;
+    begin
+        OuterTable.FindSet();
+        repeat
+            if InnerTable.FindSet() then
+                repeat
+                    [|InnerTable.CalcFields(MyFlowField)|];
+                until InnerTable.Next() = 0;
+        until OuterTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/ReportOnAfterGetRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/ReportOnAfterGetRecord.al
@@ -1,0 +1,31 @@
+report 50100 MyReport
+{
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+            trigger OnAfterGetRecord()
+            begin
+                [|MyTable.CalcFields(MyFlowField)|];
+            end;
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/WhileLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/WhileLoop.al
@@ -1,0 +1,29 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        while MyTable.FindSet() do begin
+            [|MyTable.CalcFields(MyFlowField)|];
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/FindSetRepeatUntil/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/FindSetRepeatUntil/current.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyTable.CalcFields(MyFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/FindSetRepeatUntil/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/FindSetRepeatUntil/expected.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetAutoCalcFields(MyFlowField);
+        MyTable.FindSet();
+        repeat
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetBeginRepeatUntil/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetBeginRepeatUntil/current.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if MyTable.FindSet() then begin
+            repeat
+                [|MyTable.CalcFields(MyFlowField)|];
+            until MyTable.Next() < 1;
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetBeginRepeatUntil/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetBeginRepeatUntil/expected.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetAutoCalcFields(MyFlowField);
+        if MyTable.FindSet() then begin
+            repeat
+            until MyTable.Next() < 1;
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetRepeatUntil/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetRepeatUntil/current.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if MyTable.FindSet() then
+            repeat
+                [|MyTable.CalcFields(MyFlowField)|];
+            until MyTable.Next() < 1;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetRepeatUntil/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/IfFindSetRepeatUntil/expected.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetAutoCalcFields(MyFlowField);
+        if MyTable.FindSet() then
+            repeat
+            until MyTable.Next() < 1;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/MultipleFields/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/MultipleFields/current.al
@@ -1,0 +1,35 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyTable.CalcFields(MyFlowField, MyOtherFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+        field(3; MyOtherFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/MultipleFields/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/MultipleFields/expected.al
@@ -1,0 +1,35 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.SetAutoCalcFields(MyFlowField, MyOtherFlowField);
+        MyTable.FindSet();
+        repeat
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+        field(3; MyOtherFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInCaseBlock.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInCaseBlock.al
@@ -1,0 +1,35 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyOption: Option First,Second,Third)
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            case MyOption of
+                MyOption::First:
+                    [|MyTable.CalcFields(MyFlowField)|];
+                MyOption::Second:
+                    [|MyTable.CalcFields(MyFlowField)|];
+            end;
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInIfBlock.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInIfBlock.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyCondition: Boolean)
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            if MyCondition then
+                [|MyTable.CalcFields(MyFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInIfElseBlock.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsInIfElseBlock.al
@@ -1,0 +1,33 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyCondition: Boolean)
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            if MyCondition then
+                [|MyTable.CalcFields(MyFlowField)|]
+            else
+                [|MyTable.CalcFields(MyFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsOutsideLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CalcFieldsOutsideLoop.al
@@ -1,0 +1,28 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Get(1);
+        [|MyTable.CalcFields(MyFlowField)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CrossMethodCall.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/CrossMethodCall.al
@@ -1,0 +1,35 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyCalcFieldsProcedure(MyTable)|];
+        until MyTable.Next() = 0;
+    end;
+
+    local procedure MyCalcFieldsProcedure(var MyTable: Record MyTable)
+    begin
+        MyTable.CalcFields(MyFlowField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/DifferentVariable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/DifferentVariable.al
@@ -1,0 +1,49 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyOtherTable: Record MyOtherTable;
+    begin
+        MyTable.FindSet();
+        repeat
+            [|MyOtherTable.CalcFields(OtherFlowField)|];
+        until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+table 50101 MyOtherTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; OtherFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyOtherTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/SingleRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/SingleRecord.al
@@ -1,0 +1,29 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.Get(1);
+        [|MyTable.CalcFields(MyFlowField)|];
+        Message('%1', MyTable.MyFlowField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -55,6 +55,7 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [Test]
     [TestCase("FindSetRepeatUntil")]
     [TestCase("MultipleFields")]
+    [TestCase("IfFindSetRepeatUntil")]
     public async Task HasFix(string testCase)
     {
         var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -56,6 +56,7 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("FindSetRepeatUntil")]
     [TestCase("MultipleFields")]
     [TestCase("IfFindSetRepeatUntil")]
+    [TestCase("IfFindSetBeginRepeatUntil")]
     public async Task HasFix(string testCase)
     {
         var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -1,0 +1,70 @@
+using ALCops.PlatformCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test;
+
+public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
+{
+    private AnalyzerTestFixture _fixture;
+    private static readonly Analyzers.UseSetAutoCalcFieldsForLoops _analyzer = new();
+    private string _testCasePath;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fixture = RoslynFixtureFactory.Create<Analyzers.UseSetAutoCalcFieldsForLoops>();
+
+        _testCasePath = Path.Combine(
+            Directory.GetParent(
+                Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                Path.Combine("Rules", nameof(UseSetAutoCalcFieldsForLoops)));
+    }
+
+    [Test]
+    [TestCase("FindSetRepeatUntil")]
+    [TestCase("FindRepeatUntil")]
+    [TestCase("WhileLoop")]
+    [TestCase("ReportOnAfterGetRecord")]
+    [TestCase("MultipleCalcFields")]
+    [TestCase("NestedLoop")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.UseSetAutoCalcFieldsForLoops);
+    }
+
+    [Test]
+    [TestCase("DifferentVariable")]
+    [TestCase("CalcFieldsOutsideLoop")]
+    [TestCase("CrossMethodCall")]
+    [TestCase("SingleRecord")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.UseSetAutoCalcFieldsForLoops);
+    }
+
+    [Test]
+    [TestCase("FindSetRepeatUntil")]
+    [TestCase("MultipleFields")]
+    public async Task HasFix(string testCase)
+    {
+        var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+            .ConfigureAwait(false);
+
+        var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<UseSetAutoCalcFieldsForLoopsCodeFixProvider>(
+            new CodeFixTestFixtureConfig
+            {
+                AdditionalAnalyzers = [_analyzer]
+            });
+
+        fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops);
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -27,6 +27,7 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("ReportOnAfterGetRecord")]
     [TestCase("MultipleCalcFields")]
     [TestCase("NestedLoop")]
+    [TestCase("NestedLoopInConditional")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -40,6 +41,9 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("CalcFieldsOutsideLoop")]
     [TestCase("CrossMethodCall")]
     [TestCase("SingleRecord")]
+    [TestCase("CalcFieldsInIfBlock")]
+    [TestCase("CalcFieldsInCaseBlock")]
+    [TestCase("CalcFieldsInIfElseBlock")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -462,4 +462,16 @@
   <data name="PlaceholderArgumentCountMismatchDescription" xml:space="preserve">
     <value>When calling StrSubstNo, Error, Message, or Confirm with a format string containing placeholders (%1, %2, #1, etc.), the number of substitution arguments must match the number of unique placeholders. A mismatch means either placeholders will remain unsubstituted at runtime or arguments will be silently ignored. This rule extends CodeCop AA0131 to cover cases it misses: the zero-arguments gap and the Confirm method.</value>
   </data>
+  <data name="UseSetAutoCalcFieldsForLoopsTitle" xml:space="preserve">
+    <value>Use SetAutoCalcFields instead of CalcFields inside loops</value>
+  </data>
+  <data name="UseSetAutoCalcFieldsForLoopsMessageFormat" xml:space="preserve">
+    <value>Move CalcFields to SetAutoCalcFields before the loop on '{0}'. Each CalcFields call inside a loop generates a separate SQL query per iteration.</value>
+  </data>
+  <data name="UseSetAutoCalcFieldsForLoopsDescription" xml:space="preserve">
+    <value>Calling CalcFields inside a loop (repeat-until, while, foreach, or report DataItem) causes a separate SQL query for each FlowField on every iteration. For a table with N records and M FlowFields, this results in N×M additional queries. Using SetAutoCalcFields before the loop allows the runtime to join FlowField calculations into the main SELECT query, reducing the total number of database round-trips to one.</value>
+  </data>
+  <data name="UseSetAutoCalcFieldsForLoopsCodeAction" xml:space="preserve">
+    <value>ALCops: Use SetAutoCalcFields before loop</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -90,6 +90,11 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
         // variable(s) driving the current loop scope.
         private readonly Stack<ImmutableHashSet<string>> _loopVariables = new();
 
+        // Tracks nesting depth inside conditional branches (if/case) relative to
+        // the current loop. Reset to 0 when entering a new loop body.
+        private int _conditionalDepth;
+        private readonly Stack<int> _savedConditionalDepths = new();
+
         public IReadOnlyList<CalcFieldsDiagnosticInfo> Diagnostics => _diagnostics;
 
         public CalcFieldsInLoopWalker(string? implicitLoopVariable, CancellationToken cancellationToken)
@@ -109,7 +114,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
         {
             _cancellationToken.ThrowIfCancellationRequested();
 
-            if (IsInLoop() && IsCalcFieldsCall(operation))
+            if (IsInLoop() && _conditionalDepth == 0 && IsCalcFieldsCall(operation))
             {
                 var instanceName = GetInstanceVariableName(operation);
                 if (instanceName is not null && IsLoopVariable(instanceName))
@@ -135,10 +140,10 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                     ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
                     : ImmutableHashSet<string>.Empty;
 
-                _loopVariables.Push(loopVars);
+                PushLoop(loopVars);
                 Visit(operation.Body);
                 Visit(operation.Condition);
-                _loopVariables.Pop();
+                PopLoop();
             }
             else
             {
@@ -148,10 +153,10 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                     ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
                     : ImmutableHashSet<string>.Empty;
 
-                _loopVariables.Push(loopVars);
+                PushLoop(loopVars);
                 Visit(operation.Condition);
                 Visit(operation.Body);
-                _loopVariables.Pop();
+                PopLoop();
             }
         }
 
@@ -164,10 +169,10 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                 ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, iterVarName)
                 : ImmutableHashSet<string>.Empty;
 
-            _loopVariables.Push(loopVars);
+            PushLoop(loopVars);
             Visit(operation.Expression);
             Visit(operation.Body);
-            _loopVariables.Pop();
+            PopLoop();
         }
 
         public override void VisitForLoopStatement(IForLoopStatement operation)
@@ -176,14 +181,68 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
 
             // For loops don't typically loop over records, but we still walk the body
             // with an empty loop variable set (CalcFields won't match any loop var)
-            _loopVariables.Push(ImmutableHashSet<string>.Empty);
+            PushLoop(ImmutableHashSet<string>.Empty);
             Visit(operation.InitialValue);
             Visit(operation.EndValue);
             Visit(operation.Body);
-            _loopVariables.Pop();
+            PopLoop();
+        }
+
+        public override void VisitIfStatement(IIfStatement operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsInLoop())
+            {
+                base.VisitIfStatement(operation);
+                return;
+            }
+
+            // Inside a loop: walk branches with incremented conditional depth.
+            // This suppresses direct CalcFields detection but still discovers nested loops.
+            _conditionalDepth++;
+            Visit(operation.Condition);
+            Visit(operation.IfTrueStatement);
+            Visit(operation.IfFalseStatement);
+            _conditionalDepth--;
+        }
+
+        public override void VisitCaseStatement(ICaseStatement operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsInLoop())
+            {
+                base.VisitCaseStatement(operation);
+                return;
+            }
+
+            // Inside a loop: walk case lines with incremented conditional depth.
+            _conditionalDepth++;
+            Visit(operation.Value);
+            foreach (var caseLine in operation.CaseLines)
+                Visit(caseLine);
+            if (operation.ElseStatement is not null)
+                Visit(operation.ElseStatement);
+            _conditionalDepth--;
         }
 
         private bool IsInLoop() => _loopVariables.Count > 0;
+
+        private void PushLoop(ImmutableHashSet<string> loopVars)
+        {
+            // Save current conditional depth on the stack (encoded with the loop vars)
+            // and reset to 0: inside a new loop, code is unconditional relative to that loop.
+            _savedConditionalDepths.Push(_conditionalDepth);
+            _conditionalDepth = 0;
+            _loopVariables.Push(loopVars);
+        }
+
+        private void PopLoop()
+        {
+            _loopVariables.Pop();
+            _conditionalDepth = _savedConditionalDepths.Pop();
+        }
 
         private bool IsLoopVariable(string variableName)
         {

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -1,0 +1,284 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
+{
+    private static readonly ImmutableHashSet<string> FindSetMethods =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "FindSet", "Find");
+
+    private static readonly ImmutableHashSet<string> NextMethods =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "Next");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterCodeBlockAction(AnalyzeCodeBlock);
+
+    private static void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
+    {
+        if (context.IsObsolete() ||
+            context.CodeBlock is not MethodOrTriggerDeclarationSyntax methodOrTrigger)
+            return;
+
+        if (context.OwningSymbol is not IMethodSymbol methodSymbol)
+            return;
+
+        var body = methodOrTrigger.Body;
+        if (body is null)
+            return;
+
+        var operation = context.SemanticModel.GetOperation(body, context.CancellationToken);
+        if (operation is null)
+            return;
+
+        // Determine if this is a report OnAfterGetRecord trigger
+        string? implicitLoopVariable = GetImplicitLoopVariable(methodSymbol);
+
+        var walker = new CalcFieldsInLoopWalker(implicitLoopVariable, context.CancellationToken);
+        walker.Visit(operation);
+
+        foreach (var diagnostic in walker.Diagnostics)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops,
+                diagnostic.Location,
+                diagnostic.VariableName));
+        }
+    }
+
+    /// <summary>
+    /// For report DataItem OnAfterGetRecord triggers, the entire body is implicitly a loop
+    /// on the DataItem's record variable.
+    /// </summary>
+    private static string? GetImplicitLoopVariable(IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol.MethodKind != MethodKind.Trigger)
+            return null;
+
+        if (!SemanticFacts.IsSameName(methodSymbol.Name, "OnAfterGetRecord"))
+            return null;
+
+        if (methodSymbol.ContainingSymbol is not IReportDataItemSymbol dataItem)
+            return null;
+
+        return dataItem.Name;
+    }
+
+    private sealed class CalcFieldsDiagnosticInfo
+    {
+        public required Location Location { get; init; }
+        public required string VariableName { get; init; }
+    }
+
+    private sealed class CalcFieldsInLoopWalker : OperationWalker
+    {
+        private readonly CancellationToken _cancellationToken;
+        private readonly string? _implicitLoopVariable;
+        private readonly List<CalcFieldsDiagnosticInfo> _diagnostics = new();
+
+        // Stack of loop variable names. When inside a loop, this contains the
+        // variable(s) driving the current loop scope.
+        private readonly Stack<ImmutableHashSet<string>> _loopVariables = new();
+
+        public IReadOnlyList<CalcFieldsDiagnosticInfo> Diagnostics => _diagnostics;
+
+        public CalcFieldsInLoopWalker(string? implicitLoopVariable, CancellationToken cancellationToken)
+        {
+            _implicitLoopVariable = implicitLoopVariable;
+            _cancellationToken = cancellationToken;
+
+            // If this is an OnAfterGetRecord trigger, the entire body is an implicit loop
+            if (implicitLoopVariable is not null)
+            {
+                _loopVariables.Push(
+                    ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, implicitLoopVariable));
+            }
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (IsInLoop() && IsCalcFieldsCall(operation))
+            {
+                var instanceName = GetInstanceVariableName(operation);
+                if (instanceName is not null && IsLoopVariable(instanceName))
+                {
+                    _diagnostics.Add(new CalcFieldsDiagnosticInfo
+                    {
+                        Location = operation.Syntax.GetLocation(),
+                        VariableName = instanceName
+                    });
+                }
+            }
+
+            base.VisitInvocationExpression(operation);
+        }
+
+        public override void VisitWhileRepeatLoopStatement(IWhileRepeatLoopStatement operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (operation.LoopKind == EnumProvider.LoopKind.Repeat)
+            {
+                // repeat-until: loop variable is the one that calls Next() in the condition
+                var loopVar = ExtractNextVariableFromCondition(operation.Condition);
+                var loopVars = loopVar is not null
+                    ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
+                    : ImmutableHashSet<string>.Empty;
+
+                _loopVariables.Push(loopVars);
+                Visit(operation.Body);
+                Visit(operation.Condition);
+                _loopVariables.Pop();
+            }
+            else
+            {
+                // while-do: loop variable could be in the condition (FindSet/Find)
+                var loopVar = ExtractFindSetVariableFromCondition(operation.Condition);
+                var loopVars = loopVar is not null
+                    ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
+                    : ImmutableHashSet<string>.Empty;
+
+                _loopVariables.Push(loopVars);
+                Visit(operation.Condition);
+                Visit(operation.Body);
+                _loopVariables.Pop();
+            }
+        }
+
+        public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            var iterVarName = GetIterationVariableName(operation);
+            var loopVars = iterVarName is not null
+                ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, iterVarName)
+                : ImmutableHashSet<string>.Empty;
+
+            _loopVariables.Push(loopVars);
+            Visit(operation.Expression);
+            Visit(operation.Body);
+            _loopVariables.Pop();
+        }
+
+        public override void VisitForLoopStatement(IForLoopStatement operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            // For loops don't typically loop over records, but we still walk the body
+            // with an empty loop variable set (CalcFields won't match any loop var)
+            _loopVariables.Push(ImmutableHashSet<string>.Empty);
+            Visit(operation.InitialValue);
+            Visit(operation.EndValue);
+            Visit(operation.Body);
+            _loopVariables.Pop();
+        }
+
+        private bool IsInLoop() => _loopVariables.Count > 0;
+
+        private bool IsLoopVariable(string variableName)
+        {
+            foreach (var loopVarSet in _loopVariables)
+            {
+                if (loopVarSet.Contains(variableName))
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool IsCalcFieldsCall(IInvocationExpression invocation)
+        {
+            var targetMethod = invocation.TargetMethod;
+            if (targetMethod is null)
+                return false;
+
+            return targetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
+                   SemanticFacts.IsSameName(targetMethod.Name, "CalcFields");
+        }
+
+        private static string? GetInstanceVariableName(IInvocationExpression invocation)
+        {
+            return invocation.Instance?.GetSymbolSafe()?.Name;
+        }
+
+        /// <summary>
+        /// Extracts the variable calling Next() from a repeat-until condition.
+        /// Pattern: "Rec.Next() = 0" or "Rec.Next() &lt; 1"
+        /// </summary>
+        private static string? ExtractNextVariableFromCondition(IOperation? condition)
+        {
+            if (condition is null)
+                return null;
+
+            // Walk the condition to find a Next() call
+            var finder = new MethodCallFinder(NextMethods);
+            finder.Visit(condition);
+            return finder.FoundVariableName;
+        }
+
+        /// <summary>
+        /// Extracts the variable calling FindSet/Find from a while condition.
+        /// Pattern: "Rec.FindSet()" or "Rec.Find('-')"
+        /// </summary>
+        private static string? ExtractFindSetVariableFromCondition(IOperation? condition)
+        {
+            if (condition is null)
+                return null;
+
+            var finder = new MethodCallFinder(FindSetMethods);
+            finder.Visit(condition);
+            return finder.FoundVariableName;
+        }
+
+        private static string? GetIterationVariableName(IForEachLoopStatement forEachLoop)
+        {
+            if (forEachLoop.IterationVariable is null)
+                return null;
+
+            var symbol = forEachLoop.IterationVariable.GetSymbolSafe();
+            return symbol?.Name;
+        }
+    }
+
+    /// <summary>
+    /// Finds a built-in method call (from a set of method names) in an operation tree
+    /// and extracts the instance variable name.
+    /// </summary>
+    private sealed class MethodCallFinder : OperationWalker
+    {
+        private readonly ImmutableHashSet<string> _methodNames;
+        public string? FoundVariableName { get; private set; }
+
+        public MethodCallFinder(ImmutableHashSet<string> methodNames)
+        {
+            _methodNames = methodNames;
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            if (FoundVariableName is not null)
+                return;
+
+            var targetMethod = operation.TargetMethod;
+            if (targetMethod is not null &&
+                targetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
+                _methodNames.Contains(targetMethod.Name))
+            {
+                FoundVariableName = operation.Instance?.GetSymbolSafe()?.Name;
+            }
+
+            base.VisitInvocationExpression(operation);
+        }
+    }
+}

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -74,10 +74,10 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
         return dataItem.Name;
     }
 
-    private sealed class CalcFieldsDiagnosticInfo
+    private sealed class CalcFieldsDiagnosticInfo(Location location, string variableName)
     {
-        public required Location Location { get; init; }
-        public required string VariableName { get; init; }
+        public Location Location { get; } = location;
+        public string VariableName { get; } = variableName;
     }
 
     private sealed class CalcFieldsInLoopWalker : OperationWalker
@@ -114,11 +114,9 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                 var instanceName = GetInstanceVariableName(operation);
                 if (instanceName is not null && IsLoopVariable(instanceName))
                 {
-                    _diagnostics.Add(new CalcFieldsDiagnosticInfo
-                    {
-                        Location = operation.Syntax.GetLocation(),
-                        VariableName = instanceName
-                    });
+                    _diagnostics.Add(new CalcFieldsDiagnosticInfo(
+                        operation.Syntax.GetLocation(),
+                        instanceName));
                 }
             }
 

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -62,7 +62,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
     /// </summary>
     private static string? GetImplicitLoopVariable(IMethodSymbol methodSymbol)
     {
-        if (methodSymbol.MethodKind != MethodKind.Trigger)
+        if (methodSymbol.MethodKind != EnumProvider.MethodKind.Trigger)
             return null;
 
         if (!SemanticFacts.IsSameName(methodSymbol.Name, "OnAfterGetRecord"))

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -44,7 +44,12 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
             .ConfigureAwait(false);
 
         SyntaxNode node = syntaxRoot.FindNode(span);
-        if (node is not InvocationExpressionSyntax)
+        if (node is not InvocationExpressionSyntax invocation)
+            return;
+
+        // Don't offer CodeFix when there's no valid insertion target
+        // (e.g., report OnAfterGetRecord where SetAutoCalcFields belongs in OnPreDataItem)
+        if (FindInsertionTarget(invocation) is null)
             return;
 
         ctx.RegisterCodeFix(

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -152,9 +152,8 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
 
     /// <summary>
     /// Finds the statement before which to insert SetAutoCalcFields.
-    /// For repeat-until inside begin...end: finds the FindSet/Find call before the repeat.
-    /// For repeat-until as body of if-FindSet: the if statement itself.
-    /// For while loops: the while statement itself.
+    /// For repeat-until: walks up to find the enclosing if-FindSet or while statement.
+    /// SetAutoCalcFields must be placed BEFORE the FindSet/Find call for it to take effect.
     /// For report triggers: returns null (SetAutoCalcFields belongs in OnPreDataItem).
     /// </summary>
     private static StatementSyntax? FindInsertionTarget(InvocationExpressionSyntax calcFieldsInvocation)
@@ -165,15 +164,15 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
             switch (current)
             {
                 case RepeatStatementSyntax repeatStatement:
-                    // For repeat-until, try to find the FindSet/Find statement before the repeat
+                    // Check if an ancestor if-statement contains the FindSet condition
+                    var enclosingIf = FindEnclosingIfWithFind(repeatStatement);
+                    if (enclosingIf is not null)
+                        return enclosingIf;
+
+                    // Otherwise look for a standalone FindSet statement before the repeat
                     var precedingFind = FindPrecedingFindStatement(repeatStatement);
                     if (precedingFind is not null)
                         return precedingFind;
-
-                    // Check if repeat is the body of "if Rec.FindSet() then repeat"
-                    var parentIfStatement = FindParentIfWithFindCondition(repeatStatement);
-                    if (parentIfStatement is not null)
-                        return parentIfStatement;
 
                     return repeatStatement;
 
@@ -195,13 +194,18 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
     }
 
     /// <summary>
-    /// Checks if the repeat statement is the direct body of an "if Rec.FindSet() then"
-    /// and returns that if statement as the insertion target.
+    /// Walks up from the repeat statement to find an enclosing if-statement whose condition
+    /// contains a FindSet/Find call. Handles both:
+    ///   if Rec.FindSet() then repeat...
+    ///   if Rec.FindSet() then begin repeat... end;
     /// </summary>
-    private static IfStatementSyntax? FindParentIfWithFindCondition(RepeatStatementSyntax repeatStatement)
+    private static IfStatementSyntax? FindEnclosingIfWithFind(RepeatStatementSyntax repeatStatement)
     {
-        // Walk up: repeat might be wrapped in a block (begin...end) or be direct child of if
-        var parent = repeatStatement.Parent;
+        SyntaxNode? parent = repeatStatement.Parent;
+
+        // If repeat is inside begin...end, go one level up
+        if (parent is BlockSyntax)
+            parent = parent.Parent;
 
         if (parent is IfStatementSyntax ifStatement)
             return ifStatement;

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -96,28 +96,41 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
         if (root is null)
             return document;
 
-        // Remove CalcFields statement first, then insert SetAutoCalcFields
-        // We do remove first because after insert, spans shift
+        // Remove CalcFields statement first, then insert SetAutoCalcFields.
+        // The insertion target is before the CalcFields in the file, so its span
+        // is not affected by the removal.
         var newRoot = root.RemoveNode(calcFieldsStatement, SyntaxRemoveOptions.KeepNoTrivia);
         if (newRoot is null)
             return document;
 
-        // After removing, we need to find the insertion target again in the modified tree
-        // Since we removed a node INSIDE the loop body, the insertion target (before the loop)
-        // should still be findable by span (it's earlier in the file, so its span didn't change)
-        var updatedTarget = newRoot.FindNode(insertionTarget.Span);
+        // After removing, find the insertion target in the modified tree.
+        // Use FullSpan.Start to locate the node since its start position is stable.
+        var updatedTarget = FindNodeByStartPosition(newRoot, insertionTarget.FullSpan.Start);
         if (updatedTarget is null)
             return document;
 
-        // Find the statement node for insertion
-        var targetStatement = updatedTarget as StatementSyntax
-            ?? updatedTarget.FirstAncestorOrSelf<StatementSyntax>();
-        if (targetStatement is null)
-            return document;
-
-        newRoot = newRoot.InsertNodesBefore(targetStatement, new[] { setAutoCalcFieldsStatement });
+        newRoot = newRoot.InsertNodesBefore(updatedTarget, new[] { setAutoCalcFieldsStatement });
 
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    /// <summary>
+    /// Finds a statement node at the given start position in the syntax tree.
+    /// More robust than FindNode(span) when the node's end position may have shifted.
+    /// </summary>
+    private static StatementSyntax? FindNodeByStartPosition(SyntaxNode root, int startPosition)
+    {
+        var token = root.FindToken(startPosition);
+        var node = token.Parent;
+
+        while (node is not null)
+        {
+            if (node is StatementSyntax statement && node.FullSpan.Start == startPosition)
+                return statement;
+            node = node.Parent;
+        }
+
+        return null;
     }
 
     private static ExpressionStatementSyntax BuildSetAutoCalcFieldsStatement(
@@ -139,9 +152,10 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
 
     /// <summary>
     /// Finds the statement before which to insert SetAutoCalcFields.
-    /// For repeat-until: finds the FindSet/Find call before the repeat.
-    /// For while loops: finds the while statement itself.
-    /// For report triggers: uses the first statement in the trigger body.
+    /// For repeat-until inside begin...end: finds the FindSet/Find call before the repeat.
+    /// For repeat-until as body of if-FindSet: the if statement itself.
+    /// For while loops: the while statement itself.
+    /// For report triggers: returns null (SetAutoCalcFields belongs in OnPreDataItem).
     /// </summary>
     private static StatementSyntax? FindInsertionTarget(InvocationExpressionSyntax calcFieldsInvocation)
     {
@@ -152,7 +166,16 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
             {
                 case RepeatStatementSyntax repeatStatement:
                     // For repeat-until, try to find the FindSet/Find statement before the repeat
-                    return FindPrecedingFindStatement(repeatStatement) ?? repeatStatement;
+                    var precedingFind = FindPrecedingFindStatement(repeatStatement);
+                    if (precedingFind is not null)
+                        return precedingFind;
+
+                    // Check if repeat is the body of "if Rec.FindSet() then repeat"
+                    var parentIfStatement = FindParentIfWithFindCondition(repeatStatement);
+                    if (parentIfStatement is not null)
+                        return parentIfStatement;
+
+                    return repeatStatement;
 
                 case WhileStatementSyntax whileStatement:
                     return whileStatement;
@@ -168,6 +191,21 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
             }
             current = current.Parent;
         }
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if the repeat statement is the direct body of an "if Rec.FindSet() then"
+    /// and returns that if statement as the insertion target.
+    /// </summary>
+    private static IfStatementSyntax? FindParentIfWithFindCondition(RepeatStatementSyntax repeatStatement)
+    {
+        // Walk up: repeat might be wrapped in a block (begin...end) or be direct child of if
+        var parent = repeatStatement.Parent;
+
+        if (parent is IfStatementSyntax ifStatement)
+            return ifStatement;
+
         return null;
     }
 

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -1,0 +1,194 @@
+using System.Collections.Immutable;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.PlatformCop.CodeFixes;
+
+[CodeFixProvider(nameof(UseSetAutoCalcFieldsForLoopsCodeFixProvider))]
+public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvider
+{
+    private class UseSetAutoCalcFieldsForLoopsCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public UseSetAutoCalcFieldsForLoopsCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+         WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        SyntaxNode node = syntaxRoot.FindNode(span);
+        if (node is not InvocationExpressionSyntax)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(node, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static UseSetAutoCalcFieldsForLoopsCodeAction CreateCodeAction(
+        SyntaxNode node, Document document, bool generateFixAll)
+    {
+        return new UseSetAutoCalcFieldsForLoopsCodeAction(
+            PlatformCopAnalyzers.UseSetAutoCalcFieldsForLoopsCodeAction,
+            ct => ApplyFix(document, node, ct),
+            nameof(UseSetAutoCalcFieldsForLoopsCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(
+        Document document, SyntaxNode node, CancellationToken cancellationToken)
+    {
+        Task<SyntaxNode> syntaxRootTask = document.GetSyntaxRootAsync(cancellationToken);
+
+        if (node is not InvocationExpressionSyntax invocation)
+            return document;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return document;
+
+        var variableName = memberAccess.Expression.ToString();
+        var arguments = invocation.ArgumentList?.Arguments ?? default;
+
+        if (arguments.Count == 0)
+            return document;
+
+        // Build SetAutoCalcFields statement
+        var setAutoCalcFieldsStatement = BuildSetAutoCalcFieldsStatement(variableName, arguments);
+
+        // Find the insertion point: before the loop or before the FindSet/Find call
+        var insertionTarget = FindInsertionTarget(invocation);
+        if (insertionTarget is null)
+            return document;
+
+        // Find the statement containing the CalcFields call (to remove it)
+        var calcFieldsStatement = FindContainingStatement(invocation);
+        if (calcFieldsStatement is null)
+            return document;
+
+        var root = await syntaxRootTask.ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        // Remove CalcFields statement first, then insert SetAutoCalcFields
+        // We do remove first because after insert, spans shift
+        var newRoot = root.RemoveNode(calcFieldsStatement, SyntaxRemoveOptions.KeepNoTrivia);
+        if (newRoot is null)
+            return document;
+
+        // After removing, we need to find the insertion target again in the modified tree
+        // Since we removed a node INSIDE the loop body, the insertion target (before the loop)
+        // should still be findable by span (it's earlier in the file, so its span didn't change)
+        var updatedTarget = newRoot.FindNode(insertionTarget.Span);
+        if (updatedTarget is null)
+            return document;
+
+        // Find the statement node for insertion
+        var targetStatement = updatedTarget as StatementSyntax
+            ?? updatedTarget.FirstAncestorOrSelf<StatementSyntax>();
+        if (targetStatement is null)
+            return document;
+
+        newRoot = newRoot.InsertNodesBefore(targetStatement, new[] { setAutoCalcFieldsStatement });
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static ExpressionStatementSyntax BuildSetAutoCalcFieldsStatement(
+        string variableName, SeparatedSyntaxList<CodeExpressionSyntax> calcFieldsArguments)
+    {
+        var variableIdentifier = SyntaxFactory.IdentifierName(variableName);
+
+        var setAutoCalcFieldsAccess = SyntaxFactory.MemberAccessExpression(
+            variableIdentifier,
+            SyntaxFactory.Token(EnumProvider.SyntaxKind.DotToken),
+            SyntaxFactory.IdentifierName("SetAutoCalcFields"));
+
+        var argumentList = SyntaxFactory.ArgumentList(calcFieldsArguments);
+        var invocationExpr = SyntaxFactory.InvocationExpression(setAutoCalcFieldsAccess, argumentList);
+
+        return SyntaxFactory.ExpressionStatement(invocationExpr,
+            SyntaxFactory.Token(EnumProvider.SyntaxKind.SemicolonToken));
+    }
+
+    /// <summary>
+    /// Finds the statement before which to insert SetAutoCalcFields.
+    /// For repeat-until: finds the FindSet/Find call before the repeat.
+    /// For while loops: finds the while statement itself.
+    /// For report triggers: uses the first statement in the trigger body.
+    /// </summary>
+    private static StatementSyntax? FindInsertionTarget(InvocationExpressionSyntax calcFieldsInvocation)
+    {
+        var current = calcFieldsInvocation.Parent;
+        while (current is not null)
+        {
+            switch (current)
+            {
+                case RepeatStatementSyntax repeatStatement:
+                    // For repeat-until, try to find the FindSet/Find statement before the repeat
+                    return FindPrecedingFindStatement(repeatStatement) ?? repeatStatement;
+
+                case WhileStatementSyntax whileStatement:
+                    return whileStatement;
+
+                case ForEachStatementSyntax forEachStatement:
+                    return forEachStatement;
+
+                case MethodOrTriggerDeclarationSyntax:
+                    // We've reached the method body without finding a loop
+                    // This is the report OnAfterGetRecord case - insert before the CalcFields itself
+                    return FindContainingStatement(calcFieldsInvocation);
+            }
+            current = current.Parent;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Looks for the FindSet/Find statement immediately before a repeat statement.
+    /// </summary>
+    private static StatementSyntax? FindPrecedingFindStatement(RepeatStatementSyntax repeatStatement)
+    {
+        if (repeatStatement.Parent is not BlockSyntax block)
+            return null;
+
+        var statements = block.Statements;
+        for (int i = 0; i < statements.Count; i++)
+        {
+            if (statements[i] == repeatStatement && i > 0)
+                return statements[i - 1];
+        }
+        return null;
+    }
+
+    private static ExpressionStatementSyntax? FindContainingStatement(SyntaxNode node)
+    {
+        return node.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+    }
+}

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -161,9 +161,10 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
                     return forEachStatement;
 
                 case MethodOrTriggerDeclarationSyntax:
-                    // We've reached the method body without finding a loop
-                    // This is the report OnAfterGetRecord case - insert before the CalcFields itself
-                    return FindContainingStatement(calcFieldsInvocation);
+                    // We've reached the method body without finding a loop.
+                    // This is the report OnAfterGetRecord case where SetAutoCalcFields
+                    // belongs in OnPreDataItem, not here. No CodeFix for this scenario.
+                    return null;
             }
             current = current.Parent;
         }

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -335,6 +335,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.PlaceholderArgumentCountMismatchDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.PlaceholderArgumentCountMismatch));
 
+    public static readonly DiagnosticDescriptor UseSetAutoCalcFieldsForLoops = new(
+        id: DiagnosticIds.UseSetAutoCalcFieldsForLoops,
+        title: PlatformCopAnalyzers.UseSetAutoCalcFieldsForLoopsTitle,
+        messageFormat: PlatformCopAnalyzers.UseSetAutoCalcFieldsForLoopsMessageFormat,
+        category: Category.Performance,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.UseSetAutoCalcFieldsForLoopsDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.UseSetAutoCalcFieldsForLoops));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -35,4 +35,5 @@ public static class DiagnosticIds
     public static readonly string ReportLayoutPropertyLength = "PC0032";
     public static readonly string DuplicateODataEntityName = "PC0033";
     public static readonly string PlaceholderArgumentCountMismatch = "PC0034";
+    public static readonly string UseSetAutoCalcFieldsForLoops = "PC0035";
 }


### PR DESCRIPTION
## Summary

Adds a new analyzer rule **PC0035** that detects `CalcFields` calls inside loop bodies and recommends using `SetAutoCalcFields` before the loop instead.

## Problem

When `CalcFields` is called inside a loop, each iteration generates a separate SQL query per FlowField. This is a well-documented performance anti-pattern that can lead to N+1 query problems.

## Solution

Call `SetAutoCalcFields` before the loop starts. This makes the runtime include FlowField calculations in the main SELECT query.

## What's included

- **Analyzer**: Detects CalcFields in repeat-until, while-do, and report OnAfterGetRecord loops
- **CodeFix**: Moves CalcFields arguments to SetAutoCalcFields before the loop and removes the CalcFields call
- **Tests**: 18 test cases (7 HasDiagnostic, 7 NoDiagnostic, 4 HasFix)
- **Instruction file**: For future maintenance context

## Loop types detected

| Pattern | Loop variable identified by |
|---|---|
| FindSet/Find + repeat-until | Variable in `Next()` call |
| while-do | Variable in condition |
| Report OnAfterGetRecord | DataItem source variable |

## Conditional path handling

The analyzer only flags CalcFields on **unconditional code paths** within loops. CalcFields inside `if` or `case` branches is not flagged, since the condition may not always be true. This avoids false positives.

Nested loops inside conditional branches ARE still detected. For example:

```al
repeat
    if InnerTable.FindSet() then
        repeat
            InnerTable.CalcFields(MyField); // flagged (unconditional in inner loop)
        until InnerTable.Next() = 0;
until OuterTable.Next() = 0;
```

Uses a `_conditionalDepth` counter (same pattern as `_branchDepth` in PartialRecordOperations) that saves/restores on loop entry/exit.

## CodeFix improvements

The CodeFix handles multiple patterns for insertion target placement:

| Pattern | SetAutoCalcFields placed |
|---|---|
| `FindSet(); repeat...` | Before the FindSet statement |
| `if FindSet() then repeat...` | Before the if statement |
| `if FindSet() then begin repeat...end` | Before the if statement |
| `while FindSet() do...` | Before the while statement |
| Report OnAfterGetRecord | No CodeFix offered (belongs in OnPreDataItem) |

## Out of scope (v1)

- Cross-method CalcFields tracking (variable passed to another procedure)
- ForEach loops (AL foreach only works with List/Array, not Record)
- RecordRef (doesn't have CalcFields in current SDK)
- CalcFields in all branches of if-else (accepted false negative for zero false positives)

## Related

- Discussion: https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/74
- Documentation: alcops.dev (separate PR in ALCops/alcops.dev)