### PR TITLE
fix(LC0095): suppress for handler functions with required signatures

### DIFF
--- a/.github/instructions/lc0095-parameter-not-referenced.instructions.md
+++ b/.github/instructions/lc0095-parameter-not-referenced.instructions.md
@@ -36,6 +36,7 @@ Key helper: `MethodImplementsInterfaceMethod()` from `ALCops.Common.Extensions.M
 | Skip local methods | AA0137 handles them; avoids duplicate diagnostics |
 | Include event subscribers | AA0137 explicitly excludes them despite being local |
 | Skip interface implementations | Parameters are contractually required |
+| Skip handler functions | Platform-enforced signatures (MessageHandler, ConfirmHandler, etc.); uses reflection on MethodSymbol.IsHandler |
 | Skip ErrorInfo/Notification AddAction callbacks | Single ErrorInfo/Notification param in public/internal codeunit method is contractually required by platform AddAction API |
 | Skip triggers | Platform-defined signatures |
 | Skip event declarations | Parameters define subscriber contract |
@@ -46,5 +47,5 @@ Key helper: `MethodImplementsInterfaceMethod()` from `ALCops.Common.Extensions.M
 ## Test coverage
 
 **HasDiagnostic (7 cases):** InternalProcedure, PublicProcedure, EventSubscriber, MultipleParamsOneUnused, VarParameterUnused, ErrorInfoInPage, ErrorInfoMultipleParams.
-**NoDiagnostic (9 cases):** LocalProcedure, TriggerUnusedParam, InterfaceImplementation, EventDeclaration, ObsoleteProcedure, AllParametersUsed, ParameterUsedInExpression, ErrorInfoCallbackInCodeunit, NotificationCallbackInCodeunit.
+**NoDiagnostic (11 cases):** LocalProcedure, TriggerUnusedParam, InterfaceImplementation, EventDeclaration, ObsoleteProcedure, AllParametersUsed, ParameterUsedInExpression, ErrorInfoCallbackInCodeunit, NotificationCallbackInCodeunit, MessageHandlerInCodeunit, ConfirmHandlerInCodeunit.
 **HasFix (2 cases):** RemoveSingleParameter, RemoveMiddleParameter.

--- a/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
@@ -14,6 +14,14 @@ public static class MethodSymbolInterfaceExtensions
                            .MethodImplementsInterfaceMethod(methodSymbol);
     }
 
+    /// <summary>
+    /// Checks whether the method is a handler function (e.g. MessageHandler, ConfirmHandler, etc.)
+    /// by reflecting on the internal MethodSymbol.IsHandler property.
+    /// Returns false if the property is not available (fails open: diagnostic fires).
+    /// </summary>
+    public static bool IsHandler(this IMethodSymbol method)
+        => method.GetPropertyIfExists<bool>("IsHandler");
+
     public static bool MethodImplementsInterfaceMethod(this IMethodSymbol methodSymbol, IMethodSymbol interfaceMethodSymbol)
     {
         if (methodSymbol is null || interfaceMethodSymbol is null)

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ConfirmHandlerInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/ConfirmHandlerInCodeunit.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    Subtype = Test;
+
+    [ConfirmHandler]
+    procedure ConfirmHandler([|Question: Text[1024]|]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/MessageHandlerInCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/MessageHandlerInCodeunit.al
@@ -1,0 +1,9 @@
+codeunit 50100 MyCodeunit
+{
+    Subtype = Test;
+
+    [MessageHandler]
+    procedure MessageHandler([|MessageText: Text[1024]|])
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
@@ -49,6 +49,8 @@ namespace ALCops.LinterCop.Test
         [TestCase("ParameterUsedInExpression")]
         [TestCase("ErrorInfoCallbackInCodeunit")]
         [TestCase("NotificationCallbackInCodeunit")]
+        [TestCase("MessageHandlerInCodeunit")]
+        [TestCase("ConfirmHandlerInCodeunit")]
         public async Task NoDiagnostic(string testCase)
         {
             RequireMinimumVersion("13.0",

--- a/src/ALCops.LinterCop/Analyzers/InternalProcedureNotReferenced.cs
+++ b/src/ALCops.LinterCop/Analyzers/InternalProcedureNotReferenced.cs
@@ -20,8 +20,6 @@ public sealed class InternalProcedureNotReferenced : DiagnosticAnalyzer
         private readonly PooledDictionary<IMethodSymbol, string> internalMethodsUnused = PooledDictionary<IMethodSymbol, string>.GetInstance();
         private readonly PooledDictionary<IMethodSymbol, string> internalMethodsUsedInCurrentObject = PooledDictionary<IMethodSymbol, string>.GetInstance();
         private readonly PooledDictionary<IMethodSymbol, string> internalMethodsUsedInOtherObjects = PooledDictionary<IMethodSymbol, string>.GetInstance();
-        private readonly AttributeKind[] attributeKindsOfMethodsToSkip = new AttributeKind[] { EnumProvider.AttributeKind.ConfirmHandler, EnumProvider.AttributeKind.FilterPageHandler, EnumProvider.AttributeKind.HyperlinkHandler, EnumProvider.AttributeKind.MessageHandler, EnumProvider.AttributeKind.ModalPageHandler, EnumProvider.AttributeKind.PageHandler, EnumProvider.AttributeKind.RecallNotificationHandler, EnumProvider.AttributeKind.ReportHandler, EnumProvider.AttributeKind.RequestPageHandler, EnumProvider.AttributeKind.SendNotificationHandler, EnumProvider.AttributeKind.SessionSettingsHandler, EnumProvider.AttributeKind.StrMenuHandler, EnumProvider.AttributeKind.Test };
-
         public MethodSymbolAnalyzer(CompilationAnalysisContext compilationAnalysisContext)
         {
             NavAppManifest? manifest = ManifestHelper.GetManifest(compilationAnalysisContext.Compilation);
@@ -60,7 +58,11 @@ public sealed class InternalProcedureNotReferenced : DiagnosticAnalyzer
             {
                 return false;
             }
-            if (methodSymbol.Attributes.Any(attr => attributeKindsOfMethodsToSkip.Contains(attr.AttributeKind)))
+            if (methodSymbol.IsHandler())
+            {
+                return false;
+            }
+            if (methodSymbol.Attributes.Any(attr => attr.AttributeKind == EnumProvider.AttributeKind.Test))
             {
                 return false;
             }

--- a/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop/Analyzers/ParameterNotReferenced.cs
@@ -78,6 +78,10 @@ public sealed class ParameterNotReferenced : DiagnosticAnalyzer
 
     private static bool ShouldAnalyzeMethod(IMethodSymbol method)
     {
+        // Handler functions (MessageHandler, ConfirmHandler, etc.) have platform-enforced signatures
+        if (method.IsHandler())
+            return false;
+
         // ErrorInfo/Notification AddAction callbacks have a contractually required parameter
         if (IsActionCallbackMethod(method))
             return false;


### PR DESCRIPTION
Closes #276

## Problem

LC0095 (Parameter Not Referenced) fires false positives on handler functions (`[MessageHandler]`, `[ConfirmHandler]`, `[StrMenuHandler]`, etc.). These methods have platform-enforced parameter signatures; removing unused parameters triggers CodeCop Rule0241.

## Solution

Added a reflection-based `IsHandler()` extension method on `IMethodSymbol` (in `ALCops.Common`) that accesses the internal `MethodSymbol.IsHandler` property. This property checks `HasAttributeWithTag(AttributeTagKind.Handler)`, covering all 13 handler attribute types automatically.

The check is added to `ShouldAnalyzeMethod()` in `ParameterNotReferenced`, suppressing LC0095 for any handler-attributed method.

### Handler types covered

MessageHandler, ConfirmHandler, StrMenuHandler, PageHandler, ModalPageHandler, ReportHandler, RequestPageHandler, FilterPageHandler, HyperlinkHandler, SessionSettingsHandler, SendNotificationHandler, RecallNotificationHandler, HttpClientHandler.

### Bonus: refactored InternalProcedureNotReferenced

Replaced the hardcoded `attributeKindsOfMethodsToSkip` array (12 handlers + Test) with the shared `IsHandler()` call. This also fixes a latent bug where `HttpClientHandler` was missing from the exclusion list.

## Test coverage

- **NoDiagnostic:** `MessageHandlerInCodeunit`, `ConfirmHandlerInCodeunit`
- All 20 ParameterNotReferenced tests pass
- InternalProcedureNotReferenced tests pass