### PR TITLE
feat: PageAnalysisView support (Issue #237)

### DIFF
--- a/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
+++ b/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
@@ -40,6 +40,7 @@ These decisions were made during the initial design and should be preserved unle
 | Obsolete symbols | Skip (no diagnostic) | Standard ALCops convention |
 | Empty/needs-translation targets | Treated as missing | A trans-unit with empty target or `state="needs-translation"` means no usable translation |
 | Scope | All translatable elements in one analyzer | Single XLIFF parse pass serves all symbol types |
+| AnalysisView access | Reflection via `FlattenedAnalysisViews` / `AddedAnalysisViewsFlattened` | Properties only exist in net10.0+ SDK; reflection avoids compile-time dependency |
 | netstandard2.1 | Rule is inert (empty stub) | `ExtensionObjectFoldingUtilities` and `GetLabelTextConstLanguageSymbolId` don't exist in the netstandard2.1 SDK; `GetLanguageSymbolId` has a different internal-only signature. Reflection not viable since the classes/methods are absent, not just internal. |
 
 ## Platform availability
@@ -105,7 +106,7 @@ The SDK's `OperationExtensions.GetSymbol()` can throw `InvalidCastException` for
 |---|---|
 | Table, TableExtension, XmlPort, Enum, EnumValue, Report, Profile, PermissionSet | Caption |
 | Field | Caption, ToolTip |
-| Page, PageExtension, RequestPage, RequestPageExtension, Query | Caption + flattened controls (Caption, ToolTip, OptionCaption) + flattened actions (Caption, ToolTip) |
+| Page, PageExtension, RequestPage, RequestPageExtension, Query | Caption + flattened controls (Caption, ToolTip, OptionCaption) + flattened actions (Caption, ToolTip) + flattened analysis views (Caption, ToolTip) |
 | LocalVariable, GlobalVariable | Label type only (skip non-Label, skip Locked) |
 | ReportLabel | The label itself (skip Locked) |
 
@@ -123,10 +124,10 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 
 ## Test coverage
 
-**HasDiagnostic (6 cases):** LocalLabel, GlobalLabel, TableFieldCaption, EnumValueCaption, PageControlToolTip, ReportLabel.
+**HasDiagnostic (7 cases):** LocalLabel, GlobalLabel, TableFieldCaption, EnumValueCaption, PageControlToolTip, PageAnalysisViewCaption, ReportLabel.
 **HasDiagnosticWithLanguagesToTranslateNoXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK"], no XLIFF files.
 **HasDiagnosticWithLanguagesToTranslatePartialXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK","de-DE"], only da-DK XLIFF.
-**NoDiagnostic (2 cases):** LockedLabel, LockedReportLabel.
+**NoDiagnostic (3 cases):** LockedLabel, LockedReportLabel, PageAnalysisViewLockedCaption.
 **NoDiagnosticNoXliff (1 case):** No XLIFF files present, no LanguagesToTranslate setting.
 
 ## Test infrastructure

--- a/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/CaptionRequired.cs
@@ -1,3 +1,4 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -5,12 +6,17 @@ namespace ALCops.ApplicationCop.Test
     public class CaptionRequired : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.CaptionRequired>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.CaptionRequired>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -21,26 +27,44 @@ namespace ALCops.ApplicationCop.Test
         [Test]
         [TestCase("EnumObject")]
         [TestCase("PageObject")]
+        [TestCase("PageAnalysisView")]
         [TestCase("TableObject")]
         public async Task HasDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.CaptionRequired);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.CaptionRequired);
         }
 
         [Test]
         [TestCase("ApiPage")]
         [TestCase("EnumObject")]
         [TestCase("PageObject")]
+        [TestCase("PageAnalysisView")]
         [TestCase("TableObject")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.CaptionRequired);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.CaptionRequired);
         }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/CaptionRequired.cs
@@ -34,7 +34,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 
@@ -56,7 +56,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/HasDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/HasDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    Caption = 'My Page';
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview([|MyAnalysisView|])
+        {
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/CaptionRequired/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,14 @@
+page 50100 MyPage
+{
+    Caption = 'My Page';
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview([|MyAnalysisView|])
+        {
+            Caption = 'My Analysis View';
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/EmptyCaptionLocked.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/EmptyCaptionLocked.cs
@@ -1,4 +1,5 @@
 using ALCops.ApplicationCop.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -6,13 +7,18 @@ namespace ALCops.ApplicationCop.Test
     public class EmptyCaptionLocked : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private static readonly Analyzers.PermissionSetCaptionLength _analyzer = new();
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.EmptyCaptionLocked>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.EmptyCaptionLocked>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -24,26 +30,44 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("Enum")]
         [TestCase("LockedIsFalse")]
         [TestCase("Page")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PermissionSet")]
         [TestCase("Query")]
         [TestCase("Report")]
         [TestCase("Table")]
         public async Task HasDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.EmptyCaptionLocked);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.EmptyCaptionLocked);
         }
 
         [Test]
         [TestCase("Enum")]
+        [TestCase("PageAnalysisView")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.EmptyCaptionLocked);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.EmptyCaptionLocked);
         }
 
         [Test]

--- a/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/EmptyCaptionLocked.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/EmptyCaptionLocked.cs
@@ -40,7 +40,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 
@@ -59,7 +59,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/HasDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/HasDiagnostic/PageAnalysisView.al
@@ -1,0 +1,14 @@
+page 50100 MyPage
+{
+    Caption = 'My Page';
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            [|Caption|] = '';
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/EmptyCaptionLocked/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,14 @@
+page 50100 MyPage
+{
+    Caption = 'My Page';
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            [|Caption|] = '', Locked = true;
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/HasDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/HasDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'My ToolTip.\Some more text.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'Specifies the analysis view.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/ToolTipDoNotUseLineBreaks.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/ToolTipDoNotUseLineBreaks.cs
@@ -40,7 +40,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 
@@ -67,7 +67,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/ToolTipDoNotUseLineBreaks.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipDoNotUseLineBreaks/ToolTipDoNotUseLineBreaks.cs
@@ -1,3 +1,4 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -5,12 +6,17 @@ namespace ALCops.ApplicationCop.Test
     public class ToolTipDoNotUseLineBreaks : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -20,6 +26,7 @@ namespace ALCops.ApplicationCop.Test
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task HasDiagnostic(string testCase)
@@ -30,15 +37,23 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipDoNotUseLineBreaks);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipDoNotUseLineBreaks);
         }
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task NoDiagnostic(string testCase)
@@ -49,11 +64,18 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipDoNotUseLineBreaks);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipDoNotUseLineBreaks);
         }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/HasDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/HasDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'Specifies the analysis view that is used to display data in a way that helps you analyze trends and patterns. This is a very long tooltip that exceeds the maximum allowed length of 200 characters to test the maximum length rule.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'Specifies the analysis view.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/ToolTipMaximumLength.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/ToolTipMaximumLength.cs
@@ -40,7 +40,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 
@@ -67,7 +67,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/ToolTipMaximumLength.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMaximumLength/ToolTipMaximumLength.cs
@@ -1,3 +1,4 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -5,12 +6,17 @@ namespace ALCops.ApplicationCop.Test
     public class ToolTipMaximumLength : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -20,6 +26,7 @@ namespace ALCops.ApplicationCop.Test
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task HasDiagnostic(string testCase)
@@ -30,15 +37,23 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMaximumLength);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMaximumLength);
         }
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task NoDiagnostic(string testCase)
@@ -49,11 +64,18 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMaximumLength);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMaximumLength);
         }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/HasDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/HasDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'My ToolTip'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'Specifies the analysis view.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/ToolTipMustEndWithDot.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/ToolTipMustEndWithDot.cs
@@ -1,3 +1,4 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -5,12 +6,17 @@ namespace ALCops.ApplicationCop.Test
     public class ToolTipMustEndWithDot : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -20,6 +26,7 @@ namespace ALCops.ApplicationCop.Test
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task HasDiagnostic(string testCase)
@@ -30,15 +37,23 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMustEndWithDot);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMustEndWithDot);
         }
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task NoDiagnostic(string testCase)
@@ -49,11 +64,18 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMustEndWithDot);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipMustEndWithDot);
         }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/ToolTipMustEndWithDot.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipMustEndWithDot/ToolTipMustEndWithDot.cs
@@ -40,7 +40,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 
@@ -67,7 +67,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/NoDiagnostic/PageAnalysisView.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/NoDiagnostic/PageAnalysisView.al
@@ -1,0 +1,13 @@
+page 50100 MyPage
+{
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            ToolTip = [|'My Analysis View ToolTip.'|];
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/ToolTipShouldStartWithSpecifies.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/ToolTipShouldStartWithSpecifies.cs
@@ -58,7 +58,7 @@ namespace ALCops.ApplicationCop.Test
             SkipTestIfVersionIsTooLow(
                 AnalysisViewTestCases,
                 testCase,
-                "16.0",
+                "18.0.36",
                 "PageAnalysisView requires net10.0 SDK."
             );
 

--- a/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/ToolTipShouldStartWithSpecifies.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ToolTipShouldStartWithSpecifies/ToolTipShouldStartWithSpecifies.cs
@@ -1,3 +1,4 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using RoslynTestKit;
 
 namespace ALCops.ApplicationCop.Test
@@ -5,12 +6,17 @@ namespace ALCops.ApplicationCop.Test
     public class ToolTipShouldStartWithSpecifies : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _analysisViewFixture;
         private string _testCasePath;
+
+        private static readonly string[] AnalysisViewTestCases = ["PageAnalysisView"];
 
         [SetUp]
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>();
+            _analysisViewFixture = RoslynFixtureFactory.Create<Analyzers.ToolTipPunctuation>(
+                TestHelper.CreateAnalysisViewConfig());
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -38,6 +44,7 @@ namespace ALCops.ApplicationCop.Test
 
         [Test]
         [TestCase("PageAction")]
+        [TestCase("PageAnalysisView")]
         [TestCase("PageField")]
         [TestCase("TableField")]
         public async Task NoDiagnostic(string testCase)
@@ -48,11 +55,18 @@ namespace ALCops.ApplicationCop.Test
                 "13.0",
                 "ToolTips on fields in a table object are not supported in versions lower than 13.0."
             );
+            SkipTestIfVersionIsTooLow(
+                AnalysisViewTestCases,
+                testCase,
+                "16.0",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipShouldStartWithSpecifies);
+            var fixture = AnalysisViewTestCases.Contains(testCase) ? _analysisViewFixture : _fixture;
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ToolTipShouldStartWithSpecifies);
         }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/TestHelper.cs
+++ b/src/ALCops.ApplicationCop.Test/TestHelper.cs
@@ -1,0 +1,34 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using RoslynTestKit;
+
+namespace ALCops.ApplicationCop.Test;
+
+internal static class TestHelper
+{
+    private static readonly byte[] AnalysisViewDefinitionContent = System.Text.Encoding.UTF8.GetBytes(
+        """
+        {
+            "Id": "00000000-0000-0000-0000-000000000001",
+            "Name": "MyAnalysisView",
+            "TargetObjectId": 50100,
+            "TargetObjectType": "Page"
+        }
+        """);
+
+    internal static MemoryFileSystem CreateAnalysisViewFileSystem()
+    {
+        return new MemoryFileSystem(new Dictionary<string, byte[]>
+        {
+            { "MyAnalysisView.analysis.json", AnalysisViewDefinitionContent }
+        });
+    }
+
+    internal static AnalyzerTestFixtureConfig CreateAnalysisViewConfig()
+    {
+        return new AnalyzerTestFixtureConfig
+        {
+            FileSystem = CreateAnalysisViewFileSystem(),
+            ThrowsWhenInputDocumentContainsError = false
+        };
+    }
+}

--- a/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
@@ -27,7 +27,8 @@ public sealed class CaptionRequired : DiagnosticAnalyzer
             EnumProvider.SymbolKind.Action,
             EnumProvider.SymbolKind.EnumValue,
             EnumProvider.SymbolKind.Control,
-            EnumProvider.SymbolKind.PermissionSet
+            EnumProvider.SymbolKind.PermissionSet,
+            EnumProvider.SymbolKind.AnalysisView
         );
 
     private void CheckForMissingCaptions(SymbolAnalysisContext context)
@@ -144,6 +145,11 @@ public sealed class CaptionRequired : DiagnosticAnalyzer
             if (assignableProperty is null || (bool)assignableProperty.Value)
                 if (CaptionIsMissing(context.Symbol, context))
                     RaiseDiagnostic(context);
+        }
+        else if (context.Symbol.Kind == EnumProvider.SymbolKind.AnalysisView)
+        {
+            if (CaptionIsMissing(context.Symbol, context))
+                RaiseDiagnostic(context);
         }
         else
         {

--- a/src/ALCops.ApplicationCop/Analyzers/EmptyCaptionLocked.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/EmptyCaptionLocked.cs
@@ -43,6 +43,7 @@ public sealed class EmptyCaptionLocked : DiagnosticAnalyzer
             EnumProvider.SyntaxKind.PageCustomAction,
             EnumProvider.SyntaxKind.PageSystemAction,
             EnumProvider.SyntaxKind.PageView,
+            EnumProvider.SyntaxKind.PageAnalysisView,
             EnumProvider.SyntaxKind.ReportLayout,
             EnumProvider.SyntaxKind.ProfileObject,
             EnumProvider.SyntaxKind.EnumType,

--- a/src/ALCops.ApplicationCop/Analyzers/ToolTipPunctuation.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/ToolTipPunctuation.cs
@@ -28,7 +28,8 @@ public sealed class ToolTipPunctuation : DiagnosticAnalyzer
             AnalyzeToolTipPunctuation,
             EnumProvider.SyntaxKind.PageField,
             EnumProvider.SyntaxKind.PageAction,
-            EnumProvider.SyntaxKind.Field
+            EnumProvider.SyntaxKind.Field,
+            EnumProvider.SyntaxKind.PageAnalysisView
         );
 
     private void AnalyzeToolTipPunctuation(SyntaxNodeAnalysisContext ctx)

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -847,6 +847,12 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.XmlPort)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _xmlPortNode =
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.XmlPortNode)));
+        private static readonly Lazy<NavCodeAnalysis.SymbolKind> _analysisView =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SymbolKind>("AnalysisView"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.AnalysisView)));
+#endif
 
         public static NavCodeAnalysis.SymbolKind Action => _action.Value;
         public static NavCodeAnalysis.SymbolKind Class => _class.Value;
@@ -881,6 +887,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.SymbolKind Undefined => _undefined.Value;
         public static NavCodeAnalysis.SymbolKind XmlPort => _xmlPort.Value;
         public static NavCodeAnalysis.SymbolKind XmlPortNode => _xmlPortNode.Value;
+        public static NavCodeAnalysis.SymbolKind AnalysisView => _analysisView.Value;
     }
 
     /// <summary>
@@ -1080,6 +1087,36 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageSystemPart)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageView =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageView)));
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageAnalysisView =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>("PageAnalysisView"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageAnalysisView)));
+#endif
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageAnalysisViewList =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>("PageAnalysisViewList"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageAnalysisViewList)));
+#endif
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageExtensionAnalysisViewList =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>("PageExtensionAnalysisViewList"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageExtensionAnalysisViewList)));
+#endif
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _analysisViewAddChange =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>("AnalysisViewAddChange"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.AnalysisViewAddChange)));
+#endif
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _analysisViewModifyChange =
+#if NETSTANDARD2_1 || NET8_0
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>("AnalysisViewModifyChange"));
+#else
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.AnalysisViewModifyChange)));
+#endif
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageActionArea =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PageActionArea)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pageActionGroup =
@@ -1277,6 +1314,11 @@ public static class EnumProvider
         public static NavCodeAnalysis.SyntaxKind PageSystemAction => _pageSystemAction.Value;
         public static NavCodeAnalysis.SyntaxKind PageSystemPart => _pageSystemPart.Value;
         public static NavCodeAnalysis.SyntaxKind PageView => _pageView.Value;
+        public static NavCodeAnalysis.SyntaxKind PageAnalysisView => _pageAnalysisView.Value;
+        public static NavCodeAnalysis.SyntaxKind PageAnalysisViewList => _pageAnalysisViewList.Value;
+        public static NavCodeAnalysis.SyntaxKind PageExtensionAnalysisViewList => _pageExtensionAnalysisViewList.Value;
+        public static NavCodeAnalysis.SyntaxKind AnalysisViewAddChange => _analysisViewAddChange.Value;
+        public static NavCodeAnalysis.SyntaxKind AnalysisViewModifyChange => _analysisViewModifyChange.Value;
         public static NavCodeAnalysis.SyntaxKind PageActionArea => _pageActionArea.Value;
         public static NavCodeAnalysis.SyntaxKind PageActionGroup => _pageActionGroup.Value;
         public static NavCodeAnalysis.SyntaxKind PageActionSeparator => _pageActionSeparator.Value;

--- a/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
+++ b/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
@@ -290,6 +290,11 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
             PageExtensionActionListSyntax pageExtActList => pageExtActList.Changes.Count == 0,
             PageViewListSyntax pageViewList => pageViewList.Views.Count == 0,
             PageExtensionViewListSyntax pageExtViewList => pageExtViewList.Changes.Count == 0,
+            // COMPAT: PageAnalysisViewListSyntax/PageExtensionAnalysisViewListSyntax only exist in net10.0+ SDK.
+            // Use SyntaxKind matching + ChildNodes() to avoid compile-time dependency.
+            _ when node.Kind == EnumProvider.SyntaxKind.PageAnalysisViewList
+                || node.Kind == EnumProvider.SyntaxKind.PageExtensionAnalysisViewList
+                => !node.ChildNodes().Any(),
             ParameterListSyntax paramList => paramList.Parameters.Count == 0,
             PropertyListSyntax propList => propList.Properties.Count == 0,
             _ => false

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/PageAnalysisViewCaption.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/PageAnalysisViewCaption.al
@@ -1,0 +1,14 @@
+page 50100 MyPage
+{
+    Caption = 'My Page';
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            [|Caption|] = 'My Analysis View';
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/PageAnalysisViewLockedCaption.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/PageAnalysisViewLockedCaption.al
@@ -1,0 +1,14 @@
+page 50100 MyPage
+{
+    Caption = 'My Page', Locked = true;
+    PageType = List;
+
+    analysisviews
+    {
+        analysisview(MyAnalysisView)
+        {
+            [|Caption|] = 'My Analysis View', Locked = true;
+            DefinitionFile = 'MyAnalysisView.analysis.json';
+        }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -35,11 +35,22 @@ namespace ALCops.LinterCop.Test
                     Path.Combine("Rules", nameof(TranslatableTextShouldBeTranslated)));
         }
 
+        private static readonly byte[] AnalysisViewDefinitionContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            {
+                "Id": "00000000-0000-0000-0000-000000000001",
+                "Name": "MyAnalysisView",
+                "TargetObjectId": 50100,
+                "TargetObjectType": "Page"
+            }
+            """);
+
         private static AnalyzerTestFixture CreateFixtureWithEmptyXliff()
         {
             var files = new Dictionary<string, byte[]>
             {
-                { "Translations/TestApp.da-DK.xlf", EmptyXliffContent }
+                { "Translations/TestApp.da-DK.xlf", EmptyXliffContent },
+                { "MyAnalysisView.analysis.json", AnalysisViewDefinitionContent }
             };
             var fileSystem = new MemoryFileSystem(files);
 
@@ -99,6 +110,7 @@ namespace ALCops.LinterCop.Test
         [TestCase("TableFieldCaption")]
         [TestCase("EnumValueCaption")]
         [TestCase("PageControlToolTip")]
+        [TestCase("PageAnalysisViewCaption")]
         [TestCase("ReportLabel")]
         public async Task HasDiagnostic(string testCase)
         {
@@ -116,6 +128,7 @@ namespace ALCops.LinterCop.Test
         [Test]
         [TestCase("LockedLabel")]
         [TestCase("LockedReportLabel")]
+        [TestCase("PageAnalysisViewLockedCaption")]
         public async Task NoDiagnostic(string testCase)
         {
             RequireMinimumVersion("16.0",

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -117,6 +117,13 @@ namespace ALCops.LinterCop.Test
             RequireMinimumVersion("16.0",
                 "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
 
+            SkipTestIfVersionIsTooLow(
+                ["PageAnalysisViewCaption"],
+                testCase,
+                "18.0.36",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
             var code = await File.ReadAllTextAsync(
                 Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
@@ -133,6 +140,13 @@ namespace ALCops.LinterCop.Test
         {
             RequireMinimumVersion("16.0",
                 "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            SkipTestIfVersionIsTooLow(
+                ["PageAnalysisViewLockedCaption"],
+                testCase,
+                "18.0.36",
+                "PageAnalysisView requires net10.0 SDK."
+            );
 
             var code = await File.ReadAllTextAsync(
                 Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -3,6 +3,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 
 #if !NETSTANDARD2_1
+using System.Reflection;
 using System.Xml.Linq;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
@@ -186,6 +187,19 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
                 ReportTranslatableProperty(ctx, action, EnumProvider.PropertyKind.ToolTip, translationIndex);
             }
         }
+
+        IEnumerable<ISymbol>? analysisViews = GetFlattenedAnalysisViews(symbol);
+        if (analysisViews is not null)
+        {
+            foreach (ISymbol analysisView in analysisViews)
+            {
+                if (analysisView.IsObsolete())
+                    continue;
+
+                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.Caption, translationIndex);
+                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.ToolTip, translationIndex);
+            }
+        }
     }
 
     private static void ReportTranslatableProperty(SymbolAnalysisContext ctx, ISymbol symbol, PropertyKind propertyKind, TranslationIndex translationIndex)
@@ -358,6 +372,29 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             IPageExtensionBaseTypeSymbol pageExtension => pageExtension.AddedActionsFlattened,
             _ => null
         };
+
+    // COMPAT: FlattenedAnalysisViews/AddedAnalysisViewsFlattened only exist in net10.0+ SDK.
+    // Use reflection to avoid compile-time dependency on the newest SDK.
+    private static readonly Lazy<PropertyInfo?> _flattenedAnalysisViewsProperty =
+        new(() => typeof(IPageBaseTypeSymbol).GetProperty("FlattenedAnalysisViews", BindingFlags.Public | BindingFlags.Instance));
+
+    private static readonly Lazy<PropertyInfo?> _addedAnalysisViewsFlattenedProperty =
+        new(() => typeof(IPageExtensionBaseTypeSymbol).GetProperty("AddedAnalysisViewsFlattened", BindingFlags.Public | BindingFlags.Instance));
+
+    private static IEnumerable<ISymbol>? GetFlattenedAnalysisViews(ISymbol symbol)
+    {
+        if (symbol is IPageBaseTypeSymbol page)
+        {
+            return _flattenedAnalysisViewsProperty.Value?.GetValue(page) as IEnumerable<ISymbol>;
+        }
+
+        if (symbol is IPageExtensionBaseTypeSymbol pageExtension)
+        {
+            return _addedAnalysisViewsFlattenedProperty.Value?.GetValue(pageExtension) as IEnumerable<ISymbol>;
+        }
+
+        return null;
+    }
 
     #endregion
 


### PR DESCRIPTION
## Summary

Adds support for the new BC 2026 Wave 1 **Page Analysis View** sub-element across multiple existing diagnostic rules.

### Changes

**EnumProvider** (`ALCops.Common`)
- Added `SymbolKind.AnalysisView`, `SyntaxKind.PageAnalysisView`, `PageAnalysisViewList`, `PageExtensionAnalysisViewList`, `AnalysisViewAddChange`, `AnalysisViewModifyChange`
- Uses `#if NETSTANDARD2_1 || NET8_0` guards for backward compatibility

**AC0011 (CaptionRequired)** - Register `SymbolKind.AnalysisView` for caption requirement check
**AC0014-17 (ToolTipPunctuation)** - Register `SyntaxKind.PageAnalysisView` for tooltip validation
**AC0018 (EmptyCaptionLocked)** - Register `SyntaxKind.PageAnalysisView` for empty caption check
**AC0015 (ToolTipShouldStartWithSpecifies)** - NoDiagnostic only (Specifies check not applicable to AnalysisViews)
**LC0091 (TranslatableTextShouldBeTranslated)** - Iterate `FlattenedAnalysisViews` via reflection for Caption/ToolTip translatability
**FC0001 (CasingMismatchIdentifier)** - Handle `PageAnalysisViewListSyntax`/`PageExtensionAnalysisViewListSyntax` in `IsEmptyList()`

### Test coverage
- 11 new ApplicationCop tests (5 HasDiagnostic + 6 NoDiagnostic)
- 2 new LinterCop tests (1 HasDiagnostic + 1 NoDiagnostic)
- All 1,025 tests pass (0 regressions)

### Key design decisions
- **AnalysisView is a page sub-element**, not a standalone object type
- **Reflection-based access** for `FlattenedAnalysisViews`/`AddedAnalysisViewsFlattened` (only exist in net10.0+ SDK)
- **SyntaxKind matching** for FC0001 to avoid compile-time dependency on new SDK types
- **TestHelper with MemoryFileSystem** for DefinitionFile validation in tests

Closes #237