### PR TITLE
fix(AC0032): False positives on system table permissions

### DIFF
--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -83,6 +83,7 @@ Phase 2 (`RegisterCompilationEndAction`) runs once after all Phase 1 callbacks c
 | Two descriptors sharing one ID | Same conceptual rule, different message clarity |
 | `PermissionMatchesTable` duplicated from `PermissionResolver` | Avoids coupling; operates on syntax nodes, not resolved symbols |
 | Page SourceTable exemption | Pages implicitly need RIMD on their source table |
+| System tables included in collection | AC0032 passes `includeSystemTables: true` to `RequiredPermissionDetector` so that declared permissions on system tables (ID > 2B) are matched against actual accesses, preventing false positives. AC0031 uses the default `false` to avoid suggesting permissions on virtual tables. |
 | Temporary records NOT exempted | Declaring permissions on temp-only tables is dead code |
 | Skip permissionset/permissionsetextension objects | These objects declare permissions as their core purpose, not as code-access declarations; flagging them is always a false positive |
 | `DeclaredPermissionSet` reused for RIMD tracking | Existing type from AC0031's permission module |
@@ -122,7 +123,7 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 ## Test coverage
 
 **HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
-**NoDiagnostic (8 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension.
+**NoDiagnostic (9 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable.
 **HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
 
 ## Known limitations

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/SystemTable.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/SystemTable.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MySystemTable = r|];
+
+    trigger OnRun()
+    var
+        MySystemTable: Record MySystemTable;
+    begin
+        MySystemTable.Get();
+    end;
+}
+
+table 2000000168 MySystemTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -46,6 +46,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("QueryDataItemRead")]
         [TestCase("PermissionSet")]
         [TestCase("PermissionSetExtension")]
+        [TestCase("SystemTable")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -135,7 +135,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         {
             _cancellationToken.ThrowIfCancellationRequested();
 
-            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, _containingSymbol);
+            var required = RequiredPermissionDetector.TryGetFromInvocation(operation, _containingSymbol, includeSystemTables: true);
             if (required is not null)
                 AddRequiredPermission(_accumulator, _containingObject, required.Value);
 
@@ -147,7 +147,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         SymbolAnalysisContext ctx,
         ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
     {
-        var required = RequiredPermissionDetector.TryGetFromReportDataItem(ctx.Symbol);
+        var required = RequiredPermissionDetector.TryGetFromReportDataItem(ctx.Symbol, includeSystemTables: true);
         if (required is null)
             return;
 
@@ -162,7 +162,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         SymbolAnalysisContext ctx,
         ConcurrentDictionary<string, ConcurrentBag<RequiredPermission>> accumulator)
     {
-        var required = RequiredPermissionDetector.TryGetFromQueryDataItem(ctx.Symbol);
+        var required = RequiredPermissionDetector.TryGetFromQueryDataItem(ctx.Symbol, includeSystemTables: true);
         if (required is null)
             return;
 
@@ -181,7 +181,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (containingObject is null)
             return;
 
-        foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(ctx.Symbol))
+        foreach (var required in RequiredPermissionDetector.GetFromXmlPortNode(ctx.Symbol, includeSystemTables: true))
             AddRequiredPermission(accumulator, containingObject, required);
     }
 

--- a/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
+++ b/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
@@ -15,9 +15,15 @@ public static class RequiredPermissionDetector
     /// Determines if an invocation expression requires a database permission.
     /// Returns null if the invocation doesn't require a permission (not a DB method, temporary record, system table, etc.).
     /// </summary>
+    /// <param name="includeSystemTables">
+    /// When true, system tables (ID &gt; 2,000,000,000) are included in the results.
+    /// AC0031 uses false (default) to avoid suggesting permissions on virtual tables, like for example the Integer table
+    /// AC0032 uses true so that declared permissions on system tables are not flagged as unused.
+    /// </param>
     public static RequiredPermission? TryGetFromInvocation(
         IInvocationExpression invocation,
-        ISymbol containingSymbol)
+        ISymbol containingSymbol,
+        bool includeSystemTables = false)
     {
         if (invocation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
             return null;
@@ -37,7 +43,7 @@ public static class RequiredPermissionDetector
             return null;
 
         var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
-        if (tableType is null || IsSystemTable(tableType))
+        if (tableType is null || (!includeSystemTables && IsSystemTable(tableType)))
             return null;
 
         return new RequiredPermission(tableType, recordType, operation, invocation.Syntax.GetLocation());
@@ -47,7 +53,7 @@ public static class RequiredPermissionDetector
     /// Determines if a report data item requires a database permission.
     /// Returns null if it doesn't (temporary record, system table, wrong symbol type, etc.).
     /// </summary>
-    public static RequiredPermission? TryGetFromReportDataItem(ISymbol symbol)
+    public static RequiredPermission? TryGetFromReportDataItem(ISymbol symbol, bool includeSystemTables = false)
     {
         if (symbol.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is true)
             return null;
@@ -61,7 +67,7 @@ public static class RequiredPermissionDetector
         if (recordType.Temporary)
             return null;
 
-        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+        if (recordType.OriginalDefinition is not ITableTypeSymbol tableType || (!includeSystemTables && IsSystemTable(tableType)))
             return null;
 
         return new RequiredPermission(tableType, recordType, DatabaseOperation.Read, symbol.GetLocation());
@@ -71,10 +77,10 @@ public static class RequiredPermissionDetector
     /// Determines if a query data item requires a database permission.
     /// Returns null if the underlying table is a system table.
     /// </summary>
-    public static RequiredPermission? TryGetFromQueryDataItem(ISymbol symbol)
+    public static RequiredPermission? TryGetFromQueryDataItem(ISymbol symbol, bool includeSystemTables = false)
     {
         var targetSymbol = ((IQueryDataItemSymbol)symbol).GetTypeSymbol();
-        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || (!includeSystemTables && IsSystemTable(tableType)))
             return null;
 
         return new RequiredPermission(tableType, targetSymbol, DatabaseOperation.Read, symbol.GetLocation());
@@ -84,14 +90,14 @@ public static class RequiredPermissionDetector
     /// Gets required permissions for an xmlport table node.
     /// May yield multiple permissions depending on direction and auto-save/replace/update properties.
     /// </summary>
-    public static IEnumerable<RequiredPermission> GetFromXmlPortNode(ISymbol symbol)
+    public static IEnumerable<RequiredPermission> GetFromXmlPortNode(ISymbol symbol, bool includeSystemTables = false)
     {
         var nodeSymbol = (IXmlPortNodeSymbol)symbol.OriginalDefinition;
         if (nodeSymbol.SourceTypeKind != EnumProvider.XmlPortSourceTypeKind.Table)
             yield break;
 
         var targetSymbol = nodeSymbol.GetTypeSymbol();
-        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || IsSystemTable(tableType))
+        if (targetSymbol.OriginalDefinition is not ITableTypeSymbol tableType || (!includeSystemTables && IsSystemTable(tableType)))
             yield break;
 
         var xmlPort = (IXmlPortTypeSymbol)symbol.GetContainingObjectTypeSymbol();


### PR DESCRIPTION
## Problem

AC0032 reported false positives for declared permissions on **system tables** (table ID > 2,000,000,000), such as `Tenant Web Service` (ID 2000000168). The diagnostic incorrectly flagged these as unused even when the code clearly accessed the table.

**Root cause**: `RequiredPermissionDetector.IsSystemTable()` filters out system tables during Phase 1 collection (shared with AC0031). AC0032's Phase 2 analysis had no record of these accesses, so it reported the permissions as unused.

This is a **deterministic** bug, not a race condition as initially suspected. Confirmed via debug instrumentation on the Base App (codeunit 6710 "ODataUtility").

## Fix

Add an `includeSystemTables` parameter (default `false`) to all `RequiredPermissionDetector` detection methods:
- **AC0031** uses the default (`false`), preserving existing behavior (no suggestions for virtual table permissions)
- **AC0032** passes `true`, so system table accesses appear in the accumulator and match declared permissions

## Changes

| File | Change |
|---|---|
| `RequiredPermissionDetector.cs` | Add `includeSystemTables` parameter to `TryGetFromInvocation`, `TryGetFromReportDataItem`, `TryGetFromQueryDataItem`, `GetFromXmlPortNode` |
| `TableDataAccessUnusedPermissions.cs` | Pass `includeSystemTables: true` in all 4 collection callbacks |
| `SystemTable.al` | New NoDiagnostic test fixture (table ID 2000000168) |
| `TableDataAccessUnusedPermissions.cs` (test) | Add `SystemTable` test case |
| `ac0032-*.instructions.md` | Updated design decisions and test coverage |

## Testing

All 20 AC0032 tests pass (was 19, +1 new SystemTable case). All 38 AC0031 tests pass (unchanged behavior).

Closes #243