### PR TITLE
fix(PC0030): emit unqualified field references in SetLoadFields codefix

### DIFF
--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/AllFieldsInFilters/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/AllFieldsInFilters/expected.al
@@ -6,7 +6,7 @@ codeunit 50100 MyCodeunit
     begin
         MyTable.SetRange(MyField1, 'A');
         MyTable.SetRange(MyField2, 'B');
-        MyTable.SetLoadFields(MyTable.MyField1);
+        MyTable.SetLoadFields(MyField1);
         exit(MyTable.FindFirst());
     end;
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MixedFilterAndConsume/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MixedFilterAndConsume/expected.al
@@ -5,7 +5,7 @@ codeunit 50100 MyCodeunit
         MyTable: Record MyTable;
     begin
         MyTable.SetRange(MyField1, 'A');
-        MyTable.SetLoadFields(MyTable.MyField1, MyTable.MyField2);
+        MyTable.SetLoadFields(MyField1, MyField2);
         MyTable.FindFirst();
         exit(MyTable.MyField1 + MyTable.MyField2);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/MultipleFields/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable.Description, MyTable.MyField);
+        MyTable.SetLoadFields(Description, MyField);
         MyTable.FindFirst();
         exit(MyTable.MyField + MyTable.Description);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable."Primary Key");
+        MyTable.SetLoadFields("Primary Key");
         exit(MyTable.Get());
     end;
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable."My Field Name");
+        MyTable.SetLoadFields("My Field Name");
         MyTable.Get();
         exit(MyTable."My Field Name");
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetCurrentKeyExcluded/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetCurrentKeyExcluded/expected.al
@@ -5,7 +5,7 @@ codeunit 50100 MyCodeunit
         MyTable: Record MyTable;
     begin
         MyTable.SetCurrentKey(MyField1);
-        MyTable.SetLoadFields(MyTable.MyField2);
+        MyTable.SetLoadFields(MyField2);
         MyTable.FindFirst();
         exit(MyTable.MyField2);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetFilterFieldExcluded/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetFilterFieldExcluded/expected.al
@@ -5,7 +5,7 @@ codeunit 50100 MyCodeunit
         MyTable: Record MyTable;
     begin
         MyTable.SetFilter(MyField1, '%1', 'A');
-        MyTable.SetLoadFields(MyTable.MyField2);
+        MyTable.SetLoadFields(MyField2);
         MyTable.FindFirst();
         exit(MyTable.MyField2);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetRangeFieldExcluded/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetRangeFieldExcluded/expected.al
@@ -5,7 +5,7 @@ codeunit 50100 MyCodeunit
         MyTable: Record MyTable;
     begin
         MyTable.SetRange(MyField1, 'A');
-        MyTable.SetLoadFields(MyTable.MyField2);
+        MyTable.SetLoadFields(MyField2);
         MyTable.FindFirst();
         exit(MyTable.MyField2);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetRangeValueArgIncluded/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SetRangeValueArgIncluded/expected.al
@@ -5,7 +5,7 @@ codeunit 50100 MyCodeunit
         MyTable: Record MyTable;
     begin
         MyTable.SetRange(MyField1, MyTable.MyField2);
-        MyTable.SetLoadFields(MyTable.MyField2);
+        MyTable.SetLoadFields(MyField2);
         MyTable.FindFirst();
     end;
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable.MyField);
+        MyTable.SetLoadFields(MyField);
         MyTable.Get();
         exit(MyTable.MyField);
     end;

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/TestFieldIncluded/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/TestFieldIncluded/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable.MyField1, MyTable.MyField2);
+        MyTable.SetLoadFields(MyField1, MyField2);
         MyTable.FindFirst();
         MyTable.TestField(MyField1, 'Expected');
         exit(MyTable.MyField2);

--- a/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -182,13 +182,10 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
         var arguments = new SeparatedSyntaxList<CodeExpressionSyntax>();
         foreach (var fieldName in fieldNames)
         {
-            var fieldAccess = SyntaxFactory.MemberAccessExpression(
-                SyntaxFactory.IdentifierName(variableName),
-                SyntaxFactory.Token(EnumProvider.SyntaxKind.DotToken),
-                SyntaxFactory.IdentifierName(
-                    SyntaxFactory.Identifier(fieldName.QuoteIdentifierIfNeededWithReflection())));
+            var fieldIdentifier = SyntaxFactory.IdentifierName(
+                SyntaxFactory.Identifier(fieldName.QuoteIdentifierIfNeededWithReflection()));
 
-            arguments = arguments.Add(fieldAccess);
+            arguments = arguments.Add(fieldIdentifier);
         }
 
         var argumentList = SyntaxFactory.ArgumentList(arguments);


### PR DESCRIPTION
## Summary

The PC0030 codefix previously generated qualified field references:
```al
MyTable.SetLoadFields(MyTable.MyField1, MyTable.MyField2);
```

This is redundant. The compiler enforces that fields must belong to the receiver (`memberMustBeOnSame: true` in the SDK). Now generates the unqualified form matching Microsoft's universal practice:
```al
MyTable.SetLoadFields(MyField1, MyField2);
```

## Evidence

| Source | Qualified | Unqualified |
|--------|-----------|-------------|
| BCApps (217 calls) | 0 (0%) | 217 (100%) |
| ALAppExtensions (395 calls) | 0 (0%) | 392 (99.2%)\* |
| Microsoft Docs example | 1 | — |

\*The 3 remaining are `RecordRef.SetLoadFields(Table.FieldNo(...))`, a different pattern.

## Changes

- `UsePartialRecordsOnRead.cs`: Generate `IdentifierName` instead of `MemberAccessExpression` for field arguments
- Updated all 11 HasFix expected test fixtures

All 61 UsePartialRecordsOnRead tests pass.

Closes #282