### PR TITLE
fix(LC0095): suppress for ErrorInfo/Notification AddAction callbacks

### DIFF
--- a/.github/instructions/lc0095-parameter-not-referenced.instructions.md
+++ b/.github/instructions/lc0095-parameter-not-referenced.instructions.md
@@ -36,6 +36,7 @@ Key helper: `MethodImplementsInterfaceMethod()` from `ALCops.Common.Extensions.M
 | Skip local methods | AA0137 handles them; avoids duplicate diagnostics |
 | Include event subscribers | AA0137 explicitly excludes them despite being local |
 | Skip interface implementations | Parameters are contractually required |
+| Skip ErrorInfo/Notification AddAction callbacks | Single ErrorInfo/Notification param in public/internal codeunit method is contractually required by platform AddAction API |
 | Skip triggers | Platform-defined signatures |
 | Skip event declarations | Parameters define subscriber contract |
 | Skip obsolete methods | No value in modifying deprecated code |
@@ -44,6 +45,6 @@ Key helper: `MethodImplementsInterfaceMethod()` from `ALCops.Common.Extensions.M
 
 ## Test coverage
 
-**HasDiagnostic (5 cases):** InternalProcedure, PublicProcedure, EventSubscriber, MultipleParamsOneUnused, VarParameterUnused.
-**NoDiagnostic (7 cases):** LocalProcedure, TriggerUnusedParam, InterfaceImplementation, EventDeclaration, ObsoleteProcedure, AllParametersUsed, ParameterUsedInExpression.
+**HasDiagnostic (7 cases):** InternalProcedure, PublicProcedure, EventSubscriber, MultipleParamsOneUnused, VarParameterUnused, ErrorInfoInPage, ErrorInfoMultipleParams.
+**NoDiagnostic (9 cases):** LocalProcedure, TriggerUnusedParam, InterfaceImplementation, EventDeclaration, ObsoleteProcedure, AllParametersUsed, ParameterUsedInExpression, ErrorInfoCallbackInCodeunit, NotificationCallbackInCodeunit.
 **HasFix (2 cases):** RemoveSingleParameter, RemoveMiddleParameter.

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/HasDiagnostic/ErrorInfoInPage.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/HasDiagnostic/ErrorInfoInPage.al
@@ -1,0 +1,6 @@
+page 50100 MyPage
+{
+    procedure MyProcedure([|ErrorInfo: ErrorInfo|])
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/HasDiagnostic/ErrorInfoMultipleParams.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/HasDiagnostic/ErrorInfoMultipleParams.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure([|ErrorInfo: ErrorInfo|]; MyText: Text)
+    begin
+        MyText := 'Hello';
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ErrorInfoCallbackInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ErrorInfoCallbackInCodeunit.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyErrorHandler([|ErrorInfo: ErrorInfo|])
+    var
+        MyInteger: Integer;
+    begin
+        MyInteger := 1;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ErrorInfoCallbackInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ErrorInfoCallbackInCodeunit.al
@@ -1,9 +1,6 @@
 codeunit 50100 MyCodeunit
 {
     procedure MyErrorHandler([|ErrorInfo: ErrorInfo|])
-    var
-        MyInteger: Integer;
     begin
-        MyInteger := 1;
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/NotificationCallbackInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/NotificationCallbackInCodeunit.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyNotificationHandler([|Notification: Notification|])
+    begin
+        Message('Notification handled');
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/NotificationCallbackInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/NotificationCallbackInCodeunit.al
@@ -2,6 +2,5 @@ codeunit 50100 MyCodeunit
 {
     procedure MyNotificationHandler([|Notification: Notification|])
     begin
-        Message('Notification handled');
     end;
 }

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
@@ -26,6 +26,8 @@ namespace ALCops.LinterCop.Test
         [TestCase("EventSubscriber")]
         [TestCase("MultipleParamsOneUnused")]
         [TestCase("VarParameterUnused")]
+        [TestCase("ErrorInfoInPage")]
+        [TestCase("ErrorInfoMultipleParams")]
         public async Task HasDiagnostic(string testCase)
         {
             RequireMinimumVersion("13.0",
@@ -45,6 +47,8 @@ namespace ALCops.LinterCop.Test
         [TestCase("ObsoleteProcedure")]
         [TestCase("AllParametersUsed")]
         [TestCase("ParameterUsedInExpression")]
+        [TestCase("ErrorInfoCallbackInCodeunit")]
+        [TestCase("NotificationCallbackInCodeunit")]
         public async Task NoDiagnostic(string testCase)
         {
             RequireMinimumVersion("13.0",

--- a/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
@@ -77,6 +78,10 @@ public sealed class ParameterNotReferenced : DiagnosticAnalyzer
 
     private static bool ShouldAnalyzeMethod(IMethodSymbol method)
     {
+        // ErrorInfo/Notification AddAction callbacks have a contractually required parameter
+        if (IsActionCallbackMethod(method))
+            return false;
+
         // Event subscribers are local but explicitly excluded by AA0137,
         // so we handle them here
         if (method.IsEventSubscriber())
@@ -103,5 +108,19 @@ public sealed class ParameterNotReferenced : DiagnosticAnalyzer
             return false;
 
         return true;
+    }
+
+    private static bool IsActionCallbackMethod(IMethodSymbol method)
+    {
+        if (method.Parameters.Length != 1)
+            return false;
+
+        IApplicationObjectTypeSymbol? containingObject = method.GetContainingApplicationObjectTypeSymbol();
+        if (containingObject is null || containingObject.NavTypeKind != EnumProvider.NavTypeKind.Codeunit)
+            return false;
+
+        NavTypeKind paramTypeKind = method.Parameters[0].ParameterType.GetNavTypeKindSafe();
+        return paramTypeKind == EnumProvider.NavTypeKind.ErrorInfo
+            || paramTypeKind == EnumProvider.NavTypeKind.Notification;
     }
 }


### PR DESCRIPTION
Closes #263

## Problem

LC0095 (Parameter Not Referenced) fires a false positive on methods used as `ErrorInfo.AddAction` or `Notification.AddAction` callbacks. These methods must have exactly one parameter of type `ErrorInfo` or `Notification` (contractually required by the platform), even if the method body doesn't reference it. Removing the parameter causes AL0821.

## Solution

Added `IsActionCallbackMethod()` check at the top of `ShouldAnalyzeMethod()` that suppresses the diagnostic when all conditions are met:
- Method has exactly one parameter of type `ErrorInfo` or `Notification`
- Method is public or internal (not local)
- Method is inside a codeunit

This applies regardless of whether the method is an event subscriber (event subscribers can also serve as AddAction callbacks). The check mirrors the existing pattern in `InternalProcedureNotReferenced`.

## Test coverage

- **NoDiagnostic:** `ErrorInfoCallbackInCodeunit`, `NotificationCallbackInCodeunit`
- **HasDiagnostic (edge cases):** `ErrorInfoInPage` (not a codeunit), `ErrorInfoMultipleParams` (more than one param)

All 18 ParameterNotReferenced tests pass.