### PR TITLE
fix(AC0032): recognize data item implicit variables in invocation analysis

### DIFF
--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -47,7 +47,7 @@ src/ALCops.Common/
 2. Skip PermissionSet/PermissionSetExtension, obsolete objects, test codeunits with permissions disabled
 3. Get `Permissions` property (early exit if null, covers ~70% of objects)
 4. **Collect DB invocations** (`CollectFromInvocations`):
-   - Build global record variable map from `containingObject.GetMembers()` (object-level vars)
+   - Build object-scope record map (`objectScopeRecordMap`) from `containingObject.GetMembers()`: global vars, report data items (via `GetTypeSymbol()`), xmlport table elements (via `FlattenedNodes` + `GetTypeSymbol()`)
    - Walk `ctx.Node.DescendantNodes()` for `MethodOrTriggerDeclarationSyntax`
    - Skip obsolete methods via `GetDeclaredSymbol` + `IsObsolete()`
    - For each method body: syntax pre-filter (`HasPossibleDbInvocation`)
@@ -56,6 +56,7 @@ src/ALCops.Common/
    - Fall back to `GetSymbolInfo` only for complex receivers (function calls, array indexing)
 5. **Collect data items** (`CollectFromDataItems`):
    - Iterate `containingObject.GetMembers()` for ReportDataItem, QueryDataItem, XmlPortNode symbols
+   - For XmlPortNode: also iterate `FlattenedNodes` to reach nested table elements
    - Use `RequiredPermissionDetector.TryGetFrom*` methods
 6. Compare declared entries against collected permissions, report diagnostics
 
@@ -64,10 +65,11 @@ src/ALCops.Common/
 | Method | Purpose |
 |---|---|
 | `AnalyzeApplicationObject` | Entry point; checks Permissions, orchestrates collection and reporting |
-| `CollectFromInvocations` | Builds variable maps, walks method bodies, resolves DB calls via syntax + symbol lookup |
+| `CollectFromInvocations` | Builds object-scope record map (vars + data items), walks method bodies, resolves DB calls via syntax + symbol lookup |
 | `TryGetPermissionFromInvocation` | Resolves a single invocation: fast path via variable map, fallback via GetSymbolInfo |
 | `TryGetPermissionViaSymbolInfo` | Fallback for complex receivers: uses GetSymbolInfo to resolve method and receiver type |
-| `CollectFromDataItems` | Iterates object members for report/query/xmlport data items |
+| `CollectFromDataItems` | Iterates object members for report/query/xmlport data items (incl. nested xmlport nodes via FlattenedNodes) |
+| `AddXmlPortNodeToVarMap` | Adds an xmlport table element to the object-scope record map if it references a non-temporary table |
 | `HasPossibleDbInvocation` | Syntax pre-filter: checks if body has any invocation name matching a DB operation |
 | `AnalyzePermissionEntry` | Compares one declared entry against collected required permissions |
 | `PermissionMatchesTable` | Matches identifier/qualified/objectId syntax against `ITableTypeSymbol` |
@@ -83,6 +85,8 @@ Each `SyntaxNodeAction` callback is self-contained with no shared mutable state.
 | `RegisterSyntaxNodeAction` on object kinds | Self-contained per-object analysis; no CompilationStart/End coupling; gives SemanticModel directly |
 | Variable map + syntax resolution | Resolves ~66% of DB calls via dictionary lookup from `IMethodSymbol.LocalVariables`/`.Parameters`; avoids expensive `GetOperation` calls entirely |
 | Global variable map from `GetMembers()` | Captures object-level Record variables that account for ~34% of invocations not resolvable from locals/params |
+| Data items in object-scope record map | Report data items and xmlport table elements act as implicit record variables in trigger code; added to the same map for fast-path resolution via `GetTypeSymbol()` |
+| XmlPort nested nodes via `FlattenedNodes` | `GetMembers()` returns only top-level schema nodes; nested table elements (inside textelement) require iterating `IXmlPortNodeSymbol.FlattenedNodes` |
 | `GetSymbolInfo` fallback for complex receivers | Handles function return values, array indexing, property access; only ~1% of invocations need this path |
 | No `GetOperation` / `OperationWalker` | `GetOperation` in `SyntaxNodeAction` costs ~0.3ms/call (no pre-computed cache); variable map approach is 4.5x faster |
 | No cross-callback shared state | Eliminates the fragile two-phase accumulator pattern that caused false positives during incremental compilation |
@@ -132,9 +136,9 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 
 ## Test coverage
 
-**HasDiagnostic (8 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord.
-**NoDiagnostic (9 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable.
-**HasFix (3 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty.
+**HasDiagnostic (10 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord, ParameterPartialUnused, ReportDataItemPartialUnused.
+**NoDiagnostic (13 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable, ParameterOperations, UppercasePermissions, ParameterAllOperations, LocalVarSpacedTable, GlobalVarSpacedTable, ReportDataItemModify, XmlPortTableElementModify.
+**HasFix (4 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty, ReplaceChars.
 
 ## Known limitations
 

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/ReportDataItemPartialUnused.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/HasDiagnostic/ReportDataItemPartialUnused.al
@@ -1,0 +1,29 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata MyTable = rimd|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+            trigger OnAfterGetRecord()
+            begin
+                MyTable.Modify();
+            end;
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemAliasModify.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemAliasModify.al
@@ -1,0 +1,29 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata MyTable = rm|];
+
+    dataset
+    {
+        dataitem("My Table"; MyTable)
+        {
+            trigger OnAfterGetRecord()
+            begin
+                "My Table".Modify();
+            end;
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemModify.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/ReportDataItemModify.al
@@ -1,0 +1,29 @@
+report 50000 MyReport
+{
+    Permissions = [|tabledata MyTable = rm|];
+
+    dataset
+    {
+        dataitem(MyTable; MyTable)
+        {
+            trigger OnAfterGetRecord()
+            begin
+                MyTable.Modify();
+            end;
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/XmlPortTableElementModify.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/XmlPortTableElementModify.al
@@ -1,0 +1,36 @@
+xmlport 50000 MyXmlPort
+{
+    Permissions = [|tabledata MyTable = rim|];
+
+    schema
+    {
+        textelement(Root)
+        {
+            tableelement(MyTable; MyTable)
+            {
+                fieldelement(MyField; MyTable.MyField)
+                {
+                }
+
+                trigger OnBeforeInsertRecord()
+                begin
+                    MyTable.Modify();
+                end;
+            }
+        }
+    }
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -30,6 +30,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("UnusedOnXmlPort")]
         [TestCase("TemporaryRecord")]
         [TestCase("ParameterPartialUnused")]
+        [TestCase("ReportDataItemPartialUnused")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -53,6 +54,8 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("ParameterAllOperations")]
         [TestCase("LocalVarSpacedTable")]
         [TestCase("GlobalVarSpacedTable")]
+        [TestCase("ReportDataItemModify")]
+        [TestCase("XmlPortTableElementModify")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -55,6 +55,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("LocalVarSpacedTable")]
         [TestCase("GlobalVarSpacedTable")]
         [TestCase("ReportDataItemModify")]
+        [TestCase("ReportDataItemAliasModify")]
         [TestCase("XmlPortTableElementModify")]
         public async Task NoDiagnostic(string testCase)
         {

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -4,6 +4,7 @@ using ALCops.Common.Permissions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 
@@ -75,16 +76,41 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         IApplicationObjectTypeSymbol containingObject,
         List<RequiredPermission> requiredPermissions)
     {
-        // Build object-level record variable map (global vars)
-        Dictionary<string, IRecordTypeSymbol>? globalRecordVarMap = null;
+        // Build object-scope record map (global vars, report data items, xmlport table elements)
+        Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap = null;
         foreach (var member in containingObject.GetMembers())
         {
             if (member is IVariableSymbol globalVar
                 && globalVar.Type is IRecordTypeSymbol globalRecordType
                 && !globalRecordType.Temporary)
             {
-                globalRecordVarMap ??= new(StringComparer.OrdinalIgnoreCase);
-                globalRecordVarMap.TryAdd(globalVar.Name, globalRecordType);
+                objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
+                objectScopeRecordMap.TryAdd(globalVar.Name, globalRecordType);
+                continue;
+            }
+
+            // Report data items act as implicit record variables in trigger code
+            if (member.Kind == EnumProvider.SymbolKind.ReportDataItem
+                && member.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is not true
+                && member.GetTypeSymbol() is IRecordTypeSymbol dataItemRecordType
+                && !dataItemRecordType.Temporary)
+            {
+                objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
+                objectScopeRecordMap.TryAdd(member.Name, dataItemRecordType);
+                continue;
+            }
+
+            // XmlPort table elements act as implicit record variables in trigger code
+            if (member.Kind == EnumProvider.SymbolKind.XmlPortNode
+                && member is IXmlPortNodeSymbol xmlPortNode)
+            {
+                AddXmlPortNodeToVarMap(xmlPortNode, ref objectScopeRecordMap);
+
+                // Nested nodes (tableelement inside textelement) are not direct members
+                foreach (var nestedNode in xmlPortNode.FlattenedNodes)
+                    AddXmlPortNodeToVarMap(nestedNode, ref objectScopeRecordMap);
+
+                continue;
             }
         }
 
@@ -134,7 +160,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
                     continue;
 
                 var permission = TryGetPermissionFromInvocation(
-                    invocation, containingObject, localRecordVarMap, globalRecordVarMap, ctx);
+                    invocation, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
 
                 if (permission is not null)
                     requiredPermissions.Add(permission.Value);
@@ -146,7 +172,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation,
         IApplicationObjectTypeSymbol containingObject,
         Dictionary<string, IRecordTypeSymbol>? localRecordVarMap,
-        Dictionary<string, IRecordTypeSymbol>? globalRecordVarMap,
+        Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap,
         SyntaxNodeAnalysisContext ctx)
     {
         // Extract method name and receiver from syntax
@@ -182,8 +208,8 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             if (localRecordVarMap is not null)
                 localRecordVarMap.TryGetValue(receiverName, out recordType);
 
-            if (recordType is null && globalRecordVarMap is not null)
-                globalRecordVarMap.TryGetValue(receiverName, out recordType);
+            if (recordType is null && objectScopeRecordMap is not null)
+                objectScopeRecordMap.TryGetValue(receiverName, out recordType);
 
             if (recordType is not null)
             {
@@ -278,7 +304,30 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             {
                 foreach (var r in RequiredPermissionDetector.GetFromXmlPortNode(member, includeSystemTables: true))
                     requiredPermissions.Add(r);
+
+                // Nested nodes (tableelement inside textelement) are not direct members
+                if (member is IXmlPortNodeSymbol topNode)
+                {
+                    foreach (var nestedNode in topNode.FlattenedNodes)
+                    {
+                        foreach (var r in RequiredPermissionDetector.GetFromXmlPortNode(nestedNode, includeSystemTables: true))
+                            requiredPermissions.Add(r);
+                    }
+                }
             }
+        }
+    }
+
+    private static void AddXmlPortNodeToVarMap(
+        IXmlPortNodeSymbol node,
+        ref Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap)
+    {
+        if (node.SourceTypeKind == EnumProvider.XmlPortSourceTypeKind.Table
+            && ((ISymbol)node).GetTypeSymbol() is IRecordTypeSymbol recordType
+            && !recordType.Temporary)
+        {
+            objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
+            objectScopeRecordMap.TryAdd(((ISymbol)node).Name, recordType);
         }
     }
 

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -184,7 +184,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         {
             methodName = memberAccess.Name.Identifier.ValueText;
             if (memberAccess.Expression is IdentifierNameSyntax identifierName)
-                receiverName = identifierName.Identifier.ValueText;
+                receiverName = identifierName.Identifier.ValueText?.UnquoteIdentifier();
             else
                 hasComplexReceiver = true;
         }


### PR DESCRIPTION
## Problem

AC0032 falsely flagged write permissions (m, i, d) as unused when write operations were performed via report data item or xmlport table element implicit variables inside triggers.

**Repro:**
```al
report 50100 MyReport
{
    Permissions = tabledata MyTable = rm;
    dataset
    {
        dataitem(MyTable; MyTable)
        {
            trigger OnAfterGetRecord()
            begin
                MyTable.Modify();
            end;
        }
    }
}
```

Diagnostic raised: "Permission 'm' on 'tabledata MyTable' is not needed. Only 'r' is required."

## Root cause

`CollectFromInvocations` built its object-scope record map exclusively from `IVariableSymbol` members. Report data items (`IReportDataItemSymbol`) and xmlport table elements (`IXmlPortNodeSymbol`) are not `IVariableSymbol` instances, so their implicit record variables were invisible to the invocation walker.

Additionally, `CollectFromDataItems` only iterated top-level `GetMembers()` for xmlport nodes, missing nested table elements (e.g., `tableelement` inside `textelement`) which require `FlattenedNodes`.

## Fix

- Add `IReportDataItemSymbol` entries to `objectScopeRecordMap` via `GetTypeSymbol()`
- Add `IXmlPortNodeSymbol` table elements (including nested via `FlattenedNodes`) to `objectScopeRecordMap`
- Fix `CollectFromDataItems` to iterate `FlattenedNodes` for xmlport nodes
- Rename `globalRecordVarMap` → `objectScopeRecordMap` to reflect expanded scope

## Tests

- **NoDiagnostic/ReportDataItemModify.al** — exact repro of reported bug
- **NoDiagnostic/XmlPortTableElementModify.al** — same gap for xmlport triggers
- **HasDiagnostic/ReportDataItemPartialUnused.al** — partial unused still detected correctly

All 30 AC0032 tests pass.