### PR TITLE
fix(PC0030): suppress on setup table parameterless Get()

### DIFF
--- a/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
@@ -53,6 +53,7 @@ These decisions were made during the initial design and should be preserved unle
 | In-branch read merge rule | Union (in ANY branch) | Reads added inside a branch are genuinely uncovered on their specific path and should be reported |
 | Record-as-source assignment | Treat same as write op (suppress forward + backward) | `TempMyTable := MyTable` reads all fields; adding SetLoadFields before a preceding read would cause partial copy. Only bare variable references on RHS, not field access. |
 | HasWriteOp renamed | `HasFullRecordAccess` | Flag now covers writes AND whole-record assignments; name reflects expanded semantics |
+| Setup table suppression | Suppress on parameterless `Get()` when table is a setup table | Near-zero SQL benefit for single-record cached tables; MS BaseApp uses SetLoadFields on setup tables in only 1.8% of cases. Heuristic: single PK field, Code type, name matches "Primary Key"/"PrimaryKey" case-insensitive. Uses `TableHelper.IsSetupTable()` from ALCops.Common. Only `Get()` with no arguments suppressed; FindFirst/FindSet on setup tables still fire. See [#283](https://github.com/ALCops/Analyzers/issues/283). |
 
 ## Architecture
 
@@ -183,11 +184,11 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 
 ## Test coverage
 
-62 test cases total:
+65 test cases total:
 
-**HasDiagnostic (18 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, ClearResetsRecordAssignment, LoopNoSetLoadFields.
+**HasDiagnostic (20 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, ClearResetsRecordAssignment, LoopNoSetLoadFields, SetupTableGetWithArgs, SetupTableFindFirst.
 
-**NoDiagnostic (32 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore, FindSetWithModifyInLoop, FindSetWithPassedToFunctionInLoop, GetWithConditionalModify, RecordAssignedToOther, RecordAssignedToOtherQuotedName, RecordAssignedBeforeRead.
+**NoDiagnostic (34 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore, FindSetWithModifyInLoop, FindSetWithPassedToFunctionInLoop, GetWithConditionalModify, RecordAssignedToOther, RecordAssignedToOtherQuotedName, RecordAssignedBeforeRead, SetupTableGet, SetupTableGetNoSpace.
 
 **HasFix (11 cases):** SingleField, MultipleFields, QuotedFieldName, NoFieldAccess, SetRangeFieldExcluded, SetFilterFieldExcluded, SetRangeValueArgIncluded, AllFieldsInFilters, TestFieldIncluded, SetCurrentKeyExcluded, MixedFilterAndConsume.
 

--- a/src/ALCops.ApplicationCop/Analyzers/FieldGroupsRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/FieldGroupsRequired.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
+using ALCops.Common.Helpers;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
@@ -58,19 +59,8 @@ public sealed class FieldGroupsRequired : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsTableOfTypeSetupTable(ITableTypeSymbol table)
-    {
-        // Expect Primary Key to contains only one field
-        if (table.PrimaryKey is null || table.PrimaryKey.Fields.Length != 1)
-            return false;
-
-        // The field should be of type Code
-        if (table.PrimaryKey.Fields[0].GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Code)
-            return false;
-
-        // The field should be exactly (case sensitive) called 'Primary Key'
-        return string.Equals(table.PrimaryKey.Fields[0].Name, "Primary Key", StringComparison.Ordinal);
-    }
+    private static bool IsTableOfTypeSetupTable(ITableTypeSymbol table) =>
+        TableHelper.IsSetupTable(table);
 
     private static bool IsTemporaryTable(ITableTypeSymbol table)
         => table.TableType == EnumProvider.TableTypeKind.Temporary;

--- a/src/ALCops.Common/Helpers/TableHelper.cs
+++ b/src/ALCops.Common/Helpers/TableHelper.cs
@@ -1,0 +1,30 @@
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+
+namespace ALCops.Common.Helpers;
+
+/// <summary>
+/// Helper methods for classifying table types based on structural heuristics.
+/// </summary>
+public static class TableHelper
+{
+    /// <summary>
+    /// Determines whether a table follows the standard BC setup table pattern:
+    /// single primary key field of type Code, named "Primary Key" or "PrimaryKey" (case-insensitive).
+    /// </summary>
+    public static bool IsSetupTable(ITableTypeSymbol table)
+    {
+        if (table.PrimaryKey is null || table.PrimaryKey.Fields.Length != 1)
+            return false;
+
+        var pkField = table.PrimaryKey.Fields[0];
+
+        if (pkField.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Code)
+            return false;
+
+        var name = pkField.Name;
+        return string.Equals(name, "Primary Key", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "PrimaryKey", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearBetweenSetLoadFieldsAndGet.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearBetweenSetLoadFieldsAndGet.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsPassedToFunction.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsPassedToFunction.al
@@ -19,12 +19,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsRecordAssignment.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsRecordAssignment.al
@@ -15,12 +15,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsWriteOp.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ClearResetsWriteOp.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGet.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordGet.al
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordMultipleReads.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LocalRecordMultipleReads.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LoopNoSetLoadFields.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/LoopNoSetLoadFields.al
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ResetBetweenSetLoadFieldsAndGet.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ResetBetweenSetLoadFieldsAndGet.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsAfterGet.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsAfterGet.al
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsNoArgsBetween.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetLoadFieldsNoArgsBetween.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetupTableFindFirst.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetupTableFindFirst.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MySetup: Record MySetup;
+    begin
+        [|MySetup.FindFirst()|];
+        exit(MySetup.MyField);
+    end;
+}
+
+table 50100 MySetup
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetupTableGetWithArgs.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/SetupTableGetWithArgs.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MySetup: Record MySetup;
+    begin
+        [|MySetup.Get('MYKEY')|];
+        exit(MySetup.MyField);
+    end;
+}
+
+table 50100 MySetup
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/current.al
@@ -12,12 +12,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable."Primary Key");
+        MyTable.SetLoadFields(MyTable."No.");
         exit(MyTable.Get());
     end;
 }
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/NoFieldAccess/expected.al
@@ -4,7 +4,7 @@ codeunit 50100 MyCodeunit
     var
         MyTable: Record MyTable;
     begin
-        MyTable.SetLoadFields(MyTable."No.");
+        MyTable.SetLoadFields("No.");
         exit(MyTable.Get());
     end;
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/current.al
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; "My Field Name"; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/QuotedFieldName/expected.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; "My Field Name"; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/current.al
@@ -13,12 +13,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasFix/SingleField/expected.al
@@ -14,12 +14,12 @@ table 50100 MyTable
 {
     fields
     {
-        field(1; "Primary Key"; Code[20]) { }
+        field(1; "No."; Code[20]) { }
         field(2; MyField; Text[100]) { }
     }
 
     keys
     {
-        key(PK; "Primary Key") { }
+        key(PK; "No.") { }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/SetupTableGet.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/SetupTableGet.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MySetup: Record MySetup;
+    begin
+        [|MySetup.Get()|];
+        exit(MySetup.MyField);
+    end;
+}
+
+table 50100 MySetup
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key") { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/SetupTableGetNoSpace.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/SetupTableGetNoSpace.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(): Text
+    var
+        MySetup: Record MySetup;
+    begin
+        [|MySetup.Get()|];
+        exit(MySetup.MyField);
+    end;
+}
+
+table 50100 MySetup
+{
+    fields
+    {
+        field(1; PrimaryKey; Code[20]) { }
+        field(2; MyField; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; PrimaryKey) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -39,6 +39,8 @@ namespace ALCops.PlatformCop.Test
         [TestCase("ClearResetsPassedToFunction")]
         [TestCase("ClearResetsRecordAssignment")]
         [TestCase("LoopNoSetLoadFields")]
+        [TestCase("SetupTableGetWithArgs")]
+        [TestCase("SetupTableFindFirst")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -80,6 +82,8 @@ namespace ALCops.PlatformCop.Test
         [TestCase("RecordAssignedToOther")]
         [TestCase("RecordAssignedToOtherQuotedName")]
         [TestCase("RecordAssignedBeforeRead")]
+        [TestCase("SetupTableGet")]
+        [TestCase("SetupTableGetNoSpace")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using ALCops.Common;
 using ALCops.Common.Extensions;
+using ALCops.Common.Helpers;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
@@ -125,7 +126,10 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             if (IsEligibleVariable(local))
                 result[local.Name] = new VariableState
                 {
-                    IsRecordRef = local.Type?.NavTypeKind == EnumProvider.NavTypeKind.RecordRef
+                    IsRecordRef = local.Type?.NavTypeKind == EnumProvider.NavTypeKind.RecordRef,
+                    IsSetupTable = local.Type is IRecordTypeSymbol recordType
+                        && recordType.OriginalDefinition is ITableTypeSymbol tableType
+                        && TableHelper.IsSetupTable(tableType)
                 };
         }
 
@@ -182,6 +186,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         public List<LoadFieldsInfo> LoadFieldsLocations { get; } = new();
         public HashSet<string> WriteMethodNames { get; } = new(StringComparer.OrdinalIgnoreCase);
         public bool IsRecordRef { get; set; }
+        public bool IsSetupTable { get; set; }
         public List<string?> SetTableTargets { get; } = new();
 
         public bool EverHadLoadFields { get; set; }
@@ -578,7 +583,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             }
 
             if (ReadMethods.Contains(methodName))
-                HandleReadMethod(operation, flowFlags, methodName);
+                HandleReadMethod(operation, state, flowFlags, methodName);
             else if (LoadFieldsMethods.Contains(methodName))
                 HandleLoadFieldsMethod(operation, state, flowFlags, methodName);
             else if (WriteMethods.Contains(methodName))
@@ -591,11 +596,17 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 state.SetTableTargets.Add(GetVariableNameFromArgument(operation.Arguments[0]));
         }
 
-        private static void HandleReadMethod(IInvocationExpression operation, FlowFlags flowFlags, string methodName)
+        private static void HandleReadMethod(IInvocationExpression operation, VariableState state, FlowFlags flowFlags, string methodName)
         {
             // PC0031: a read while HasLoadFields means the record buffer is now partial
             if (flowFlags.HasLoadFields)
                 flowFlags.HasPartialRead = true;
+
+            // Suppress on setup table parameterless Get() - near-zero performance benefit
+            if (state.IsSetupTable
+                && string.Equals(methodName, "Get", StringComparison.OrdinalIgnoreCase)
+                && operation.Arguments.IsEmpty)
+                return;
 
             // Only flag reads where no suppression condition exists.
             // Write/pass AFTER read is handled by retroactive clearing of UncoveredReads.


### PR DESCRIPTION
## Summary

Suppresses PC0030 when a parameterless `Get()` is called on a setup table. Setup tables (single-record configuration tables) gain near-zero benefit from `SetLoadFields`.

## Changes

- **New shared helper**: `ALCops.Common/Helpers/TableHelper.IsSetupTable()` with relaxed heuristic (single Code PK field named "Primary Key" or "PrimaryKey", case-insensitive)
- **PC0030 suppression**: Only when `Get()` has zero arguments AND the table matches the setup table heuristic
- **AC0013 refactor**: Now uses shared `TableHelper.IsSetupTable()` instead of private method
- **Tests**: 4 new test cases (2 NoDiagnostic: SetupTableGet, SetupTableGetNoSpace; 2 HasDiagnostic: SetupTableGetWithArgs, SetupTableFindFirst)

## Rationale

- Microsoft's BaseApp uses `SetLoadFields` on setup tables in only **1.8%** of cases (~54 out of ~2,977)
- [keytogoodcode.com](https://www.keytogoodcode.com/post/who-benefits-from-partial-records-the-true-magic-of-setloadfields) SQL analysis proves near-zero benefit for single-record cached tables
- [alguidelines.dev refactoring guide](https://alguidelines.dev/docs/agentic-coding/gettingmore/refactoring/) shows `SalesSetup.Get()` without SetLoadFields as the correct pattern

Closes #283