### PR TITLE
fix(PC0033): don't report diagnostics on PK field locations

### DIFF
--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -22,8 +22,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         EnumProvider.PageTypeKind.Worksheet
     ];
 
-    private static ImmutableArray<IPageExtensionBaseTypeSymbol> GetCachedPageExtensions(Compilation compilation)
-        => PageExtensionsCache.GetValue(compilation, static c => new PageExtensionsCacheEntry(c)).Value.Value;
     private static readonly ConditionalWeakTable<Compilation, PageExtensionsCacheEntry> PageExtensionsCache = new();
     private sealed class PageExtensionsCacheEntry(Compilation compilation)
     {
@@ -64,21 +62,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         }
     }
 
-    private static void AnalyzePage(SymbolAnalysisContext ctx, IPageBaseTypeSymbol page)
-    {
-        if (!RelevantPageTypes.Contains(page.PageType))
-            return;
-
-        var controlEntries = CollectFieldControlEntries(page.FlattenedControls);
-        var pkEntries = CollectPrimaryKeyEntries(page.RelatedTable);
-
-        var allEntries = new List<ODataNameEntry>(controlEntries.Count + pkEntries.Count);
-        allEntries.AddRange(controlEntries);
-        allEntries.AddRange(pkEntries);
-
-        ReportDuplicates(ctx, allEntries, reportableFilter: null);
-    }
-
     private static void AnalyzePageExtension(SymbolAnalysisContext ctx, IPageExtensionBaseTypeSymbol pageExtension)
     {
         var targetPage = pageExtension.Target?.OriginalDefinition as IPageBaseTypeSymbol;
@@ -92,7 +75,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         var baseControls = CollectFieldControlEntries(targetPage.FlattenedControls);
         var pkEntries = CollectPrimaryKeyEntries(targetPage.RelatedTable);
 
-        // Collect controls from sibling page extensions targeting the same base page
         var siblingControls = CollectSiblingExtensionControls(ctx, pageExtension, targetPage);
 
         var allEntries = new List<ODataNameEntry>(
@@ -108,6 +90,9 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
 
         ReportDuplicates(ctx, allEntries, reportableFilter: entry => entry.Control is not null && extensionControlSet.Contains(entry.Control));
     }
+
+    private static ImmutableArray<IPageExtensionBaseTypeSymbol> GetCachedPageExtensions(Compilation compilation)
+        => PageExtensionsCache.GetValue(compilation, static c => new PageExtensionsCacheEntry(c)).Value.Value;
 
     private static List<ODataNameEntry> CollectSiblingExtensionControls(
         SymbolAnalysisContext ctx,
@@ -134,7 +119,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
                 if (odataName is null)
                     continue;
 
-                // Use null Control so sibling controls are not reportable
                 entries.Add(new ODataNameEntry(odataName, control.Name, control.GetLocation(), null));
             }
         }
@@ -157,6 +141,24 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             return lId.Id == rId.Id && source.Kind == target.Kind;
 
         return source.Equals(target);
+    }
+
+    private static void AnalyzePage(SymbolAnalysisContext ctx, IPageBaseTypeSymbol page)
+    {
+        if (!RelevantPageTypes.Contains(page.PageType))
+            return;
+
+        var controlEntries = CollectFieldControlEntries(page.FlattenedControls);
+        var pkEntries = CollectPrimaryKeyEntries(page.RelatedTable);
+
+        var allEntries = new List<ODataNameEntry>(controlEntries.Count + pkEntries.Count);
+        allEntries.AddRange(controlEntries);
+        allEntries.AddRange(pkEntries);
+
+        // Only report on controls (not PK fields) - PK fields from external dependencies
+        // have locations that crash the AL Language Extension host when reported.
+        // PK entries still participate in duplicate detection.
+        ReportDuplicates(ctx, allEntries, reportableFilter: entry => entry.Control is not null);
     }
 
     private static List<ODataNameEntry> CollectFieldControlEntries(ImmutableArray<IControlSymbol> controls)
@@ -217,7 +219,6 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             }
         }
     }
-
 
 #if NETSTANDARD2_1
     private readonly struct ODataNameEntry


### PR DESCRIPTION
## Problem

The `DuplicateODataEntityName` analyzer (PC0033) crashed the AL Language Extension host when `ctx.ReportDiagnostic` was called with a `Location` from a primary key field belonging to an external dependency (e.g., base application tables). This caused the **entire PlatformCop analyzer assembly** to be disabled in VS Code's Problems tab, while batch compilation worked fine.

## Root cause

When a page control's OData name collided with a PK field's OData name, `ReportDuplicates` reported diagnostics on **both** the control and the PK field (since `reportableFilter` was `null` for pages). The PK field's location points to an external dependency file that the AL Language Extension host cannot handle, causing it to crash and disable the entire assembly.

## Fix

Use `reportableFilter: entry => entry.Control is not null` for the page analysis path. PK entries still participate in duplicate detection but are never directly reported. This matches the existing pattern in the page extension path which already filtered to extension-owned controls only.

Cherry-picked from `release/v0.8.0` (e6d7762) to unblock development on main.