### PR TITLE
fix(PC0030): false positive on FindSet with Modify in loop

### DIFF
--- a/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
@@ -49,6 +49,8 @@ These decisions were made during the initial design and should be preserved unle
 | Retroactive read clearing | Clear UncoveredReads when write/pass encountered | Handles `Get(); Modify()` pattern where write comes after read |
 | Loop analysis | Single pass, no fixed-point iteration | Acceptable approximation; fixed-point adds complexity for rare edge cases |
 | RecordRef flow analysis | Kept method-level (EverHad* flags) | RecordRef SetTable linkage is already complex; bug fixes focus on Record variables |
+| Pre-fork read merge rule | Intersection (must be in ALL branches) | Reads before a fork that are retroactively cleared by write/pass in any branch should stay cleared; prevents false positives on `if FindSet then repeat Modify` pattern |
+| In-branch read merge rule | Union (in ANY branch) | Reads added inside a branch are genuinely uncovered on their specific path and should be reported |
 
 ## Architecture
 
@@ -89,7 +91,7 @@ Uses `RegisterCodeBlockAction` (not `RegisterOperationAction`) to analyze entire
 | `HasLoadFields` | AND (all branches must have it) | If any path lacks SetLoadFields, the read might execute without it |
 | `HasWriteOp` | OR (any branch having it) | If any path writes, suggesting SetLoadFields could interfere |
 | `PassedToFunction` | OR (any branch having it) | If any path passes the variable, callee might access any field |
-| `UncoveredReads` | Union (concat all branches) | A read uncovered in ANY branch should be reported |
+| `UncoveredReads` | Pre-fork: intersection; in-branch: union | Pre-fork reads retroactively cleared in any branch stay cleared; in-branch reads on specific paths should be reported |
 
 ### Reset operations
 
@@ -178,11 +180,11 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 
 ## Test coverage
 
-55 test cases total:
+58 test cases total:
 
 **HasDiagnostic (17 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, LoopNoSetLoadFields.
 
-**NoDiagnostic (26 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore.
+**NoDiagnostic (29 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore, FindSetWithModifyInLoop, FindSetWithPassedToFunctionInLoop, GetWithConditionalModify.
 
 **HasFix (11 cases):** SingleField, MultipleFields, QuotedFieldName, NoFieldAccess, SetRangeFieldExcluded, SetFilterFieldExcluded, SetRangeValueArgIncluded, AllFieldsInFilters, TestFieldIncluded, SetCurrentKeyExcluded, MixedFilterAndConsume.
 

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/FindSetWithModifyInLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/FindSetWithModifyInLoop.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure UpdateVendorLedgerEntries()
+    var
+        MyTable: Record MyTable;
+    begin
+        if [|MyTable.FindSet()|] then
+            repeat
+                MyTable.Modify(true);
+            until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/FindSetWithPassedToFunctionInLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/FindSetWithPassedToFunctionInLoop.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure ProcessRecords()
+    var
+        MyTable: Record MyTable;
+    begin
+        if [|MyTable.FindSet()|] then
+            repeat
+                ProcessRecord(MyTable);
+            until MyTable.Next() = 0;
+    end;
+
+    local procedure ProcessRecord(var Rec: Record MyTable)
+    begin
+        Rec.MyField := Rec.MyField + 1;
+        Rec.Modify();
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/GetWithConditionalModify.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/GetWithConditionalModify.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure UpdateRecord()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get()|];
+        if MyTable.MyField > 0 then
+            MyTable.Modify(true);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -73,6 +73,9 @@ namespace ALCops.PlatformCop.Test
         [TestCase("DatabaseObjectReference")]
         [TestCase("IfBothBranchesSetLoadFields")]
         [TestCase("LoopSetLoadFieldsBefore")]
+        [TestCase("FindSetWithModifyInLoop")]
+        [TestCase("FindSetWithPassedToFunctionInLoop")]
+        [TestCase("GetWithConditionalModify")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -334,6 +334,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         {
             Visit(operation.Condition);
 
+            var preForkReads = CapturePreForkReadPositions();
             var preBranchState = SaveFlowState();
 
             Visit(operation.IfTrueStatement);
@@ -343,13 +344,14 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             Visit(operation.IfFalseStatement);
             var falseBranchState = SaveFlowState();
 
-            MergeFlowStates(trueBranchState, falseBranchState);
+            MergeFlowStates(trueBranchState, falseBranchState, preForkReads);
         }
 
         public override void VisitCaseStatement(ICaseStatement operation)
         {
             Visit(operation.Value);
 
+            var preForkReads = CapturePreForkReadPositions();
             var preCaseState = SaveFlowState();
             var branchStates = new List<Dictionary<string, FlowFlags>>();
 
@@ -372,7 +374,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 branchStates.Add(CloneState(preCaseState));
             }
 
-            MergeFlowStates(branchStates);
+            MergeFlowStates(branchStates, preForkReads);
         }
 
         public override void VisitWhileRepeatLoopStatement(IWhileRepeatLoopStatement operation)
@@ -388,11 +390,12 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 // while-do: body might not execute
                 Visit(operation.Condition);
 
+                var preForkReads = CapturePreForkReadPositions();
                 var preLoopState = SaveFlowState();
                 Visit(operation.Body);
                 var postBodyState = SaveFlowState();
 
-                MergeFlowStates(preLoopState, postBodyState);
+                MergeFlowStates(preLoopState, postBodyState, preForkReads);
             }
         }
 
@@ -401,22 +404,24 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             Visit(operation.InitialValue);
             Visit(operation.EndValue);
 
+            var preForkReads = CapturePreForkReadPositions();
             var preLoopState = SaveFlowState();
             Visit(operation.Body);
             var postBodyState = SaveFlowState();
 
-            MergeFlowStates(preLoopState, postBodyState);
+            MergeFlowStates(preLoopState, postBodyState, preForkReads);
         }
 
         public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
         {
             Visit(operation.Expression);
 
+            var preForkReads = CapturePreForkReadPositions();
             var preLoopState = SaveFlowState();
             Visit(operation.Body);
             var postBodyState = SaveFlowState();
 
-            MergeFlowStates(preLoopState, postBodyState);
+            MergeFlowStates(preLoopState, postBodyState, preForkReads);
         }
 
         #endregion
@@ -454,7 +459,23 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             return clone;
         }
 
-        private void MergeFlowStates(Dictionary<string, FlowFlags> stateA, Dictionary<string, FlowFlags> stateB)
+        /// <summary>
+        /// Captures current UncoveredReads positions per variable before a fork.
+        /// Used during merge to apply intersection semantics for pre-fork reads.
+        /// </summary>
+        private Dictionary<string, HashSet<int>> CapturePreForkReadPositions()
+        {
+            var result = new Dictionary<string, HashSet<int>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in _flowState)
+            {
+                if (kvp.Value.UncoveredReads.Count > 0)
+                    result[kvp.Key] = new HashSet<int>(kvp.Value.UncoveredReads.Select(r => r.Location.SourceSpan.Start));
+            }
+            return result;
+        }
+
+        private void MergeFlowStates(Dictionary<string, FlowFlags> stateA, Dictionary<string, FlowFlags> stateB,
+            Dictionary<string, HashSet<int>>? preForkReads = null)
         {
             foreach (var kvp in _flowState)
             {
@@ -466,13 +487,16 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 kvp.Value.PassedToFunction = a.PassedToFunction || b.PassedToFunction;
                 kvp.Value.HasPartialRead = a.HasPartialRead || b.HasPartialRead;
 
-                MergeUncoveredReads(kvp.Value, a.UncoveredReads, b.UncoveredReads);
+                HashSet<int>? preFork = null;
+                preForkReads?.TryGetValue(kvp.Key, out preFork);
+                MergeUncoveredReads(kvp.Value, a.UncoveredReads, b.UncoveredReads, preFork);
                 MergeLoadFieldsLocations(kvp.Value, a.LoadFieldsLocations, b.LoadFieldsLocations);
                 MergeWriteMethodNames(kvp.Value, a.WriteMethodNamesAfterPartialRead, b.WriteMethodNamesAfterPartialRead);
             }
         }
 
-        private void MergeFlowStates(List<Dictionary<string, FlowFlags>> branchStates)
+        private void MergeFlowStates(List<Dictionary<string, FlowFlags>> branchStates,
+            Dictionary<string, HashSet<int>>? preForkReads = null)
         {
             if (branchStates.Count == 0)
                 return;
@@ -484,12 +508,28 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 kvp.Value.PassedToFunction = branchStates.Any(bs => bs[kvp.Key].PassedToFunction);
                 kvp.Value.HasPartialRead = branchStates.Any(bs => bs[kvp.Key].HasPartialRead);
 
+                HashSet<int>? preFork = null;
+                preForkReads?.TryGetValue(kvp.Key, out preFork);
+
                 kvp.Value.UncoveredReads.Clear();
                 var seenReads = new HashSet<int>();
                 foreach (var bs in branchStates)
+                {
                     foreach (var read in bs[kvp.Key].UncoveredReads)
+                    {
                         if (seenReads.Add(read.Location.SourceSpan.Start))
                             kvp.Value.UncoveredReads.Add(read);
+                    }
+                }
+
+                // Pre-fork reads use intersection: keep only if present in ALL branches
+                if (preFork is { Count: > 0 })
+                {
+                    kvp.Value.UncoveredReads.RemoveAll(read =>
+                        preFork.Contains(read.Location.SourceSpan.Start) &&
+                        !branchStates.All(bs => bs[kvp.Key].UncoveredReads.Any(
+                            r => r.Location.SourceSpan.Start == read.Location.SourceSpan.Start)));
+                }
 
                 kvp.Value.LoadFieldsLocations.Clear();
                 var seenLF = new HashSet<int>();
@@ -505,11 +545,11 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
         /// <summary>
         /// Merges uncovered reads from two branches with deduplication by source position.
-        /// Pre-fork reads exist in both branches; without dedup, list size doubles at each
-        /// nesting level causing exponential growth and OOM on large codebases.
+        /// Pre-fork reads use intersection semantics (keep only if in both branches),
+        /// in-branch reads use union semantics (keep if in either branch).
         /// </summary>
         private static void MergeUncoveredReads(FlowFlags target,
-            List<ReadInfo> readsA, List<ReadInfo> readsB)
+            List<ReadInfo> readsA, List<ReadInfo> readsB, HashSet<int>? preForkPositions)
         {
             target.UncoveredReads.Clear();
 
@@ -521,6 +561,19 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             foreach (var read in readsB)
                 if (seen.Add(read.Location.SourceSpan.Start))
                     target.UncoveredReads.Add(read);
+
+            // Pre-fork reads use intersection: keep only if present in BOTH branches.
+            // If a branch retroactively cleared a pre-fork read (via write/pass), it stays cleared.
+            if (preForkPositions is { Count: > 0 })
+            {
+                var positionsInA = new HashSet<int>(readsA.Select(r => r.Location.SourceSpan.Start));
+                var positionsInB = new HashSet<int>(readsB.Select(r => r.Location.SourceSpan.Start));
+
+                target.UncoveredReads.RemoveAll(read =>
+                    preForkPositions.Contains(read.Location.SourceSpan.Start) &&
+                    !(positionsInA.Contains(read.Location.SourceSpan.Start) &&
+                      positionsInB.Contains(read.Location.SourceSpan.Start)));
+            }
         }
 
         private static void MergeLoadFieldsLocations(FlowFlags target,

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -344,7 +344,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             Visit(operation.IfFalseStatement);
             var falseBranchState = SaveFlowState();
 
-            MergeFlowStates(trueBranchState, falseBranchState, preForkReads);
+            MergeFlowStates([trueBranchState, falseBranchState], preForkReads);
         }
 
         public override void VisitCaseStatement(ICaseStatement operation)
@@ -395,7 +395,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 Visit(operation.Body);
                 var postBodyState = SaveFlowState();
 
-                MergeFlowStates(preLoopState, postBodyState, preForkReads);
+                MergeFlowStates([preLoopState, postBodyState], preForkReads);
             }
         }
 
@@ -409,7 +409,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             Visit(operation.Body);
             var postBodyState = SaveFlowState();
 
-            MergeFlowStates(preLoopState, postBodyState, preForkReads);
+            MergeFlowStates([preLoopState, postBodyState], preForkReads);
         }
 
         public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
@@ -421,7 +421,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             Visit(operation.Body);
             var postBodyState = SaveFlowState();
 
-            MergeFlowStates(preLoopState, postBodyState, preForkReads);
+            MergeFlowStates([preLoopState, postBodyState], preForkReads);
         }
 
         #endregion
@@ -439,16 +439,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         private void RestoreFlowState(Dictionary<string, FlowFlags> saved)
         {
             foreach (var kvp in saved)
-            {
-                if (_flowState.TryGetValue(kvp.Key, out var current))
-                {
-                    current.HasLoadFields = kvp.Value.HasLoadFields;
-                    current.HasWriteOp = kvp.Value.HasWriteOp;
-                    current.PassedToFunction = kvp.Value.PassedToFunction;
-                    current.UncoveredReads.Clear();
-                    current.UncoveredReads.AddRange(kvp.Value.UncoveredReads);
-                }
-            }
+                _flowState[kvp.Key] = kvp.Value.Clone();
         }
 
         private static Dictionary<string, FlowFlags> CloneState(Dictionary<string, FlowFlags> source)
@@ -472,27 +463,6 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                     result[kvp.Key] = new HashSet<int>(kvp.Value.UncoveredReads.Select(r => r.Location.SourceSpan.Start));
             }
             return result;
-        }
-
-        private void MergeFlowStates(Dictionary<string, FlowFlags> stateA, Dictionary<string, FlowFlags> stateB,
-            Dictionary<string, HashSet<int>>? preForkReads = null)
-        {
-            foreach (var kvp in _flowState)
-            {
-                var a = stateA[kvp.Key];
-                var b = stateB[kvp.Key];
-
-                kvp.Value.HasLoadFields = a.HasLoadFields && b.HasLoadFields;
-                kvp.Value.HasWriteOp = a.HasWriteOp || b.HasWriteOp;
-                kvp.Value.PassedToFunction = a.PassedToFunction || b.PassedToFunction;
-                kvp.Value.HasPartialRead = a.HasPartialRead || b.HasPartialRead;
-
-                HashSet<int>? preFork = null;
-                preForkReads?.TryGetValue(kvp.Key, out preFork);
-                MergeUncoveredReads(kvp.Value, a.UncoveredReads, b.UncoveredReads, preFork);
-                MergeLoadFieldsLocations(kvp.Value, a.LoadFieldsLocations, b.LoadFieldsLocations);
-                MergeWriteMethodNames(kvp.Value, a.WriteMethodNamesAfterPartialRead, b.WriteMethodNamesAfterPartialRead);
-            }
         }
 
         private void MergeFlowStates(List<Dictionary<string, FlowFlags>> branchStates,
@@ -543,69 +513,6 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             }
         }
 
-        /// <summary>
-        /// Merges uncovered reads from two branches with deduplication by source position.
-        /// Pre-fork reads use intersection semantics (keep only if in both branches),
-        /// in-branch reads use union semantics (keep if in either branch).
-        /// </summary>
-        private static void MergeUncoveredReads(FlowFlags target,
-            List<ReadInfo> readsA, List<ReadInfo> readsB, HashSet<int>? preForkPositions)
-        {
-            target.UncoveredReads.Clear();
-
-            var seen = new HashSet<int>();
-            foreach (var read in readsA)
-                if (seen.Add(read.Location.SourceSpan.Start))
-                    target.UncoveredReads.Add(read);
-
-            foreach (var read in readsB)
-                if (seen.Add(read.Location.SourceSpan.Start))
-                    target.UncoveredReads.Add(read);
-
-            // Pre-fork reads use intersection: keep only if present in BOTH branches.
-            // If a branch retroactively cleared a pre-fork read (via write/pass), it stays cleared.
-            if (preForkPositions is { Count: > 0 })
-            {
-                var positionsInA = new HashSet<int>(readsA.Select(r => r.Location.SourceSpan.Start));
-                var positionsInB = new HashSet<int>(readsB.Select(r => r.Location.SourceSpan.Start));
-
-                target.UncoveredReads.RemoveAll(read =>
-                    preForkPositions.Contains(read.Location.SourceSpan.Start) &&
-                    !(positionsInA.Contains(read.Location.SourceSpan.Start) &&
-                      positionsInB.Contains(read.Location.SourceSpan.Start)));
-            }
-        }
-
-        private static void MergeLoadFieldsLocations(FlowFlags target,
-            List<LoadFieldsInfo> locsA, List<LoadFieldsInfo> locsB)
-        {
-            target.LoadFieldsLocations.Clear();
-
-            var seen = new HashSet<int>();
-            foreach (var info in locsA)
-                if (seen.Add(info.Location.SourceSpan.Start))
-                    target.LoadFieldsLocations.Add(info);
-
-            foreach (var info in locsB)
-                if (seen.Add(info.Location.SourceSpan.Start))
-                    target.LoadFieldsLocations.Add(info);
-        }
-
-        private static void MergeWriteMethodNames(FlowFlags target,
-            HashSet<string>? setA, HashSet<string>? setB)
-        {
-            if (setA is null && setB is null)
-            {
-                target.WriteMethodNamesAfterPartialRead = null;
-                return;
-            }
-
-            var merged = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (setA is not null) merged.UnionWith(setA);
-            if (setB is not null) merged.UnionWith(setB);
-            target.WriteMethodNamesAfterPartialRead = merged.Count > 0 ? merged : null;
-        }
-
         private static void MergeWriteMethodNames(FlowFlags target, params HashSet<string>?[] sets)
         {
             HashSet<string>? merged = null;
@@ -627,71 +534,74 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         {
             var methodName = operation.TargetMethod.Name;
 
-            if (operation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod)
-            {
-                if (ReadMethods.Contains(methodName))
-                {
-                    // PC0031: a read while HasLoadFields means the record buffer is now partial
-                    if (flowFlags.HasLoadFields)
-                        flowFlags.HasPartialRead = true;
-
-                    // Check ALL flow flags: hasLoadFields (SetLoadFields before read),
-                    // hasWriteOp (write before read means SetLoadFields could break the write),
-                    // passedToFunction (callee might need all fields).
-                    // Write/pass AFTER read is handled by retroactive clearing of UncoveredReads.
-                    if (!flowFlags.HasLoadFields && !flowFlags.HasWriteOp && !flowFlags.PassedToFunction)
-                        flowFlags.UncoveredReads.Add(new ReadInfo(operation.Syntax.GetLocation(), methodName));
-                }
-                else if (LoadFieldsMethods.Contains(methodName))
-                {
-                    if (string.Equals(methodName, "SetLoadFields", StringComparison.OrdinalIgnoreCase)
-                        && operation.Arguments.IsEmpty)
-                    {
-                        // SetLoadFields() with no arguments resets partial records to "load all"
-                        flowFlags.HasLoadFields = false;
-                        flowFlags.HasPartialRead = false;
-                        flowFlags.LoadFieldsLocations.Clear();
-                        flowFlags.WriteMethodNamesAfterPartialRead = null;
-                    }
-                    else
-                    {
-                        flowFlags.HasLoadFields = true;
-                        flowFlags.LoadFieldsLocations.Add(
-                            new LoadFieldsInfo(operation.Syntax.GetLocation(), methodName));
-                        state.EverHadLoadFields = true;
-                    }
-                }
-                else if (WriteMethods.Contains(methodName))
-                {
-                    // Retroactively suppress uncovered reads: a write after a read means
-                    // adding SetLoadFields before the read could break the write operation
-                    flowFlags.UncoveredReads.Clear();
-                    flowFlags.HasWriteOp = true;
-                    state.EverHadWriteOp = true;
-
-                    // PC0031: only record writes for JIT-load detection when a partial read
-                    // has occurred on this flow path. Writes before SetLoadFields or between
-                    // SetLoadFields and the next read use the full record buffer and don't JIT.
-                    if (flowFlags.HasPartialRead && JitLoadWriteMethods.Contains(methodName))
-                        flowFlags.AddWriteAfterPartialRead(methodName);
-                }
-                else if (string.Equals(methodName, "Reset", StringComparison.OrdinalIgnoreCase))
-                {
-                    flowFlags.ResetFlags();
-                }
-                else if (state.IsRecordRef
-                    && string.Equals(methodName, "SetTable", StringComparison.OrdinalIgnoreCase)
-                    && operation.Arguments.Length == 1)
-                    state.SetTableTargets.Add(GetVariableNameFromArgument(operation.Arguments[0]));
-            }
-            else
+            if (operation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
             {
                 // Non-built-in method called on the record variable (table-defined method):
                 // retroactively suppress uncovered reads (callee might access any field)
                 flowFlags.UncoveredReads.Clear();
                 flowFlags.PassedToFunction = true;
                 state.EverPassedToFunction = true;
+                return;
             }
+
+            if (ReadMethods.Contains(methodName))
+                HandleReadMethod(operation, flowFlags, methodName);
+            else if (LoadFieldsMethods.Contains(methodName))
+                HandleLoadFieldsMethod(operation, state, flowFlags, methodName);
+            else if (WriteMethods.Contains(methodName))
+                HandleWriteMethod(state, flowFlags, methodName);
+            else if (string.Equals(methodName, "Reset", StringComparison.OrdinalIgnoreCase))
+                flowFlags.ResetFlags();
+            else if (state.IsRecordRef
+                && string.Equals(methodName, "SetTable", StringComparison.OrdinalIgnoreCase)
+                && operation.Arguments.Length == 1)
+                state.SetTableTargets.Add(GetVariableNameFromArgument(operation.Arguments[0]));
+        }
+
+        private static void HandleReadMethod(IInvocationExpression operation, FlowFlags flowFlags, string methodName)
+        {
+            // PC0031: a read while HasLoadFields means the record buffer is now partial
+            if (flowFlags.HasLoadFields)
+                flowFlags.HasPartialRead = true;
+
+            // Only flag reads where no suppression condition exists.
+            // Write/pass AFTER read is handled by retroactive clearing of UncoveredReads.
+            if (!flowFlags.HasLoadFields && !flowFlags.HasWriteOp && !flowFlags.PassedToFunction)
+                flowFlags.UncoveredReads.Add(new ReadInfo(operation.Syntax.GetLocation(), methodName));
+        }
+
+        private static void HandleLoadFieldsMethod(IInvocationExpression operation,
+            VariableState state, FlowFlags flowFlags, string methodName)
+        {
+            if (string.Equals(methodName, "SetLoadFields", StringComparison.OrdinalIgnoreCase)
+                && operation.Arguments.IsEmpty)
+            {
+                // SetLoadFields() with no arguments resets partial records to "load all"
+                flowFlags.HasLoadFields = false;
+                flowFlags.HasPartialRead = false;
+                flowFlags.LoadFieldsLocations.Clear();
+                flowFlags.WriteMethodNamesAfterPartialRead = null;
+                return;
+            }
+
+            flowFlags.HasLoadFields = true;
+            flowFlags.LoadFieldsLocations.Add(
+                new LoadFieldsInfo(operation.Syntax.GetLocation(), methodName));
+            state.EverHadLoadFields = true;
+        }
+
+        private static void HandleWriteMethod(VariableState state, FlowFlags flowFlags, string methodName)
+        {
+            // Retroactively suppress uncovered reads: a write after a read means
+            // adding SetLoadFields before the read could break the write operation
+            flowFlags.UncoveredReads.Clear();
+            flowFlags.HasWriteOp = true;
+            state.EverHadWriteOp = true;
+
+            // PC0031: only record writes for JIT-load detection when a partial read
+            // has occurred on this flow path.
+            if (flowFlags.HasPartialRead && JitLoadWriteMethods.Contains(methodName))
+                flowFlags.AddWriteAfterPartialRead(methodName);
         }
 
         private void CheckArgumentsForTrackedVariables(IInvocationExpression operation)


### PR DESCRIPTION
## Summary

Fixes #248

PC0030 raised a false positive on the common pattern:

```al
if MyTable.FindSet() then
    repeat
        MyTable.Modify(true);
    until MyTable.Next() = 0;
```

## Root cause

`FindSet()` in the if-condition was added to `UncoveredReads` before the branch fork. The true branch's `Modify` retroactively cleared it, but the implicit else branch (representing FindSet returning false) still carried it. At merge, the union of both branches re-introduced the read from the false branch.

## Fix

Changed merge semantics for `UncoveredReads` to distinguish between:
- **Pre-fork reads** (existed before the fork): use **intersection** (keep only if present in ALL branches)
- **In-branch reads** (added during a branch): use **union** (keep if in ANY branch)

Applied consistently to all 5 control flow constructs: if, case, while, for, foreach.

## Test coverage

Added 3 new NoDiagnostic test cases:
- `FindSetWithModifyInLoop` — the exact reported pattern
- `FindSetWithPassedToFunctionInLoop` — same pattern with function pass
- `GetWithConditionalModify` — Get followed by conditional Modify

All 57 PC0030 tests and 24 PC0031 tests pass.