### PR TITLE
feat(PC0036): Page.SetRecord() with temporary record

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -270,7 +270,7 @@ private void AnalyzeInvocation(OperationAnalysisContext ctx)
         return;
 
     if (invocation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
-        invocation.TargetMethod.Name != "Commit")
+        !SemanticFacts.IsSameName(invocation.TargetMethod.Name, "Commit"))
         return;
 
     ctx.ReportDiagnostic(Diagnostic.Create(
@@ -670,6 +670,14 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
 - **Never compare raw syntax text to identify symbols.** Do not use `syntax.ToString()`, `node.Identifier.ValueText`, or similar text-based checks to determine what a variable, method, or expression refers to. These are fragile (case-sensitive, whitespace-dependent, miss implicit conversions) and produce incorrect results when the source text doesn't match the canonical symbol name. Instead, resolve the symbol via `IOperation.GetSymbolSafe()`, `SemanticModel.GetSymbolInfo()`, or `SemanticModel.GetDeclaredSymbol()`, then compare using symbol identity (`symbol.Equals(other)`) or symbol properties (`symbol.Kind`, `symbol.Name`). Checking `ISymbol.Name` after resolution is acceptable because it's the compiler-resolved canonical form, not raw source text.
   - **Exception: when you must fall back to syntax text** (e.g., extracting a variable name from `IConversionExpression.Syntax` where `GetSymbol()` returns null), always call `.UnquoteIdentifier()` on the `ValueText` before comparing against symbol names. AL identifiers can be quoted (`"My Table"`), and `ValueText` preserves quotes while `ISymbol.Name` strips them. Missing `UnquoteIdentifier()` causes silent failures on any quoted identifier. The extension is in `Microsoft.Dynamics.Nav.CodeAnalysis.Utilities`.
 - **Use `CancellationToken`** via `ctx.CancellationToken.ThrowIfCancellationRequested()` in loops over large collections (e.g., iterating all fields in a table).
+- **Always use `SemanticFacts.IsSameName()` for AL identifier comparison.** AL is case-insensitive. When comparing method names, field names, object names, or any AL identifiers, use `SemanticFacts.IsSameName(a, b)` from `Microsoft.Dynamics.Nav.CodeAnalysis` instead of `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)`. This makes the intent explicit (AL name comparison) and keeps the codebase consistent. Example:
+  ```csharp
+  // WRONG - generic string comparison
+  if (string.Equals(targetMethod.Name, "SetRecord", StringComparison.OrdinalIgnoreCase))
+
+  // CORRECT - AL-specific name comparison
+  if (SemanticFacts.IsSameName(targetMethod.Name, "SetRecord"))
+  ```
 - **Mark analyzer classes `sealed`** unless there is a specific reason for inheritance.
 - **One analyzer class per rule or tightly related rule group.** The `AnalyzeCountMethod` analyzer handles both `LC0081` (IsEmpty) and `LC0082` (FindWithNext) because they share the same analysis logic.
 - **Use `ImmutableArray.Create()`** for `SupportedDiagnostics`, listing all descriptors the analyzer may report.

--- a/.github/instructions/pc0036-page-variable-setrecord-temporary-record.instructions.md
+++ b/.github/instructions/pc0036-page-variable-setrecord-temporary-record.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/PageVariableSetRecordTemporaryRecord*'
+---
+
+# PC0036: Page SetRecord with temporary record
+
+## Purpose
+
+Detects calls to `Page.SetRecord()` where the record argument is a temporary record. The SDK explicitly states "You cannot use a temporary record for the Record parameter" and such calls will fail at runtime.
+
+## Diagnostic properties
+
+| Property | Value |
+|----------|-------|
+| ID | PC0036 |
+| Category | Usage |
+| Severity | Warning |
+| Enabled by default | Yes |
+| Has CodeFix | No |
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | Only `SetRecord` | SDK only documents restriction for SetRecord; other page methods (GetRecord, SetTableView, SetSelectionFilter) have no documented restriction |
+| TableType = Temporary | Not flagged unless variable has `temporary` keyword | `IRecordTypeSymbol.Temporary` is only true when the variable is declared as temporary |
+| Page.Run/RunModal | Not covered | Strict scope matching original LC0058 intent |
+| Standalone vs embedded in PC0017 | Standalone | ALCops one-concern-per-ID pattern |
+
+## Architecture
+
+- Registers `OperationAction` for `InvocationExpression`
+- Checks: built-in method, name is "SetRecord", containing type is Page, single argument is a conversion from a temporary record
+- Reports with page variable name as `{0}` argument
+
+## Test coverage
+
+**HasDiagnostic (2 cases):** TempVarSetRecord, TempTableTypeSetRecord.
+**NoDiagnostic (3 cases):** NonTempVarSetRecord, TempVarGetRecord, TempTableTypeWithoutKeyword.

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/HasDiagnostic/TempTableTypeSetRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/HasDiagnostic/TempTableTypeSetRecord.al
@@ -1,0 +1,21 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        TempMyTable: Record MyTempTable temporary;
+        MyPage: Page MyPage;
+    begin
+        [|MyPage.SetRecord(TempMyTable)|];
+    end;
+}
+
+page 50100 MyPage { SourceTable = MyTempTable; }
+table 50100 MyTempTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/HasDiagnostic/TempVarSetRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/HasDiagnostic/TempVarSetRecord.al
@@ -1,0 +1,13 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        TempMyTable: Record MyTable temporary;
+        MyPage: Page MyPage;
+    begin
+        [|MyPage.SetRecord(TempMyTable)|];
+    end;
+}
+
+page 50100 MyPage { SourceTable = MyTable; }
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/NonTempVarSetRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/NonTempVarSetRecord.al
@@ -1,0 +1,13 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyPage: Page MyPage;
+    begin
+        [|MyPage.SetRecord(MyTable)|];
+    end;
+}
+
+page 50100 MyPage { SourceTable = MyTable; }
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/TempTableTypeWithoutKeyword.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/TempTableTypeWithoutKeyword.al
@@ -1,0 +1,21 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTempTable: Record MyTempTable;
+        MyPage: Page MyPage;
+    begin
+        [|MyPage.SetRecord(MyTempTable)|];
+    end;
+}
+
+page 50100 MyPage { SourceTable = MyTempTable; }
+table 50100 MyTempTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/TempVarGetRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/NoDiagnostic/TempVarGetRecord.al
@@ -1,0 +1,13 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        TempMyTable: Record MyTable temporary;
+        MyPage: Page MyPage;
+    begin
+        [|MyPage.GetRecord(TempMyTable)|];
+    end;
+}
+
+page 50100 MyPage { SourceTable = MyTable; }
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/PageVariableSetRecordTemporaryRecord.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/PageVariableSetRecordTemporaryRecord/PageVariableSetRecordTemporaryRecord.cs
@@ -1,0 +1,44 @@
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test
+{
+    public class PageVariableSetRecordTemporaryRecord : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.PageVariableSetRecordTemporaryRecord>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(PageVariableSetRecordTemporaryRecord)));
+        }
+
+        [Test]
+        [TestCase("TempVarSetRecord")]
+        [TestCase("TempTableTypeSetRecord")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.PageVariableSetRecordTemporaryRecord);
+        }
+
+        [Test]
+        [TestCase("NonTempVarSetRecord")]
+        [TestCase("TempVarGetRecord")]
+        [TestCase("TempTableTypeWithoutKeyword")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PageVariableSetRecordTemporaryRecord);
+        }
+    }
+}

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -474,4 +474,13 @@
   <data name="UseSetAutoCalcFieldsForLoopsCodeAction" xml:space="preserve">
     <value>ALCops: Use SetAutoCalcFields before loop</value>
   </data>
+  <data name="PageVariableSetRecordTemporaryRecordTitle" xml:space="preserve">
+    <value>SetRecord() does not support temporary records</value>
+  </data>
+  <data name="PageVariableSetRecordTemporaryRecordMessageFormat" xml:space="preserve">
+    <value>{0}.SetRecord(): You cannot use a temporary record for the Record parameter.</value>
+  </data>
+  <data name="PageVariableSetRecordTemporaryRecordDescription" xml:space="preserve">
+    <value>The SetRecord method on a Page variable does not support temporary records. Passing a temporary record to SetRecord will cause a runtime error because Business Central cannot bind a page to a temporary record instance via this method.</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/Analyzers/PageVariableSetRecordTemporaryRecord.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PageVariableSetRecordTemporaryRecord.cs
@@ -1,0 +1,74 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class PageVariableSetRecordTemporaryRecord : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.PageVariableSetRecordTemporaryRecord);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterOperationAction(
+            AnalyzeInvocation,
+            EnumProvider.OperationKind.InvocationExpression);
+
+    private void AnalyzeInvocation(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
+            return;
+
+        var targetMethod = invocation.TargetMethod;
+        if (targetMethod is null || targetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
+            return;
+
+        if (!string.Equals(targetMethod.Name, "SetRecord", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (targetMethod.ContainingType?.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Page)
+            return;
+
+        if (invocation.Arguments.Length != 1)
+            return;
+
+        var recordArgument = invocation.Arguments[0];
+        if (recordArgument.Value is not IConversionExpression conversion)
+            return;
+
+        var operand = conversion.Operand;
+        if (operand?.Type is not IRecordTypeSymbol recordType)
+            return;
+
+        if (!recordType.Temporary)
+            return;
+
+        var pageVariableName = ResolvePageVariableName(invocation);
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.PageVariableSetRecordTemporaryRecord,
+            ctx.Operation.Syntax.GetLocation(),
+            pageVariableName));
+    }
+
+    private static string ResolvePageVariableName(IInvocationExpression invocation)
+    {
+        foreach (var op in invocation.DescendantsAndSelf())
+        {
+            if (op.Type is null || op.Type.GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Page)
+                continue;
+
+            var symbol = op.GetSymbol();
+            if (symbol is null)
+                continue;
+
+            return symbol.ToString() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/ALCops.PlatformCop/Analyzers/PageVariableSetRecordTemporaryRecord.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PageVariableSetRecordTemporaryRecord.cs
@@ -27,7 +27,7 @@ public sealed class PageVariableSetRecordTemporaryRecord : DiagnosticAnalyzer
         if (targetMethod is null || targetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
             return;
 
-        if (!string.Equals(targetMethod.Name, "SetRecord", StringComparison.OrdinalIgnoreCase))
+        if (!SemanticFacts.IsSameName(targetMethod.Name, "SetRecord"))
             return;
 
         if (targetMethod.ContainingType?.GetTypeSymbol().GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Page)

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -345,6 +345,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.UseSetAutoCalcFieldsForLoopsDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseSetAutoCalcFieldsForLoops));
 
+    public static readonly DiagnosticDescriptor PageVariableSetRecordTemporaryRecord = new(
+        id: DiagnosticIds.PageVariableSetRecordTemporaryRecord,
+        title: PlatformCopAnalyzers.PageVariableSetRecordTemporaryRecordTitle,
+        messageFormat: PlatformCopAnalyzers.PageVariableSetRecordTemporaryRecordMessageFormat,
+        category: Category.Usage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.PageVariableSetRecordTemporaryRecordDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.PageVariableSetRecordTemporaryRecord));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -36,4 +36,5 @@ public static class DiagnosticIds
     public static readonly string DuplicateODataEntityName = "PC0033";
     public static readonly string PlaceholderArgumentCountMismatch = "PC0034";
     public static readonly string UseSetAutoCalcFieldsForLoops = "PC0035";
+    public static readonly string PageVariableSetRecordTemporaryRecord = "PC0036";
 }


### PR DESCRIPTION
## Summary

New analyzer **PC0036** (PageVariableSetRecordTemporaryRecord) that detects calls to `Page.SetRecord()` where the record argument is a temporary record.

The Business Central SDK explicitly states: *"You cannot use a temporary record for the Record parameter."* Such calls will cause a runtime error.

## Details

- **Cop:** PlatformCop
- **ID:** PC0036
- **Category:** Usage
- **Severity:** Warning
- **Ported from:** BusinessCentral.LinterCop LC0058

## Changes

- `DiagnosticIds.cs`: Added `PageVariableSetRecordTemporaryRecord = "PC0036"`
- `DiagnosticDescriptors.cs`: Added descriptor (Usage, Warning)
- `ALCops.PlatformCopAnalyzers.resx`: Added Title, MessageFormat, Description
- `Analyzers/PageVariableSetRecordTemporaryRecord.cs`: New analyzer class
- Test fixtures: 2 HasDiagnostic, 3 NoDiagnostic cases
- `.github/instructions/`: Rule instruction file

## Test cases

| Type | Case | Description |
|------|------|-------------|
| HasDiagnostic | TempVarSetRecord | Temp variable passed to SetRecord |
| HasDiagnostic | TempTableTypeSetRecord | Temp variable for TableType=Temporary table |
| NoDiagnostic | NonTempVarSetRecord | Normal record passed to SetRecord |
| NoDiagnostic | TempVarGetRecord | Temp record passed to GetRecord (not flagged) |
| NoDiagnostic | TempTableTypeWithoutKeyword | TableType=Temporary without temporary keyword |
