### PR TITLE
fix: reverse NuGet TFM path order to prefer highest framework

### DIFF
--- a/.github/actions/get-bc-devtools/Get-BC-DevTools.ps1
+++ b/.github/actions/get-bc-devtools/Get-BC-DevTools.ps1
@@ -250,8 +250,9 @@ function Get-AssetInfo {
     }
 
     # Determine the archive-internal folder and the full entry path for the target DLL.
-    # For NuGet, try net8.0 first; fall back to net10.0 if the entry isn't found.
-    $nugetTfmPaths = @('tools/net8.0/any', 'tools/net10.0/any')
+    # For NuGet packages that ship multiple TFMs, we want the highest.
+    # Order highest-first so the first successful extraction wins.
+    $nugetTfmPaths = @('tools/net10.0/any', 'tools/net8.0/any')
     $pathInArchive = switch ($PackageType) {
         'VSIX' { 'extension/bin/Analyzers' }
         'NuGet' { $nugetTfmPaths[0] }

--- a/.github/instructions/get-bc-devtools.instructions.md
+++ b/.github/instructions/get-bc-devtools.instructions.md
@@ -53,7 +53,7 @@ When a new .NET major version appears in BC DevTools assemblies:
 1. Add a `tfm-net{major*10}0-version-lowest` output to `action.yml` (e.g. `tfm-net100-version-lowest` for net10.0)
 2. Propagate the new output through `build-test.yml` workflow_call outputs and setup job outputs
 3. Add conditional "Setup BC DevTools" steps for the new TFM in Build (`build-test.yml`) and Release (`build-and-release.yml`) jobs
-4. Add the new TFM path to `$nugetTfmPaths` in `Get-BC-DevTools.ps1` for NuGet package analysis
+4. **Prepend** the new TFM path to `$nugetTfmPaths` in `Get-BC-DevTools.ps1` (highest TFM first, so the first successful extraction determines the reported TFM)
 5. The `System.Reflection.Metadata`-based TFM detection and TFM parsing require no changes (they handle any .NET version automatically)
 
 ## net10.0 pipeline support


### PR DESCRIPTION
## Problem

NuGet packages that ship assemblies for multiple TFMs (e.g. `18.0.36.33307-beta` contains both `tools/net8.0/any` and `tools/net10.0/any`) were misreported as `net8.0`.

**Root cause:** `Get-AssetInfo` in `Get-BC-DevTools.ps1` tried `tools/net8.0/any` first and stopped on the first successful extraction.

Example: [actions/runs/25987309595](https://github.com/ALCops/Analyzers/actions/runs/25987309595/job/76386969422) — `18.0.36.33307-beta` shows `net8.0` but should be `net10.0`.

## Fix

- Reverse `$nugetTfmPaths` to try `net10.0` before `net8.0`, so the highest TFM wins
- Update maintenance docs to clarify new TFM paths must be **prepended** (highest first)

## Note

After merging, the GitHub Actions cache for `TargetFramework.json` needs manual invalidation to re-analyze `18.0.36.33307-beta` with the corrected ordering.