### PR TITLE
fix(PC0033): exclude PK fields already referenced by page controls

### DIFF
--- a/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
+++ b/.github/instructions/pc0033-duplicate-odata-entity-name.instructions.md
@@ -152,7 +152,7 @@ If the SDK's `MangleIntoValidXmlIdentifier` method is not found (older BC SDK ve
 ## Test coverage
 
 **HasDiagnostic (8 cases):** DotRemoval, PercentSign, ParenthesisRemoval, SlashToUnderscore, PageExtensionCollision, PrimaryKeyCollision, ThreeWayCollision, MultiplePageExtensionCollision.
-**NoDiagnostic (5 cases):** UniqueNames, ApiPage, RoleCenterPage, ObsoletePage, PageExtensionUniqueNames.
+**NoDiagnostic (6 cases):** UniqueNames, ApiPage, RoleCenterPage, ObsoletePage, PageExtensionUniqueNames, PrimaryKeyFieldOnPage.
 
 ## Phase 2 roadmap (not yet implemented)
 

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/DuplicateODataEntityName.cs
@@ -47,6 +47,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("RoleCenterPage")]
         [TestCase("ObsoletePage")]
         [TestCase("PageExtensionUniqueNames")]
+        [TestCase("PrimaryKeyFieldOnPage")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/PrimaryKeyFieldOnPage.al
+++ b/src/ALCops.PlatformCop.Test/Rules/DuplicateODataEntityName/NoDiagnostic/PrimaryKeyFieldOnPage.al
@@ -1,0 +1,31 @@
+// Page control directly references the PK field - no auto-add collision
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                [|field("Primary Key"; Rec."Primary Key") { }|]
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -73,9 +73,14 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             return;
 
         var baseControls = CollectFieldControlEntries(targetPage.FlattenedControls);
-        var pkEntries = CollectPrimaryKeyEntries(targetPage.RelatedTable);
-
         var siblingControls = CollectSiblingExtensionControls(ctx, pageExtension, targetPage);
+
+        // Build set of PK fields already referenced by any control on the page
+        var referencedFields = CollectReferencedFields(targetPage.FlattenedControls);
+        CollectReferencedFieldsInto(referencedFields, pageExtension.AddedControlsFlattened);
+        AddSiblingReferencedFields(referencedFields, ctx, pageExtension, targetPage);
+
+        var pkEntries = CollectPrimaryKeyEntries(targetPage.RelatedTable, referencedFields);
 
         var allEntries = new List<ODataNameEntry>(
             extensionControls.Count + baseControls.Count + pkEntries.Count + siblingControls.Count);
@@ -149,7 +154,8 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             return;
 
         var controlEntries = CollectFieldControlEntries(page.FlattenedControls);
-        var pkEntries = CollectPrimaryKeyEntries(page.RelatedTable);
+        var referencedFields = CollectReferencedFields(page.FlattenedControls);
+        var pkEntries = CollectPrimaryKeyEntries(page.RelatedTable, referencedFields);
 
         var allEntries = new List<ODataNameEntry>(controlEntries.Count + pkEntries.Count);
         allEntries.AddRange(controlEntries);
@@ -178,7 +184,7 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         return entries;
     }
 
-    private static List<ODataNameEntry> CollectPrimaryKeyEntries(ITableTypeSymbol? table)
+    private static List<ODataNameEntry> CollectPrimaryKeyEntries(ITableTypeSymbol? table, HashSet<IFieldSymbol> referencedFields)
     {
         var entries = new List<ODataNameEntry>();
         if (table?.PrimaryKey is null)
@@ -186,6 +192,9 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
 
         foreach (var field in table.PrimaryKey.Fields)
         {
+            if (field.OriginalDefinition is IFieldSymbol fieldDef && referencedFields.Contains(fieldDef))
+                continue;
+
             var odataName = ODataNameHelper.MangleIntoValidXmlIdentifier(field.Name);
             if (odataName is null)
                 continue;
@@ -193,6 +202,47 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
             entries.Add(new ODataNameEntry(odataName, field.Name, field.GetLocation(), null));
         }
         return entries;
+    }
+
+    private static HashSet<IFieldSymbol> CollectReferencedFields(ImmutableArray<IControlSymbol> controls)
+    {
+        var set = new HashSet<IFieldSymbol>();
+        CollectReferencedFieldsInto(set, controls);
+        return set;
+    }
+
+    private static void CollectReferencedFieldsInto(HashSet<IFieldSymbol> set, ImmutableArray<IControlSymbol> controls)
+    {
+        foreach (var control in controls)
+        {
+            if (control.ControlKind != EnumProvider.ControlKind.Field)
+                continue;
+
+            if (control.RelatedFieldSymbol is not IFieldSymbol field)
+                continue;
+
+            set.Add((IFieldSymbol)field.OriginalDefinition);
+        }
+    }
+
+    private static void AddSiblingReferencedFields(
+        HashSet<IFieldSymbol> set,
+        SymbolAnalysisContext ctx,
+        IPageExtensionBaseTypeSymbol currentExtension,
+        IPageBaseTypeSymbol targetPage)
+    {
+        var allPageExtensions = GetCachedPageExtensions(ctx.Compilation);
+
+        foreach (var ext in allPageExtensions)
+        {
+            if (ReferenceEquals(ext, currentExtension))
+                continue;
+
+            if (!SameApplicationObject(ext.Target?.OriginalDefinition, targetPage))
+                continue;
+
+            CollectReferencedFieldsInto(set, ext.AddedControlsFlattened);
+        }
     }
 
     private static void ReportDuplicates(


### PR DESCRIPTION
## Problem

PC0033 reports a false positive when a page control directly references a primary key field. The rule unconditionally adds all PK fields to the OData name pool (since they're auto-added by the EDMX system), but if a page control already references that PK field via `RelatedFieldSymbol`, the EDMX system won't auto-add it separately.

**False positive example:**
```al
field("Primary Key"; Rec."Primary Key")  // References the PK field directly
```

**True positive (still detected):**
```al
field("Primary Key"; Rec.MyField)  // References a DIFFERENT field, PK still auto-added
```

## Fix

- Build a `HashSet<IFieldSymbol>` of table fields already referenced by page controls via `RelatedFieldSymbol`
- Skip PK fields in `CollectPrimaryKeyEntries` that are already in the set
- Applies to Page, PageExtension, and sibling extension scenarios

## Tests

- Added `NoDiagnostic/PrimaryKeyFieldOnPage.al`: page control directly references PK field (no collision)
- Existing `HasDiagnostic/PrimaryKeyCollision.al` still passes (control references a different field)