### PR TITLE
fix(AC0032): improve EntireEntry message format

### DIFF
--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -18,7 +18,7 @@ Detects `Permissions` property entries that have no corresponding table data acc
 | Help URI | https://alcops.dev/docs/analyzers/applicationcop/ac0032/ |
 
 Two `DiagnosticDescriptor` instances share the same ID but have different message formats:
-- `TableDataAccessUnusedPermissionsEntireEntry`: table not accessed at all
+- `TableDataAccessUnusedPermissionsEntireEntry`: no database operations found on the table
 - `TableDataAccessUnusedPermissionsPartialChars`: table accessed but not all declared RIMD chars are needed
 
 ## Architecture

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -430,13 +430,13 @@
     <value>Unused permission declared</value>
   </data>
   <data name="TableDataAccessUnusedPermissionsEntireEntryMessageFormat" xml:space="preserve">
-    <value>Permission 'tabledata {0}' is declared but no code in this object accesses table '{0}'.</value>
+    <value>Permission 'tabledata {0}' is declared but this object performs no database operations on table '{0}'.</value>
   </data>
   <data name="TableDataAccessUnusedPermissionsPartialCharsMessageFormat" xml:space="preserve">
     <value>Permission '{0}' on 'tabledata {1}' is not needed. Only '{2}' is required.</value>
   </data>
   <data name="TableDataAccessUnusedPermissionsDescription" xml:space="preserve">
-    <value>The Permissions property declares table data access that is not used by any code in this object. Unused permissions are dead code and should be removed or reduced to match actual usage. The Permissions property only applies to direct table access within the object itself; it does not flow through to called objects.</value>
+    <value>The Permissions property declares table data access for which no corresponding database operations (read, insert, modify, delete) were found in this object. Unused permissions are dead code and should be removed or reduced to match actual usage. The Permissions property only applies to direct database operations within the object itself; it does not flow through to called objects.</value>
   </data>
   <data name="TableDataAccessUnusedPermissionsCodeAction" xml:space="preserve">
     <value>ALCops: Remove unused permission for table '{0}'</value>


### PR DESCRIPTION
## Problem

The `TableDataAccessUnusedPermissionsEntireEntryMessageFormat` said:

> Permission 'tabledata {0}' is declared but no code in this object accesses table '{0}'.

This is misleading because the analyzer checks for **database operations** (read/insert/modify/delete), not any code reference to the table. Code might use the table (e.g., declare a variable of that record type) without performing RIMD operations.

## Fix

Updated to:

> Permission 'tabledata {0}' is declared but this object performs no database operations on table '{0}'.

Also updated the Description to explicitly mention RIMD operations.

## Changes

- `ALCops.ApplicationCopAnalyzers.resx`: Updated message format and description
- `ac0032-table-data-access-unused-permissions.instructions.md`: Updated instruction file