### PR TITLE
fix(LC0091): false positive on translated report labels

### DIFF
--- a/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
+++ b/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
@@ -127,6 +127,7 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 **HasDiagnosticWithLanguagesToTranslateNoXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK"], no XLIFF files.
 **HasDiagnosticWithLanguagesToTranslatePartialXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK","de-DE"], only da-DK XLIFF.
 **NoDiagnostic (2 cases):** LockedLabel, LockedReportLabel.
+**NoDiagnosticTranslated (1 case):** TranslatedReportLabel (XLIFF contains proper translation with matching trans-unit ID).
 **NoDiagnosticNoXliff (1 case):** No XLIFF files present, no LanguagesToTranslate setting.
 
 ## Test infrastructure

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/TranslatedReportLabel.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/TranslatedReportLabel.al
@@ -1,0 +1,7 @@
+report 50100 MyReport
+{
+    labels
+    {
+        [|MyReportLabel = 'Report Label Text'|];
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -20,6 +20,24 @@ namespace ALCops.LinterCop.Test
             </xliff>
             """);
 
+        private static readonly byte[] TranslatedReportLabelXliffContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file datatype="xml" source-language="en-US" target-language="da-DK" original="TestApp">
+                <body>
+                  <group id="body">
+                    <trans-unit id="Report 2858589782 - ReportLabel 973805576" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>Report Label Text</source>
+                      <target>Berichtsbezeichnungstext</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Report MyReport - ReportLabel MyReportLabel</note>
+                    </trans-unit>
+                  </group>
+                </body>
+              </file>
+            </xliff>
+            """);
+
         private static readonly byte[] SettingsWithDaDK = System.Text.Encoding.UTF8.GetBytes(
             """{"LanguagesToTranslate": ["da-DK"]}""");
 
@@ -93,6 +111,21 @@ namespace ALCops.LinterCop.Test
                 });
         }
 
+        private static AnalyzerTestFixture CreateFixtureWithTranslatedReportLabelXliff()
+        {
+            var files = new Dictionary<string, byte[]>
+            {
+                { "Translations/TestApp.da-DK.xlf", TranslatedReportLabelXliffContent }
+            };
+            var fileSystem = new MemoryFileSystem(files);
+
+            return RoslynFixtureFactory.Create<Analyzers.TranslatableTextShouldBeTranslated>(
+                new AnalyzerTestFixtureConfig
+                {
+                    FileSystem = fileSystem
+                });
+        }
+
         [Test]
         [TestCase("LocalLabel")]
         [TestCase("GlobalLabel")]
@@ -126,6 +159,21 @@ namespace ALCops.LinterCop.Test
                 .ConfigureAwait(false);
 
             var fixture = CreateFixtureWithEmptyXliff();
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("TranslatedReportLabel")]
+        public async Task NoDiagnosticTranslated(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithTranslatedReportLabelXliff();
             fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
         }
 

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -151,7 +151,7 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(symbol);
-        string translationId = LanguageFileUtilities.GetLabelTextConstLanguageSymbolId(symbol, rootSymbol);
+        string translationId = LanguageFileUtilities.GetLanguageSymbolId(symbol, rootSymbol);
 
         ReportMissingTranslation(ctx, symbol, translationId, translationIndex);
     }


### PR DESCRIPTION
## Summary

Fixes #281

LC0091 fired a false positive on report labels even when a proper translation existed in the XLIFF file.

## Root cause

`AnalyzeReportLabel` used `GetLabelTextConstLanguageSymbolId` which generates translation IDs with `SymbolKind.NamedType`. The AL compiler generates XLIFF trans-unit IDs for report labels using `SymbolKind.ReportLabel` (via `GetLanguageSymbolId`).

- Analyzer generated: `"Report {hash} - NamedType {hash}"`
- XLIFF contained: `"Report {hash} - ReportLabel {hash}"`

These never matched, so every translated report label triggered the diagnostic.

## Fix

One-line change: replace `GetLabelTextConstLanguageSymbolId` with `GetLanguageSymbolId` in `AnalyzeReportLabel`.

## Testing

Added `NoDiagnosticTranslated/TranslatedReportLabel` test case with a proper XLIFF containing the correct trans-unit ID. Verified the test fails before the fix and passes after.