### PR TITLE
fix(AC0006): add 'using Microsoft.Utilities' when namespace is present

### DIFF
--- a/.github/instructions/ac0006-run-page-implement-page-management.instructions.md
+++ b/.github/instructions/ac0006-run-page-implement-page-management.instructions.md
@@ -1,0 +1,52 @@
+---
+applyTo: 'src/ALCops.ApplicationCop/**/RunPageImplementPageManagement*'
+---
+
+# AC0006: Use "Page Management" codeunit instead of Page.Run
+
+## Purpose
+
+Detects `Page.Run(...)` and `Page.RunModal(...)` calls that can be replaced with the `"Page Management"` codeunit's methods (`PageRun`, `PageRunModal`, `PageRunAtField`). The CodeFix refactors the call and adds the necessary variable declaration and `using` directive.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | AC0006 |
+| Prefix | AC |
+| Severity | Warning |
+| Category | Design |
+| DiagnosticIds field | `RunPageImplementPageManagement` |
+
+## Analyzer logic
+
+Triggers on `InvocationExpression` operations where:
+1. Target method is a `BuiltInMethod` on a `Page` type with >= 2 arguments
+2. Not `EnqueueBackgroundTask`
+3. Return type `Action` is not used (Page Management doesn't support it)
+4. First argument is either literal `0` or an `OptionAccessExpression` (e.g., `Page::MyPage`)
+5. For `OptionAccessExpression`, the record must be in the `SupportedRecords` dictionary (well-known BC tables)
+
+## CodeFix logic
+
+The CodeFix (`RunPageImplementPageManagementCodeFixProvider`) performs three transformations:
+
+1. **Replace invocation**: `Page.Run(0, Rec)` → `PageManagement.PageRun(Rec)`
+2. **Add variable**: If no existing `Codeunit "Page Management"` variable exists (local or global), adds `PageManagement: Codeunit "Page Management"` as a local variable
+3. **Add using directive**: If the file has a `namespace` declaration and `using Microsoft.Utilities;` is not already present, adds it in sorted order among existing usings
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| Add `using` only when namespace present | Files without `namespace` resolve globally; adding `using` would be unnecessary |
+| Skip if `using Microsoft.Utilities;` exists | Prevents duplicates during FixAll or when user already has the import |
+| Sorted insertion for usings | Maintains alphabetical order among existing `using` directives |
+| Replicate sorted insertion (not reflection) | SDK's `NamespaceActionUtilities` is `internal`; public API (`CompilationUnitSyntax.WithUsings`) suffices |
+| Case-insensitive duplicate check | AL is case-insensitive; `Microsoft.Utilities` == `microsoft.utilities` |
+
+## Test coverage
+
+**HasDiagnostic (4 cases):** PageRunModalPageIdentifierAndRecord, PageRunModalZeroIdentifierAndRecord, PageRunPageIdentifierAndRecord, PageRunZeroIdentifierAndRecord.
+**NoDiagnostic (2 cases):** PageRunPageIdentifierWithoutRecord, PageRunWithReturnTypeAction.
+**HasFix (7 cases):** PageRunModelPageIdentifierAndRecord, PageRunModelPageIdentifierAndRecordWithPageFIeld, PageRunPageIdentifierAndRecord, PageRunPageIdentifierAndRecordWithPageField, PageRunZeroIdentifierAndRecord, PageRunZeroIdentifierAndRecordWithNamespace, PageRunPageIdentifierAndRecordWithNamespaceAndUsing.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -103,3 +103,4 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `pc0033-duplicate-odata-entity-name` | rule-scoped | PC0033 rule |
 | `pc0034-placeholder-argument-count-mismatch` | rule-scoped | PC0034 rule |
 | `lc0095-parameter-not-referenced` | rule-scoped | LC0095 rule |
+| `ac0006-run-page-implement-page-management` | rule-scoped | AC0006 rule |

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,7 @@ nunit-*.xml
 ALCops.*Analyzers.cs
 
 # Microsoft.Dynamics.BusinessCentral.Development.Tools
-**/*Microsoft.Dynamics.BusinessCentral.Development.Tools**.lscache
+**/*Microsoft.Dynamics.BusinessCentral.Development.Tools
+
+# These file caches language service data to improve the performance of C# Dev Kit
+**.lscache

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ nunit-*.xml
 ALCops.*Analyzers.cs
 
 # Microsoft.Dynamics.BusinessCentral.Development.Tools
-**/*Microsoft.Dynamics.BusinessCentral.Development.Tools*
+**/*Microsoft.Dynamics.BusinessCentral.Development.Tools**.lscache

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunPageIdentifierAndRecordWithNamespaceAndUsing/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunPageIdentifierAndRecordWithNamespaceAndUsing/current.al
@@ -1,0 +1,19 @@
+namespace ALCops;
+
+using Microsoft.Utilities;
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+    begin
+        [|Page.Run(Page::MyPage, SalesHeader)|];
+    end;
+}
+
+page 50100 MyPage { }
+table 36 "Sales Header"
+{
+    fields { field(1; MyField; Integer) { } }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunPageIdentifierAndRecordWithNamespaceAndUsing/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunPageIdentifierAndRecordWithNamespaceAndUsing/expected.al
@@ -1,0 +1,20 @@
+namespace ALCops;
+
+using Microsoft.Utilities;
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+        PageManagement: Codeunit "Page Management";
+    begin
+        PageManagement.PageRun(SalesHeader);
+    end;
+}
+
+page 50100 MyPage { }
+table 36 "Sales Header"
+{
+    fields { field(1; MyField; Integer) { } }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/current.al
@@ -1,0 +1,16 @@
+namespace ALCops;
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+    begin
+        [|Page.Run(0, SalesHeader)|];
+    end;
+}
+
+table 36 "Sales Header"
+{
+    fields { field(1; MyField; Integer) { } }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/expected.al
@@ -1,5 +1,7 @@
 namespace ALCops;
+
 using Microsoft.Utilities;
+
 codeunit 50100 MyCodeunit
 {
     procedure MyProcedure()

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/HasFix/PageRunZeroIdentifierAndRecordWithNamespace/expected.al
@@ -1,0 +1,17 @@
+namespace ALCops;
+using Microsoft.Utilities;
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+        PageManagement: Codeunit "Page Management";
+    begin
+        PageManagement.PageRun(SalesHeader);
+    end;
+}
+
+table 36 "Sales Header"
+{
+    fields { field(1; MyField; Integer) { } }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/RunPageImplementPageManagement.cs
@@ -50,10 +50,32 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("PageRunPageIdentifierAndRecord")]
         [TestCase("PageRunPageIdentifierAndRecordWithPageField")]
         [TestCase("PageRunZeroIdentifierAndRecord")]
-        [TestCase("PageRunZeroIdentifierAndRecordWithNamespace")]
-        [TestCase("PageRunPageIdentifierAndRecordWithNamespaceAndUsing")]
         public async Task HasFix(string testCase)
         {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<RunPageImplementPageManagementCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.NotBlankRequiredOnPrimaryKeyField);
+        }
+
+        [Test]
+        [TestCase("PageRunZeroIdentifierAndRecordWithNamespace")]
+        [TestCase("PageRunPageIdentifierAndRecordWithNamespaceAndUsing")]
+        public async Task HasFixWithNamespace(string testCase)
+        {
+            RequireMinimumVersion(
+                "16.0",
+                "Namespaces are not supported before AL version 16");
+
             var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/RunPageImplementPageManagement/RunPageImplementPageManagement.cs
@@ -50,6 +50,8 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("PageRunPageIdentifierAndRecord")]
         [TestCase("PageRunPageIdentifierAndRecordWithPageField")]
         [TestCase("PageRunZeroIdentifierAndRecord")]
+        [TestCase("PageRunZeroIdentifierAndRecordWithNamespace")]
+        [TestCase("PageRunPageIdentifierAndRecordWithNamespaceAndUsing")]
         public async Task HasFix(string testCase)
         {
             var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -376,6 +376,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
 
     #region Using Directive Helpers
 
+#if !NETSTANDARD2_1
     private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root, string namespaceName)
     {
         if (root is not CompilationUnitSyntax compilationUnit)
@@ -433,6 +434,9 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
 
         return compilationUnit.WithUsings(newList);
     }
+#else
+    private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root, string namespaceName) => root;
+#endif
 
     #endregion
 }

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -135,8 +135,10 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
                 newRoot = AddLocalVariable(newRoot, updatedMethodOrTrigger, variableName);
         }
 
+#if NET8_0_OR_GREATER
         // If the file uses namespaces, ensure "using Microsoft.Utilities;" is present
         newRoot = AddUsingDirectiveIfNeeded(newRoot, PageManagementNamespace);
+#endif
 
         return document.WithSyntaxRoot(newRoot);
     }
@@ -376,7 +378,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
 
     #region Using Directive Helpers
 
-#if !NETSTANDARD2_1
+#if NET8_0_OR_GREATER
     private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root, string namespaceName)
     {
         if (root is not CompilationUnitSyntax compilationUnit)
@@ -434,8 +436,6 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
 
         return compilationUnit.WithUsings(newList);
     }
-#else
-    private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root, string namespaceName) => root;
 #endif
 
     #endregion

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -403,8 +403,14 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
         var usings = compilationUnit.Usings;
 
         if (usings.Count == 0)
-            return compilationUnit.AddUsings(
-                newUsing.WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine)));
+        {
+            var eol = SyntaxFactory.EndOfLine(Environment.NewLine, elastic: false);
+            var usingWithTrivia = newUsing
+                .WithLeadingTrivia(eol)
+                .WithTrailingTrivia(eol);
+            return compilationUnit.WithUsings(
+                new SyntaxList<UsingDirectiveSyntax>().Add(usingWithTrivia));
+        }
 
         var newUsingName = newUsing.Name!.ToString();
         var newList = new SyntaxList<UsingDirectiveSyntax>();

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -14,6 +14,7 @@ namespace ALCops.ApplicationCop.CodeFixes;
 public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvider
 {
     private const string PageManagementCodeunitName = "Page Management";
+    private const string PageManagementNamespace = "Microsoft.Utilities";
     private const string DefaultVariableName = "PageManagement";
     private const string PageRunMethodName = "PageRun";
     private const string PageRunModalMethodName = "PageRunModal";
@@ -133,6 +134,9 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
             if (updatedMethodOrTrigger is not null)
                 newRoot = AddLocalVariable(newRoot, updatedMethodOrTrigger, variableName);
         }
+
+        // If the file uses namespaces, ensure "using Microsoft.Utilities;" is present
+        newRoot = AddUsingDirectiveIfNeeded(newRoot, PageManagementNamespace);
 
         return document.WithSyntaxRoot(newRoot);
     }
@@ -366,6 +370,62 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
                 codeunitObjectNameOrId);
 
         return SyntaxFactory.SimpleTypeReference(codeunitDataType);
+    }
+
+    #endregion
+
+    #region Using Directive Helpers
+
+    private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root, string namespaceName)
+    {
+        if (root is not CompilationUnitSyntax compilationUnit)
+            return root;
+
+        if (compilationUnit.NamespaceDeclaration is null)
+            return root;
+
+        var namespaceText = namespaceName;
+        for (int i = 0; i < compilationUnit.Usings.Count; i++)
+        {
+            if (string.Equals(compilationUnit.Usings[i].Name?.ToString(), namespaceText, StringComparison.OrdinalIgnoreCase))
+                return root;
+        }
+
+        var usingDirective = SyntaxFactory.UsingDirective(
+            SyntaxFactory.ParseQualifiedName(namespaceText))
+            .WithSemicolonToken(SyntaxFactory.Token(EnumProvider.SyntaxKind.SemicolonToken));
+
+        return AddUsingInSortedOrder(compilationUnit, usingDirective);
+    }
+
+    private static CompilationUnitSyntax AddUsingInSortedOrder(CompilationUnitSyntax compilationUnit, UsingDirectiveSyntax newUsing)
+    {
+        var usings = compilationUnit.Usings;
+
+        if (usings.Count == 0)
+            return compilationUnit.AddUsings(
+                newUsing.WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine)));
+
+        var newUsingName = newUsing.Name!.ToString();
+        var newList = new SyntaxList<UsingDirectiveSyntax>();
+        bool inserted = false;
+
+        for (int i = 0; i < usings.Count; i++)
+        {
+            if (!inserted && string.CompareOrdinal(usings[i].Name?.ToString(), newUsingName) > 0)
+            {
+                newList = newList.Add(
+                    newUsing.WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine)));
+                inserted = true;
+            }
+            newList = newList.Add(usings[i]);
+        }
+
+        if (!inserted)
+            newList = newList.Add(
+                newUsing.WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine)));
+
+        return compilationUnit.WithUsings(newList);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

The `RunPageImplementPageManagement` CodeFix (AC0006) now adds `using Microsoft.Utilities;` when the source file uses AL namespaces. This prevents AL0185 ("Codeunit 'Page Management' is missing") after the CodeFix refactors `Page.Run` calls.

## Changes

### CodeFix: `RunPageImplementPageManagement.cs`
- Added `AddUsingDirectiveIfNeeded()`: checks if file has a `namespace` declaration and if `using Microsoft.Utilities;` is already present
- Added `AddUsingInSortedOrder()`: inserts the using directive alphabetically among existing usings
- Called at the end of `ImplementPageManagement()` after replacing the invocation and adding the variable

### New test fixtures
- `PageRunZeroIdentifierAndRecordWithNamespace`: verifies using directive is added when namespace is present
- `PageRunPageIdentifierAndRecordWithNamespaceAndUsing`: verifies no duplicate using when already present

### Instruction file
- Created `ac0006-run-page-implement-page-management.instructions.md`

## Design decisions
- Only adds `using` when file has a `namespace` declaration (files without namespaces resolve globally)
- Skips if `using Microsoft.Utilities;` already exists (handles FixAll and pre-existing imports)
- Sorted insertion using ordinal comparison (replicates SDK's `NamespaceActionUtilities.AddUsing` behavior using public API)

Closes #256