### PR TITLE
chore: replace OrdinalIgnoreCase with SemanticFacts API for AL identifiers (#292)

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -670,13 +670,37 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
 - **Never compare raw syntax text to identify symbols.** Do not use `syntax.ToString()`, `node.Identifier.ValueText`, or similar text-based checks to determine what a variable, method, or expression refers to. These are fragile (case-sensitive, whitespace-dependent, miss implicit conversions) and produce incorrect results when the source text doesn't match the canonical symbol name. Instead, resolve the symbol via `IOperation.GetSymbolSafe()`, `SemanticModel.GetSymbolInfo()`, or `SemanticModel.GetDeclaredSymbol()`, then compare using symbol identity (`symbol.Equals(other)`) or symbol properties (`symbol.Kind`, `symbol.Name`). Checking `ISymbol.Name` after resolution is acceptable because it's the compiler-resolved canonical form, not raw source text.
   - **Exception: when you must fall back to syntax text** (e.g., extracting a variable name from `IConversionExpression.Syntax` where `GetSymbol()` returns null), always call `.UnquoteIdentifier()` on the `ValueText` before comparing against symbol names. AL identifiers can be quoted (`"My Table"`), and `ValueText` preserves quotes while `ISymbol.Name` strips them. Missing `UnquoteIdentifier()` causes silent failures on any quoted identifier. The extension is in `Microsoft.Dynamics.Nav.CodeAnalysis.Utilities`.
 - **Use `CancellationToken`** via `ctx.CancellationToken.ThrowIfCancellationRequested()` in loops over large collections (e.g., iterating all fields in a table).
-- **Always use `SemanticFacts.IsSameName()` for AL identifier comparison.** AL is case-insensitive. When comparing method names, field names, object names, or any AL identifiers, use `SemanticFacts.IsSameName(a, b)` from `Microsoft.Dynamics.Nav.CodeAnalysis` instead of `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)`. This makes the intent explicit (AL name comparison) and keeps the codebase consistent. Example:
-  ```csharp
-  // WRONG - generic string comparison
-  if (string.Equals(targetMethod.Name, "SetRecord", StringComparison.OrdinalIgnoreCase))
+- **Always use the `SemanticFacts` name comparison API for AL identifiers.** AL is case-insensitive. Use the appropriate `SemanticFacts` member from `Microsoft.Dynamics.Nav.CodeAnalysis` instead of raw `StringComparison.OrdinalIgnoreCase` / `StringComparer.OrdinalIgnoreCase`. This makes intent explicit (AL name comparison) and keeps the codebase consistent with Microsoft's own CodeCops.
 
-  // CORRECT - AL-specific name comparison
+  | Scenario | Use | Instead of |
+  |----------|-----|------------|
+  | Direct equality | `SemanticFacts.IsSameName(a, b)` | `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)` or `a.Equals(b, StringComparison.OrdinalIgnoreCase)` |
+  | Collection comparer | `SemanticFacts.NameEqualityComparer` | `StringComparer.OrdinalIgnoreCase` in HashSet/Dictionary/ImmutableHashSet/GroupBy/ToLookup |
+  | Substring/prefix/suffix | `SemanticFacts.NameEqualityComparison` | `StringComparison.OrdinalIgnoreCase` in StartsWith/EndsWith/Contains/IndexOf |
+  | Sorting | `SemanticFacts.NameComparer` | `StringComparer.OrdinalIgnoreCase` in OrderBy/Sort |
+
+  **When NOT to use SemanticFacts (keep OrdinalIgnoreCase):**
+  - Property value comparisons (enum values like "Always", "Never", "#All")
+  - File path or assembly location comparisons
+  - Non-AL text (diagnostic IDs, translation keys, manifest metadata, punctuation)
+  - User-configured strings (affix lists from alcops.json settings)
+  - Permission character strings (e.g., searching "RIMD" for a permission char)
+
+  ```csharp
+  // Direct equality - comparing AL method name
   if (SemanticFacts.IsSameName(targetMethod.Name, "SetRecord"))
+
+  // Collection of AL method names
+  private static readonly HashSet<string> Methods = new(SemanticFacts.NameEqualityComparer)
+  {
+      "Find", "FindFirst", "FindLast", "FindSet"
+  };
+
+  // Substring check on AL identifier name
+  if (field.Name.Contains("no", SemanticFacts.NameEqualityComparison))
+
+  // Sorting AL identifier names
+  fields.Sort(SemanticFacts.NameComparer);
   ```
 - **Mark analyzer classes `sealed`** unless there is a specific reason for inheritance.
 - **One analyzer class per rule or tightly related rule group.** The `AnalyzeCountMethod` analyzer handles both `LC0081` (IsEmpty) and `LC0082` (FindWithNext) because they share the same analysis logic.

--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -674,10 +674,13 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
 
   | Scenario | Use | Instead of |
   |----------|-----|------------|
-  | Direct equality | `SemanticFacts.IsSameName(a, b)` | `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)` or `a.Equals(b, StringComparison.OrdinalIgnoreCase)` |
+  | Direct equality (non-null) | `SemanticFacts.IsSameName(a, b)` | `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)` or `a.Equals(b, StringComparison.OrdinalIgnoreCase)` |
+  | Direct equality (nullable) | `a.IsSameName(b)` (extension from `ALCops.Common.Extensions`) | `is { } x && SemanticFacts.IsSameName(x, ...)` null-guard pattern |
   | Collection comparer | `SemanticFacts.NameEqualityComparer` | `StringComparer.OrdinalIgnoreCase` in HashSet/Dictionary/ImmutableHashSet/GroupBy/ToLookup |
   | Substring/prefix/suffix | `SemanticFacts.NameEqualityComparison` | `StringComparison.OrdinalIgnoreCase` in StartsWith/EndsWith/Contains/IndexOf |
   | Sorting | `SemanticFacts.NameComparer` | `StringComparer.OrdinalIgnoreCase` in OrderBy/Sort |
+
+  **Nullable inputs:** When comparing values from `SyntaxToken.ValueText` (which is `string?`), use the `IsSameName` extension method from `ALCops.Common.Extensions.StringExtensions`. It returns `false` when either argument is null, avoiding the verbose `is { } varName &&` pattern.
 
   **When NOT to use SemanticFacts (keep OrdinalIgnoreCase):**
   - Property value comparisons (enum values like "Always", "Never", "#All")
@@ -687,8 +690,11 @@ private static bool SameApplicationObject(ISymbol? source, ISymbol? target)
   - Permission character strings (e.g., searching "RIMD" for a permission char)
 
   ```csharp
-  // Direct equality - comparing AL method name
+  // Direct equality - comparing AL method name (both non-null)
   if (SemanticFacts.IsSameName(targetMethod.Name, "SetRecord"))
+
+  // Direct equality - nullable source (e.g. SyntaxToken.ValueText)
+  if (attr.Name.Identifier.ValueText.IsSameName("IntegrationEvent"))
 
   // Collection of AL method names
   private static readonly HashSet<string> Methods = new(SemanticFacts.NameEqualityComparer)

--- a/.github/instructions/codefix-development.instructions.md
+++ b/.github/instructions/codefix-development.instructions.md
@@ -494,6 +494,20 @@ See `testing.instructions.md` for the full testing guide. CodeFix-specific detai
 - `fixture.TestCodeFix()` verifies the transformation from current to expected code
 - Test cases live in `HasFix/<TestCaseName>/` with `current.al` (with `[|...|]` marker) and `expected.al`
 
+## AL name comparisons in CodeFixes
+
+When comparing AL identifiers (method names, property names, object names, variable names, namespaces) in CodeFix code, use the `SemanticFacts` API family. See `analyzer-development.instructions.md` for the full reference table. Quick summary:
+
+```csharp
+// Direct equality
+if (SemanticFacts.IsSameName(expression.GetNameStringValue(), "RunModal"))
+
+// Collection of AL names
+private static readonly HashSet<string> Methods = new(SemanticFacts.NameEqualityComparer) { "Get", "Set" };
+```
+
+Do NOT use `SemanticFacts` for property value text, file paths, or non-AL strings.
+
 ## Reference implementations by pattern
 
 When writing a new CodeFix, find an existing one that uses the same technique. Use `ls src/*/CodeFixes/` to discover all CodeFix files.

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -417,7 +417,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
         {
             var name = ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier();
-            return name is not null && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+            return name is not null && SemanticFacts.IsSameName(name, table.Name);
         }
 
         if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
@@ -437,8 +437,8 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
                 return false;
 
             var tableNamespace = table.OriginalDefinition.GetContainingNamespaceQualifiedNameWithReflection();
-            return qualifier.Equals(tableNamespace, StringComparison.OrdinalIgnoreCase)
-                && name.Equals(table.Name, StringComparison.OrdinalIgnoreCase);
+            return tableNamespace is not null && SemanticFacts.IsSameName(qualifier, tableNamespace)
+                && SemanticFacts.IsSameName(name, table.Name);
         }
 
         return false;

--- a/src/ALCops.ApplicationCop/CodeFixes/GlobalLanguageImplementTranslationHelper.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/GlobalLanguageImplementTranslationHelper.cs
@@ -242,7 +242,7 @@ public sealed class GlobalLanguageImplementTranslationHelperCodeFixProvider : Co
             return false;
 
         // Check if matches "Translation Helper"
-        return string.Equals(GetSubtypeName(typeReference.DataType), TranslationHelperCodeunitName, StringComparison.OrdinalIgnoreCase);
+        return GetSubtypeName(typeReference.DataType) is { } subtypeName && SemanticFacts.IsSameName(subtypeName, TranslationHelperCodeunitName);
     }
 
     private static string? GetSubtypeName(DataTypeSyntax dataType)

--- a/src/ALCops.ApplicationCop/CodeFixes/GlobalLanguageImplementTranslationHelper.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/GlobalLanguageImplementTranslationHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 
 namespace ALCops.ApplicationCop.CodeFixes;
@@ -242,7 +243,7 @@ public sealed class GlobalLanguageImplementTranslationHelperCodeFixProvider : Co
             return false;
 
         // Check if matches "Translation Helper"
-        return GetSubtypeName(typeReference.DataType) is { } subtypeName && SemanticFacts.IsSameName(subtypeName, TranslationHelperCodeunitName);
+        return GetSubtypeName(typeReference.DataType).IsSameName(TranslationHelperCodeunitName);
     }
 
     private static string? GetSubtypeName(DataTypeSyntax dataType)

--- a/src/ALCops.ApplicationCop/CodeFixes/InstallAndUpgradeCodeunitsShouldBeInternal.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/InstallAndUpgradeCodeunitsShouldBeInternal.cs
@@ -82,10 +82,7 @@ public sealed class InstallAndUpgradeCodeunitsShouldBeInternalCodeFixProvider : 
 
         var existingAccessProperty = properties
                                         .OfType<PropertySyntax>()
-                                        .FirstOrDefault(p => string.Equals(
-                                                                p.Name?.Identifier.ValueText,
-                                                                AccessPropertyName,
-                                                                StringComparison.OrdinalIgnoreCase));
+                                        .FirstOrDefault(p => p.Name?.Identifier.ValueText is { } nameText && SemanticFacts.IsSameName(nameText, AccessPropertyName));
 
         PropertyListSyntax newPropertyList;
         if (existingAccessProperty is not null)

--- a/src/ALCops.ApplicationCop/CodeFixes/InstallAndUpgradeCodeunitsShouldBeInternal.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/InstallAndUpgradeCodeunitsShouldBeInternal.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
@@ -82,7 +83,7 @@ public sealed class InstallAndUpgradeCodeunitsShouldBeInternalCodeFixProvider : 
 
         var existingAccessProperty = properties
                                         .OfType<PropertySyntax>()
-                                        .FirstOrDefault(p => p.Name?.Identifier.ValueText is { } nameText && SemanticFacts.IsSameName(nameText, AccessPropertyName));
+                                        .FirstOrDefault(p => p.Name?.Identifier.ValueText.IsSameName(AccessPropertyName) == true);
 
         PropertyListSyntax newPropertyList;
         if (existingAccessProperty is not null)

--- a/src/ALCops.ApplicationCop/CodeFixes/IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs
@@ -72,7 +72,7 @@ public sealed class IntegrationEventInInternalCodeunitConvertToInternalEventFixP
         MemberAttributeSyntax? attribute =
             methodDeclaration.Attributes.FirstOrDefault(attr =>
                 attr.Name is IdentifierNameSyntax name &&
-                string.Equals(name.Identifier.ValueText, IntegrationEventAttributeName, StringComparison.OrdinalIgnoreCase));
+                name.Identifier.ValueText is { } attrName && SemanticFacts.IsSameName(attrName, IntegrationEventAttributeName));
 
         if (attribute is null)
             return document;

--- a/src/ALCops.ApplicationCop/CodeFixes/IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/IntegrationEventsInInternalCodeunitConvertToInternalEvent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
@@ -72,7 +73,7 @@ public sealed class IntegrationEventInInternalCodeunitConvertToInternalEventFixP
         MemberAttributeSyntax? attribute =
             methodDeclaration.Attributes.FirstOrDefault(attr =>
                 attr.Name is IdentifierNameSyntax name &&
-                name.Identifier.ValueText is { } attrName && SemanticFacts.IsSameName(attrName, IntegrationEventAttributeName));
+                name.Identifier.ValueText.IsSameName(IntegrationEventAttributeName));
 
         if (attribute is null)
             return document;

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -6,6 +6,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 
 namespace ALCops.ApplicationCop.CodeFixes;
@@ -90,7 +91,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
         if (originalInvocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             return document;
 
-        var runModel = originalInvocation.Expression.GetNameStringValue() is { } exprName && SemanticFacts.IsSameName(exprName, "RunModal");
+        var runModel = originalInvocation.Expression.GetNameStringValue().IsSameName("RunModal");
         var methodName = GetMethodNameForPageManagement(originalInvocation, runModel);
 
         // Track nodes across edits so we always operate on nodes from the current tree
@@ -245,7 +246,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
             return false;
 
         // Check if matches "Page Management"
-        return GetSubtypeName(typeReference.DataType) is { } subtypeName && SemanticFacts.IsSameName(subtypeName, PageManagementCodeunitName);
+        return GetSubtypeName(typeReference.DataType).IsSameName(PageManagementCodeunitName);
     }
 
     private static string? GetSubtypeName(DataTypeSyntax dataType)
@@ -390,7 +391,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
         var namespaceText = namespaceName;
         for (int i = 0; i < compilationUnit.Usings.Count; i++)
         {
-            if (compilationUnit.Usings[i].Name?.ToString() is { } usingName && SemanticFacts.IsSameName(usingName, namespaceText))
+            if (compilationUnit.Usings[i].Name?.ToString().IsSameName(namespaceText) == true)
                 return root;
         }
 

--- a/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/RunPageImplementPageManagement.cs
@@ -90,7 +90,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
         if (originalInvocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             return document;
 
-        var runModel = string.Equals(originalInvocation.Expression.GetNameStringValue(), "RunModal", StringComparison.OrdinalIgnoreCase);
+        var runModel = originalInvocation.Expression.GetNameStringValue() is { } exprName && SemanticFacts.IsSameName(exprName, "RunModal");
         var methodName = GetMethodNameForPageManagement(originalInvocation, runModel);
 
         // Track nodes across edits so we always operate on nodes from the current tree
@@ -245,7 +245,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
             return false;
 
         // Check if matches "Page Management"
-        return string.Equals(GetSubtypeName(typeReference.DataType), PageManagementCodeunitName, StringComparison.OrdinalIgnoreCase);
+        return GetSubtypeName(typeReference.DataType) is { } subtypeName && SemanticFacts.IsSameName(subtypeName, PageManagementCodeunitName);
     }
 
     private static string? GetSubtypeName(DataTypeSyntax dataType)
@@ -390,7 +390,7 @@ public sealed class RunPageImplementPageManagementCodeFixProvider : CodeFixProvi
         var namespaceText = namespaceName;
         for (int i = 0; i < compilationUnit.Usings.Count; i++)
         {
-            if (string.Equals(compilationUnit.Usings[i].Name?.ToString(), namespaceText, StringComparison.OrdinalIgnoreCase))
+            if (compilationUnit.Usings[i].Name?.ToString() is { } usingName && SemanticFacts.IsSameName(usingName, namespaceText))
                 return root;
         }
 

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Permissions;
+using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
@@ -194,7 +195,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
             if (node is ObjectSyntax obj
                 && obj is not ApplicationObjectExtensionSyntax
                 && obj.Kind == identity.Kind
-                && obj.Name?.Identifier.ValueText is { } objName && identity.Name is { } idName && SemanticFacts.IsSameName(objName, idName))
+                && obj.Name?.Identifier.ValueText.IsSameName(identity.Name) == true)
             {
                 return obj;
             }

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -194,7 +194,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
             if (node is ObjectSyntax obj
                 && obj is not ApplicationObjectExtensionSyntax
                 && obj.Kind == identity.Kind
-                && string.Equals(obj.Name?.Identifier.ValueText, identity.Name, StringComparison.OrdinalIgnoreCase))
+                && obj.Name?.Identifier.ValueText is { } objName && identity.Name is { } idName && SemanticFacts.IsSameName(objName, idName))
             {
                 return obj;
             }
@@ -294,7 +294,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         return propertyList.Properties
             .OfType<PropertySyntax>()
             .FirstOrDefault(p => p.Name is { Identifier.ValueText: { } valueText } &&
-                valueText.Equals(nameof(PropertyKind.Permissions), StringComparison.OrdinalIgnoreCase));
+                SemanticFacts.IsSameName(valueText, nameof(PropertyKind.Permissions)));
     }
 
     private static string ResolveTableNameForFix(string tableName, string tableNamespace,

--- a/src/ALCops.Common/Extensions/StringExtensions.cs
+++ b/src/ALCops.Common/Extensions/StringExtensions.cs
@@ -2,10 +2,21 @@
 using ALCops.Common.Reflection;
 #endif
 
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+
 namespace ALCops.Common.Extensions;
 
 public static class StringExtensions
 {
+    /// <summary>
+    /// Null-tolerant wrapper around <see cref="SemanticFacts.IsSameName(string, string)"/>.
+    /// Returns <c>false</c> when either argument is <c>null</c>.
+    /// Use for AL identifier comparisons where the source value may be nullable
+    /// (e.g. <c>SyntaxToken.ValueText</c>).
+    /// </summary>
+    public static bool IsSameName(this string? nameA, string? nameB)
+        => nameA is not null && nameB is not null && SemanticFacts.IsSameName(nameA, nameB);
+
     /// <summary>
     /// Quotes the identifier if needed.
     /// COMPAT(netstandard2.1, net8.0): Uses reflection to handle breaking changes

--- a/src/ALCops.Common/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ALCops.Common/Extensions/SyntaxNodeExtensions.cs
@@ -119,7 +119,7 @@ public static class SyntaxNodeExtensions
     {
         foreach (var entry in list.ChildNodes().OfType<IdentifierEqualsLiteralSyntax>())
         {
-            if (string.Equals(entry.Identifier.ValueText, propertyName, StringComparison.OrdinalIgnoreCase))
+            if (entry.Identifier.ValueText is { } valueText && SemanticFacts.IsSameName(valueText, propertyName))
                 return entry;
         }
 

--- a/src/ALCops.Common/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ALCops.Common/Extensions/SyntaxNodeExtensions.cs
@@ -119,7 +119,7 @@ public static class SyntaxNodeExtensions
     {
         foreach (var entry in list.ChildNodes().OfType<IdentifierEqualsLiteralSyntax>())
         {
-            if (entry.Identifier.ValueText is { } valueText && SemanticFacts.IsSameName(valueText, propertyName))
+            if (entry.Identifier.ValueText.IsSameName(propertyName))
                 return entry;
         }
 

--- a/src/ALCops.Common/Helpers/TableHelper.cs
+++ b/src/ALCops.Common/Helpers/TableHelper.cs
@@ -24,7 +24,7 @@ public static class TableHelper
             return false;
 
         var name = pkField.Name;
-        return string.Equals(name, "Primary Key", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "PrimaryKey", StringComparison.OrdinalIgnoreCase);
+        return SemanticFacts.IsSameName(name, "Primary Key")
+            || SemanticFacts.IsSameName(name, "PrimaryKey");
     }
 }

--- a/src/ALCops.Common/Permissions/MethodOperationMap.cs
+++ b/src/ALCops.Common/Permissions/MethodOperationMap.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 
 namespace ALCops.Common.Permissions;
 
@@ -9,7 +10,7 @@ public static class MethodOperationMap
 {
     private static readonly ImmutableDictionary<string, DatabaseOperation> Map =
         ImmutableDictionary.CreateRange(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             [
                 // Read operations
                 new KeyValuePair<string, DatabaseOperation>("Find", DatabaseOperation.Read),

--- a/src/ALCops.Common/Permissions/PermissionResolver.cs
+++ b/src/ALCops.Common/Permissions/PermissionResolver.cs
@@ -151,16 +151,16 @@ public static class PermissionResolver
     private static bool IsTableNameMatch(string declaredName, ITypeSymbol variableType)
     {
         // Match by simple name
-        if (declaredName.Equals(variableType.Name, StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(declaredName, variableType.Name))
             return true;
 
         // Match by unquoted simple name
-        if (declaredName.UnquoteIdentifier().Equals(variableType.Name, StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(declaredName.UnquoteIdentifier(), variableType.Name))
             return true;
 
         // Match by fully qualified name (namespace.name)
         var qualifiedName = variableType.GetFullyQualifiedObjectName();
-        if (declaredName.UnquoteIdentifier().Equals(qualifiedName, StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(declaredName.UnquoteIdentifier(), qualifiedName))
             return true;
 
         return false;
@@ -208,7 +208,7 @@ public static class PermissionResolver
         if (identifier.Kind == EnumProvider.SyntaxKind.IdentifierName)
         {
             var name = ((IdentifierNameSyntax)identifier).Identifier.ValueText?.UnquoteIdentifier();
-            return name is not null && name.Equals(variableType.Name, StringComparison.OrdinalIgnoreCase);
+            return name is not null && SemanticFacts.IsSameName(name, variableType.Name);
         }
 
         if (identifier.Kind == EnumProvider.SyntaxKind.ObjectId)
@@ -229,8 +229,8 @@ public static class PermissionResolver
 
             // Match namespace.name against the variable's fully qualified name
             var variableNamespace = variableType.OriginalDefinition.GetContainingNamespaceQualifiedNameWithReflection();
-            return qualifier.Equals(variableNamespace, StringComparison.OrdinalIgnoreCase)
-                && name.Equals(variableType.Name, StringComparison.OrdinalIgnoreCase);
+            return variableNamespace is not null && SemanticFacts.IsSameName(qualifier, variableNamespace)
+                && SemanticFacts.IsSameName(name, variableType.Name);
         }
 
         return false;

--- a/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
+++ b/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
@@ -1,4 +1,5 @@
 using ALCops.Common.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace ALCops.Common.Permissions;
@@ -20,10 +21,10 @@ public static class PermissionTableNameResolver
         if (string.IsNullOrEmpty(tableNamespace))
             return tableName.QuoteIdentifierIfNeededWithReflection();
 
-        if (string.Equals(tableNamespace, containingNamespace, StringComparison.OrdinalIgnoreCase))
+        if (containingNamespace is not null && SemanticFacts.IsSameName(tableNamespace, containingNamespace))
             return tableName.QuoteIdentifierIfNeededWithReflection();
 
-        if (importedNamespaces.Any(ns => string.Equals(ns, tableNamespace, StringComparison.OrdinalIgnoreCase)))
+        if (importedNamespaces.Any(ns => SemanticFacts.IsSameName(ns, tableNamespace)))
             return tableName.QuoteIdentifierIfNeededWithReflection();
 
         return $"{tableNamespace}.{tableName.QuoteIdentifierIfNeededWithReflection()}";

--- a/src/ALCops.Common/RecordMethodClassification.cs
+++ b/src/ALCops.Common/RecordMethodClassification.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Permissions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 
 namespace ALCops.Common;
 
@@ -17,7 +18,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> ReadMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Find", "FindFirst", "FindLast", "FindSet",
             "Get", "GetBySystemId",
             "IsEmpty", "Count");
@@ -28,7 +29,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> SingleRecordReadMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Find", "FindFirst", "FindLast",
             "Get", "GetBySystemId");
 
@@ -37,7 +38,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> InsertMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Insert");
 
     /// <summary>
@@ -45,7 +46,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> ModifyMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Modify", "ModifyAll", "Rename");
 
     /// <summary>
@@ -53,7 +54,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> DeleteMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Delete", "DeleteAll");
 
     /// <summary>
@@ -62,7 +63,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> WriteMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll",
             "Rename", "TransferFields", "Init", "Copy");
 
@@ -71,7 +72,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> LoadFieldsMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "SetLoadFields", "AddLoadFields", "SetBaseLoadFields");
 
     /// <summary>
@@ -83,7 +84,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> JitLoadWriteMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Insert", "Delete", "Rename", "TransferFields", "Copy");
 
     /// <summary>
@@ -91,7 +92,7 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> TriggerMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Insert", "Modify", "Delete", "DeleteAll", "Validate", "ModifyAll");
 
     /// <summary>
@@ -99,6 +100,6 @@ public static class RecordMethodClassification
     /// </summary>
     public static ImmutableHashSet<string> RunTriggerParameterMethods { get; } =
         ImmutableHashSet.Create(
-            StringComparer.OrdinalIgnoreCase,
+            SemanticFacts.NameEqualityComparer,
             "Insert", "Modify", "ModifyAll", "Delete", "DeleteAll");
 }

--- a/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
+++ b/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Immutable;
 using System.Reflection;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
@@ -265,7 +266,7 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
             parentKind == EnumProvider.SyntaxKind.UnaryNotExpression)
             return false;
 
-        if (idName.Identifier.ValueText is { } valueText && SemanticFacts.IsSameName(valueText, "Rec"))
+        if (idName.Identifier.ValueText.IsSameName("Rec"))
             return false;
 
         if (idName.Parent?.Parent is PermissionSyntax permissionSyntax &&
@@ -325,9 +326,9 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
                 break;
 
             case CommaSeparatedPropertyValueSyntax when
-                 prop.Name.Identifier.ValueText is { } propNameAA && SemanticFacts.IsSameName(propNameAA, "ApplicationArea"):
+                 prop.Name.Identifier.ValueText.IsSameName("ApplicationArea"):
             case CommaSeparatedIdentifierOrLiteralPropertyValueSyntax when
-                 prop.Name.Identifier.ValueText is { } propNameVA && SemanticFacts.IsSameName(propNameVA, "ValuesAllowed"):
+                 prop.Name.Identifier.ValueText.IsSameName("ValuesAllowed"):
             case ImagePropertyValueSyntax:
             case StringPropertyValueSyntax:
             case OptionValuePropertyValueSyntax:

--- a/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
+++ b/src/ALCops.FormattingCop/Analyzers/CasingMismatchIdentifier.cs
@@ -265,7 +265,7 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
             parentKind == EnumProvider.SyntaxKind.UnaryNotExpression)
             return false;
 
-        if (string.Equals(idName.Identifier.ValueText, "Rec", StringComparison.OrdinalIgnoreCase))
+        if (idName.Identifier.ValueText is { } valueText && SemanticFacts.IsSameName(valueText, "Rec"))
             return false;
 
         if (idName.Parent?.Parent is PermissionSyntax permissionSyntax &&
@@ -325,9 +325,9 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
                 break;
 
             case CommaSeparatedPropertyValueSyntax when
-                 string.Equals(prop.Name.Identifier.ValueText, "ApplicationArea", StringComparison.OrdinalIgnoreCase):
+                 prop.Name.Identifier.ValueText is { } propNameAA && SemanticFacts.IsSameName(propNameAA, "ApplicationArea"):
             case CommaSeparatedIdentifierOrLiteralPropertyValueSyntax when
-                 string.Equals(prop.Name.Identifier.ValueText, "ValuesAllowed", StringComparison.OrdinalIgnoreCase):
+                 prop.Name.Identifier.ValueText is { } propNameVA && SemanticFacts.IsSameName(propNameVA, "ValuesAllowed"):
             case ImagePropertyValueSyntax:
             case StringPropertyValueSyntax:
             case OptionValuePropertyValueSyntax:
@@ -414,7 +414,7 @@ public sealed class CasingMismatchIdentifier : DiagnosticAnalyzer
 
             if (symbolKindDict.ContainsKey(nameText))
             {
-                var memberDict = string.Equals(expressionText, "ObjectType", StringComparison.OrdinalIgnoreCase)
+                var memberDict = SemanticFacts.IsSameName(expressionText, "ObjectType")
                     ? _objectTypeMemberDictionary
                     : _symbolKindDictionary;
                 CompareAgainstDictionary(ctx, name.Identifier, memberDict);

--- a/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
+++ b/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
@@ -123,7 +123,7 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
 
     private static bool IsEligibleUseQueryOrFindWithNext(IRecordTypeSymbol record)
     {
-        if (possibleLargeTableIdentifierKeywords.Any(keyword => record.Name.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0))
+        if (possibleLargeTableIdentifierKeywords.Any(keyword => record.Name.IndexOf(keyword, SemanticFacts.NameEqualityComparison) >= 0))
             return true;
 
         // Tables with a field "Entry No." could possible have a large amount of records

--- a/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
+++ b/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
@@ -128,7 +128,7 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
 
         // Tables with a field "Entry No." could possible have a large amount of records
         if (record.OriginalDefinition is ITableTypeSymbol table)
-            return table.PrimaryKey.Fields.Any(field => string.Equals(field.Name, "Entry No.", StringComparison.OrdinalIgnoreCase));
+            return table.PrimaryKey.Fields.Any(field => SemanticFacts.IsSameName(field.Name, "Entry No."));
 
         return false;
     }

--- a/src/ALCops.LinterCop/Analyzers/ApiPageCanonicalFieldNameGuide.cs
+++ b/src/ALCops.LinterCop/Analyzers/ApiPageCanonicalFieldNameGuide.cs
@@ -62,8 +62,8 @@ public sealed class ApiPageCanonicalFieldNameGuide : DiagnosticAnalyzer
             return DescriptiveNames[field.RelatedFieldSymbol.Name];
 
         if (field.RelatedFieldSymbol.Name.Contains("No.")
-                && field.Name.Contains("no", StringComparison.OrdinalIgnoreCase)
-                && !field.Name.Contains("number", StringComparison.OrdinalIgnoreCase))
+                && field.Name.Contains("no", SemanticFacts.NameEqualityComparison)
+                && !field.Name.Contains("number", SemanticFacts.NameEqualityComparison))
             return ReplaceNoWithNumber(field.Name);
 
         return null;

--- a/src/ALCops.LinterCop/Analyzers/CognitiveComplexity.cs
+++ b/src/ALCops.LinterCop/Analyzers/CognitiveComplexity.cs
@@ -45,7 +45,7 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
 
     // This HashSet defines specific identifiers that, in certain cases, restrict whether a statement qualifies as a guard clause.
     // Some exit commands (e.g., "Break", "Skip", "Quit") are only considered guard clauses if they are called on these identifiers.
-    private static readonly HashSet<string> guardClauseIdentifiers = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> guardClauseIdentifiers = new(SemanticFacts.NameEqualityComparer)
     {
         "CurrReport",
         "CurrXMLport"
@@ -54,7 +54,7 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
     // This HashSet defines commands that act as guard clause exits, meaning they immediately alter the flow of execution.
     // These commands are typically used in scenarios where a function, loop, or process needs to be stopped or skipped under certain conditions.
     // However, "Exit" is not included in this set, as we can get the ExitStatementSyntax type directly on the Statement of the IfStatementSyntax
-    private static readonly HashSet<string> guardClauseExitCommands = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> guardClauseExitCommands = new(SemanticFacts.NameEqualityComparer)
     {
         "Break",
         "Continue",
@@ -63,7 +63,7 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
         "Skip"
     };
 
-    private static readonly HashSet<string> eventPublisherDecoratorNames = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> eventPublisherDecoratorNames = new(SemanticFacts.NameEqualityComparer)
     {
         "BusinessEvent",
         "IntegrationEvent",

--- a/src/ALCops.LinterCop/Analyzers/CyclomaticComplexityAndMaintainabilityIndex.cs
+++ b/src/ALCops.LinterCop/Analyzers/CyclomaticComplexityAndMaintainabilityIndex.cs
@@ -11,7 +11,7 @@ namespace ALCops.LinterCop.Analyzers;
 [DiagnosticAnalyzer]
 public sealed class CyclomaticComplexityAndMaintainabilityIndex : DiagnosticAnalyzer
 {
-    private static readonly HashSet<string> EventPublisherDecoratorNames = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> EventPublisherDecoratorNames = new(SemanticFacts.NameEqualityComparer)
     {
         "BusinessEvent",
         "IntegrationEvent",

--- a/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
+++ b/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
@@ -42,7 +42,7 @@ public sealed class ExplicitlySetRunTrigger : DiagnosticAnalyzer
 
         foreach (var arg in invocation.Arguments)
         {
-            if (string.Equals(arg.Parameter.Name, RunTriggerParameterName, StringComparison.OrdinalIgnoreCase))
+            if (SemanticFacts.IsSameName(arg.Parameter.Name, RunTriggerParameterName))
                 return;
         }
 

--- a/src/ALCops.LinterCop/Analyzers/InterfaceObjectNameGuide.cs
+++ b/src/ALCops.LinterCop/Analyzers/InterfaceObjectNameGuide.cs
@@ -96,7 +96,7 @@ public sealed class InterfaceObjectNameGuide : DiagnosticAnalyzer
     {
         foreach (var affix in Affixes ?? Enumerable.Empty<string>())
         {
-            if (typeSymbolName.StartsWith(affix, StringComparison.OrdinalIgnoreCase))
+            if (typeSymbolName.StartsWith(affix, SemanticFacts.NameEqualityComparison))
             {
                 int affixLength = affix.Length;
                 if (typeSymbolName.Length > affixLength)

--- a/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
+++ b/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
@@ -374,13 +374,13 @@ public sealed class NamingPattern : DiagnosticAnalyzer
 
         foreach (var affix in affixes)
         {
-            if (name.StartsWith(affix, StringComparison.OrdinalIgnoreCase) &&
+            if (name.StartsWith(affix, SemanticFacts.NameEqualityComparison) &&
                 name.Length > affix.Length)
             {
                 return name.Substring(affix.Length).TrimStart();
             }
 
-            if (name.EndsWith(affix, StringComparison.OrdinalIgnoreCase) &&
+            if (name.EndsWith(affix, SemanticFacts.NameEqualityComparison) &&
                 name.Length > affix.Length)
             {
                 return name.Substring(0, name.Length - affix.Length).TrimEnd();

--- a/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
+++ b/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
@@ -524,7 +524,7 @@ public sealed class NamingPattern : DiagnosticAnalyzer
             var targetName = target.ToString();
             foreach (var kvp in overrides)
             {
-                if (string.Equals(kvp.Key, targetName, StringComparison.OrdinalIgnoreCase))
+                if (SemanticFacts.IsSameName(kvp.Key, targetName))
                 {
                     setting = kvp.Value;
                     return true;

--- a/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
+++ b/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
@@ -286,7 +286,7 @@ public sealed class ObjectIdInDeclaration : DiagnosticAnalyzer
 
     private static ImmutableDictionary<string, string> GenerateSymbolKindDictionary()
     {
-        var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+        var builder = ImmutableDictionary.CreateBuilder<string, string>(SemanticFacts.NameEqualityComparer);
 
         foreach (var kind in Enum.GetNames(typeof(SymbolKind)))
         {

--- a/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
+++ b/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
@@ -120,12 +120,12 @@ public sealed class ObjectIdInDeclaration : DiagnosticAnalyzer
 
         var symbolKindText = symbolKindAsText.ToString();
         // Special treatment for RecordRef where we only want to analyze Open method calls
-        if (string.Equals(symbolKindText, "RecordRef", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(targetMethod.Name, "Open", StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(symbolKindText, "RecordRef") &&
+            !SemanticFacts.IsSameName(targetMethod.Name, "Open"))
             return;
 
         // Map RecordRef to Table Data Type
-        if (string.Equals(symbolKindText, "RecordRef", StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(symbolKindText, "RecordRef"))
             symbolKindText = "Table";
 
         if (!Enum.TryParse(symbolKindText, ignoreCase: true, out SymbolKind symbolKind))

--- a/src/ALCops.LinterCop/Analyzers/RecordInstanceIsolationLevel.cs
+++ b/src/ALCops.LinterCop/Analyzers/RecordInstanceIsolationLevel.cs
@@ -26,7 +26,7 @@ public sealed class RecordInstanceIsolationLevel : DiagnosticAnalyzer
             return;
 
         if (operation.TargetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
-            !string.Equals(operation.TargetMethod.Name, "LockTable", StringComparison.OrdinalIgnoreCase))
+            !SemanticFacts.IsSameName(operation.TargetMethod.Name, "LockTable"))
             return;
 
         ctx.ReportDiagnostic(Diagnostic.Create(

--- a/src/ALCops.LinterCop/Analyzers/UseSecretTextForSensitiveText.cs
+++ b/src/ALCops.LinterCop/Analyzers/UseSecretTextForSensitiveText.cs
@@ -13,7 +13,7 @@ public sealed class UseSecretTextForSensitiveText : DiagnosticAnalyzer
     private const string AuthorizationHeaderName = "Authorization";
 
     private static readonly HashSet<string> HttpHeadersMethodNames =
-        new(StringComparer.OrdinalIgnoreCase)
+        new(SemanticFacts.NameEqualityComparer)
         {
             "Add",
             "GetValues",

--- a/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
+++ b/src/ALCops.PlatformCop/Analyzers/DuplicateODataEntityName.cs
@@ -251,7 +251,7 @@ public sealed class DuplicateODataEntityName : DiagnosticAnalyzer
         Func<ODataNameEntry, bool>? reportableFilter)
     {
         var groups = entries
-            .GroupBy(e => e.ODataName, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(e => e.ODataName, SemanticFacts.NameEqualityComparer)
             .Where(g => g.Count() > 1);
 
         foreach (var group in groups)

--- a/src/ALCops.PlatformCop/Analyzers/EventSubscriberVarKeyword.cs
+++ b/src/ALCops.PlatformCop/Analyzers/EventSubscriberVarKeyword.cs
@@ -48,7 +48,7 @@ public sealed class EventSubscriberVarKeyword : DiagnosticAnalyzer
 
             var publisherParameter = publisherParameters
                 .FirstOrDefault(p =>
-                    string.Equals(p.Name, subscriberParameter.Name, StringComparison.OrdinalIgnoreCase));
+                    SemanticFacts.IsSameName(p.Name, subscriberParameter.Name));
 
             if (publisherParameter is null)
                 continue;

--- a/src/ALCops.PlatformCop/Analyzers/MandatoryFieldMissingOnApiPage.cs
+++ b/src/ALCops.PlatformCop/Analyzers/MandatoryFieldMissingOnApiPage.cs
@@ -10,11 +10,11 @@ namespace ALCops.PlatformCop.Analyzers;
 public sealed class MandatoryFieldMissingOnApiPage : DiagnosticAnalyzer
 {
     private static readonly ImmutableDictionary<string, string> MandatoryFields =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        new Dictionary<string, string>(SemanticFacts.NameEqualityComparer)
         {
             ["SystemId"] = "id",
             ["SystemModifiedAt"] = "lastModifiedDateTime",
-        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+        }.ToImmutableDictionary(SemanticFacts.NameEqualityComparer);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(

--- a/src/ALCops.PlatformCop/Analyzers/PageRecordArgumentMismatch.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PageRecordArgumentMismatch.cs
@@ -15,14 +15,14 @@ public sealed class PageRecordArgumentMismatch : DiagnosticAnalyzer
             DiagnosticDescriptors.PageRecordArgumentMismatch);
 
     private static readonly ImmutableHashSet<string> PageProcedureNames =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
+        ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer,
             "GetRecord",
             "SetRecord",
             "SetSelectionFilter",
             "SetTableView");
 
     private static readonly ImmutableHashSet<string> PageRunProcedureNames =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
+        ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer,
             "Run",
             "RunModal");
 

--- a/src/ALCops.PlatformCop/Analyzers/PageRecordArgumentMismatch.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PageRecordArgumentMismatch.cs
@@ -287,6 +287,6 @@ public sealed class PageRecordArgumentMismatch : DiagnosticAnalyzer
         if (!string.Equals(eNs, aNs, StringComparison.Ordinal))
             return false;
 
-        return string.Equals(expected.Name, actual.Name, StringComparison.OrdinalIgnoreCase);
+        return SemanticFacts.IsSameName(expected.Name, actual.Name);
     }
 }

--- a/src/ALCops.PlatformCop/Analyzers/PageRecordMethodRequiresSourceTable.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PageRecordMethodRequiresSourceTable.cs
@@ -14,7 +14,7 @@ public sealed class PageRecordMethodRequiresSourceTable : DiagnosticAnalyzer
         ImmutableArray.Create(DiagnosticDescriptors.PageRecordMethodRequiresSourceTable);
 
     private static readonly ImmutableHashSet<string> PageRecordMethodNames =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
+        ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer,
             "GetRecord",
             "SetRecord",
             "SetSelectionFilter",

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -16,7 +16,7 @@ namespace ALCops.PlatformCop.Analyzers;
 public sealed class PartialRecordOperations : DiagnosticAnalyzer
 {
     private static readonly ImmutableHashSet<string> ReadMethods = RecordMethodClassification.SingleRecordReadMethods
-        .Union(ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "FindSet"));
+        .Union(ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, "FindSet"));
 
     private static readonly ImmutableHashSet<string> LoadFieldsMethods = RecordMethodClassification.LoadFieldsMethods;
 
@@ -99,7 +99,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
             var jitOperations = state.WriteMethodNames
                 .Where(m => JitLoadWriteMethods.Contains(m))
-                .OrderBy(m => m, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(m => m, SemanticFacts.NameComparer)
                 .ToList();
 
             if (jitOperations.Count == 0)
@@ -119,7 +119,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
     private static Dictionary<string, VariableState> CollectEligibleLocalVariables(IMethodSymbol methodSymbol)
     {
-        var result = new Dictionary<string, VariableState>(StringComparer.OrdinalIgnoreCase);
+        var result = new Dictionary<string, VariableState>(SemanticFacts.NameEqualityComparer);
 
         foreach (var local in methodSymbol.LocalVariables)
         {
@@ -184,7 +184,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
     {
         public List<ReadInfo> UncoveredReadLocations { get; } = new();
         public List<LoadFieldsInfo> LoadFieldsLocations { get; } = new();
-        public HashSet<string> WriteMethodNames { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> WriteMethodNames { get; } = new(SemanticFacts.NameEqualityComparer);
         public bool IsRecordRef { get; set; }
         public bool IsSetupTable { get; set; }
         public List<string?> SetTableTargets { get; } = new();
@@ -220,7 +220,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             UncoveredReads = new List<ReadInfo>(UncoveredReads),
             LoadFieldsLocations = new List<LoadFieldsInfo>(LoadFieldsLocations),
             WriteMethodNamesAfterPartialRead = WriteMethodNamesAfterPartialRead is not null
-                ? new HashSet<string>(WriteMethodNamesAfterPartialRead, StringComparer.OrdinalIgnoreCase)
+                ? new HashSet<string>(WriteMethodNamesAfterPartialRead, SemanticFacts.NameEqualityComparer)
                 : null
         };
 
@@ -240,7 +240,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
         public void AddWriteAfterPartialRead(string methodName)
         {
-            WriteMethodNamesAfterPartialRead ??= new(StringComparer.OrdinalIgnoreCase);
+            WriteMethodNamesAfterPartialRead ??= new(SemanticFacts.NameEqualityComparer);
             WriteMethodNamesAfterPartialRead.Add(methodName);
         }
     }
@@ -285,7 +285,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         {
             _trackedVariables = trackedVariables;
             _cancellationToken = cancellationToken;
-            _flowState = new Dictionary<string, FlowFlags>(StringComparer.OrdinalIgnoreCase);
+            _flowState = new Dictionary<string, FlowFlags>(SemanticFacts.NameEqualityComparer);
             foreach (var key in trackedVariables.Keys)
                 _flowState[key] = new FlowFlags();
         }
@@ -476,7 +476,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
         private Dictionary<string, FlowFlags> SaveFlowState()
         {
-            var saved = new Dictionary<string, FlowFlags>(StringComparer.OrdinalIgnoreCase);
+            var saved = new Dictionary<string, FlowFlags>(SemanticFacts.NameEqualityComparer);
             foreach (var kvp in _flowState)
                 saved[kvp.Key] = kvp.Value.Clone();
             return saved;
@@ -494,7 +494,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         /// </summary>
         private Dictionary<string, HashSet<int>> CapturePreForkReadPositions()
         {
-            var result = new Dictionary<string, HashSet<int>>(StringComparer.OrdinalIgnoreCase);
+            var result = new Dictionary<string, HashSet<int>>(SemanticFacts.NameEqualityComparer);
             foreach (var kvp in _flowState)
             {
                 if (kvp.Value.UncoveredReads.Count > 0)
@@ -557,7 +557,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             foreach (var set in sets)
             {
                 if (set is null) continue;
-                merged ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                merged ??= new HashSet<string>(SemanticFacts.NameEqualityComparer);
                 merged.UnionWith(set);
             }
             target.WriteMethodNamesAfterPartialRead = merged;

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -588,10 +588,10 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
                 HandleLoadFieldsMethod(operation, state, flowFlags, methodName);
             else if (WriteMethods.Contains(methodName))
                 HandleWriteMethod(state, flowFlags, methodName);
-            else if (string.Equals(methodName, "Reset", StringComparison.OrdinalIgnoreCase))
+            else if (SemanticFacts.IsSameName(methodName, "Reset"))
                 flowFlags.ResetFlags();
             else if (state.IsRecordRef
-                && string.Equals(methodName, "SetTable", StringComparison.OrdinalIgnoreCase)
+                && SemanticFacts.IsSameName(methodName, "SetTable")
                 && operation.Arguments.Length == 1)
                 state.SetTableTargets.Add(GetVariableNameFromArgument(operation.Arguments[0]));
         }
@@ -604,7 +604,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
 
             // Suppress on setup table parameterless Get() - near-zero performance benefit
             if (state.IsSetupTable
-                && string.Equals(methodName, "Get", StringComparison.OrdinalIgnoreCase)
+                && SemanticFacts.IsSameName(methodName, "Get")
                 && operation.Arguments.IsEmpty)
                 return;
 
@@ -617,7 +617,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         private static void HandleLoadFieldsMethod(IInvocationExpression operation,
             VariableState state, FlowFlags flowFlags, string methodName)
         {
-            if (string.Equals(methodName, "SetLoadFields", StringComparison.OrdinalIgnoreCase)
+            if (SemanticFacts.IsSameName(methodName, "SetLoadFields")
                 && operation.Arguments.IsEmpty)
             {
                 // SetLoadFields() with no arguments resets partial records to "load all"
@@ -656,7 +656,7 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
         {
             // Clear(variable) resets flow state instead of marking passedToFunction
             if (operation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod
-                && string.Equals(operation.TargetMethod.Name, "Clear", StringComparison.OrdinalIgnoreCase)
+                && SemanticFacts.IsSameName(operation.TargetMethod.Name, "Clear")
                 && operation.Arguments.Length >= 1)
             {
                 var clearVarName = GetVariableNameFromArgument(operation.Arguments[0]);

--- a/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
@@ -87,7 +87,7 @@ public sealed class PlaceholderArgumentCountMismatch : DiagnosticAnalyzer
     /// </summary>
     private static int GetSubstitutionArgumentCount(string methodName, int totalArguments)
     {
-        if (string.Equals(methodName, "Confirm", StringComparison.OrdinalIgnoreCase))
+        if (SemanticFacts.IsSameName(methodName, "Confirm"))
         {
             // Confirm: args[0]=format, args[1]=default button (Boolean, required if subs present)
             // If only 1 arg (format only) or 2 args (format + default): 0 subs

--- a/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PlaceholderArgumentCountMismatch.cs
@@ -20,14 +20,14 @@ public sealed class PlaceholderArgumentCountMismatch : DiagnosticAnalyzer
 {
     private static readonly Regex PlaceholderPattern = new("[#%](\\d+)", RegexOptions.Compiled);
 
-    private static readonly HashSet<string> MethodsCoveredByAA0131 = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> MethodsCoveredByAA0131 = new(SemanticFacts.NameEqualityComparer)
     {
         "StrSubstNo",
         "Message",
         "Error"
     };
 
-    private static readonly HashSet<string> AllTargetMethods = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> AllTargetMethods = new(SemanticFacts.NameEqualityComparer)
     {
         "StrSubstNo",
         "Message",

--- a/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
@@ -81,7 +81,7 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
         public Lazy<HashSet<string>> Paths { get; } = new Lazy<HashSet<string>>(
                 () =>
                 {
-                    var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    var set = new HashSet<string>(SemanticFacts.NameEqualityComparer);
 
                     foreach (var tree in compilation.SyntaxTrees)
                     {

--- a/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
@@ -463,7 +463,7 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
     {
         var sourceName = (source.Name ?? string.Empty).UnquoteIdentifier();
         var targetName = (target.Name ?? string.Empty).UnquoteIdentifier();
-        return string.Equals(sourceName, targetName, StringComparison.OrdinalIgnoreCase);
+        return SemanticFacts.IsSameName(sourceName, targetName);
     }
 
     private static MismatchResult ReportMismatches(

--- a/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSequentialGuid.cs
@@ -199,7 +199,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
         {
             if (operation is IInvocationExpression inv &&
                 inv.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
-                string.Equals(inv.TargetMethod.Name, "CreateGuid", StringComparison.OrdinalIgnoreCase) &&
+                SemanticFacts.IsSameName(inv.TargetMethod.Name, "CreateGuid") &&
                 inv.Arguments.IsEmpty)
             {
                 invocation = inv;
@@ -342,7 +342,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
 
     private static bool IsValidateCall(IInvocationExpression invocation) =>
         invocation.TargetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
-        string.Equals(invocation.TargetMethod.Name, "Validate", StringComparison.OrdinalIgnoreCase);
+        SemanticFacts.IsSameName(invocation.TargetMethod.Name, "Validate");
 
     private static KeyFieldResult? CheckFieldInKey(IFieldAccess fieldAccess)
     {
@@ -393,7 +393,7 @@ public sealed class UseSequentialGuid : DiagnosticAnalyzer
         {
             foreach (var keyField in key.Fields)
             {
-                if (string.Equals(keyField.Name, field.Name, StringComparison.OrdinalIgnoreCase))
+                if (SemanticFacts.IsSameName(keyField.Name, field.Name))
                     return true;
             }
         }

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -13,10 +13,10 @@ namespace ALCops.PlatformCop.Analyzers;
 public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
 {
     private static readonly ImmutableHashSet<string> FindSetMethods =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "FindSet", "Find");
+        ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, "FindSet", "Find");
 
     private static readonly ImmutableHashSet<string> NextMethods =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "Next");
+        ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, "Next");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops);
@@ -106,7 +106,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
             if (implicitLoopVariable is not null)
             {
                 _loopVariables.Push(
-                    ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, implicitLoopVariable));
+                    ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, implicitLoopVariable));
             }
         }
 
@@ -137,7 +137,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                 // repeat-until: loop variable is the one that calls Next() in the condition
                 var loopVar = ExtractNextVariableFromCondition(operation.Condition);
                 var loopVars = loopVar is not null
-                    ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
+                    ? ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, loopVar)
                     : ImmutableHashSet<string>.Empty;
 
                 PushLoop(loopVars);
@@ -150,7 +150,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
                 // while-do: loop variable could be in the condition (FindSet/Find)
                 var loopVar = ExtractFindSetVariableFromCondition(operation.Condition);
                 var loopVars = loopVar is not null
-                    ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, loopVar)
+                    ? ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, loopVar)
                     : ImmutableHashSet<string>.Empty;
 
                 PushLoop(loopVars);
@@ -166,7 +166,7 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
 
             var iterVarName = GetIterationVariableName(operation);
             var loopVars = iterVarName is not null
-                ? ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, iterVarName)
+                ? ImmutableHashSet.Create(SemanticFacts.NameEqualityComparer, iterVarName)
                 : ImmutableHashSet<string>.Empty;
 
             PushLoop(loopVars);

--- a/src/ALCops.PlatformCop/CodeFixes/ApplicationAreaOnApiPage.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/ApplicationAreaOnApiPage.cs
@@ -93,5 +93,5 @@ public sealed class ApplicationAreaOnApiPageCodeFix : CodeFixProvider
     }
 
     private static bool IsApplicationAreaProperty(PropertySyntax propertySyntax) =>
-        string.Equals(propertySyntax.Name?.Identifier.ValueText, ApplicationAreaPropertyName, StringComparison.OrdinalIgnoreCase);
+        propertySyntax.Name?.Identifier.ValueText is { } nameText && SemanticFacts.IsSameName(nameText, ApplicationAreaPropertyName);
 }

--- a/src/ALCops.PlatformCop/CodeFixes/ApplicationAreaOnApiPage.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/ApplicationAreaOnApiPage.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
@@ -93,5 +94,5 @@ public sealed class ApplicationAreaOnApiPageCodeFix : CodeFixProvider
     }
 
     private static bool IsApplicationAreaProperty(PropertySyntax propertySyntax) =>
-        propertySyntax.Name?.Identifier.ValueText is { } nameText && SemanticFacts.IsSameName(nameText, ApplicationAreaPropertyName);
+        propertySyntax.Name?.Identifier.ValueText.IsSameName(ApplicationAreaPropertyName) == true;
 }

--- a/src/ALCops.PlatformCop/CodeFixes/ExtensiblePropertyExplicitlySet.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/ExtensiblePropertyExplicitlySet.cs
@@ -122,7 +122,7 @@ public sealed class ExtensiblePropertyExplicitlySetCodeFix : CodeFixProvider
                 continue;
 
             // If Name is tokenized differently in your syntax model, adapt this comparison.
-            if (string.Equals(p.Name?.ToString(), kind.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (p.Name?.ToString() is { } propName && SemanticFacts.IsSameName(propName, kind.ToString()))
                 return p;
         }
         return null;

--- a/src/ALCops.PlatformCop/CodeFixes/ExtensiblePropertyExplicitlySet.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/ExtensiblePropertyExplicitlySet.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
@@ -122,7 +123,7 @@ public sealed class ExtensiblePropertyExplicitlySetCodeFix : CodeFixProvider
                 continue;
 
             // If Name is tokenized differently in your syntax model, adapt this comparison.
-            if (p.Name?.ToString() is { } propName && SemanticFacts.IsSameName(propName, kind.ToString()))
+            if (p.Name?.ToString().IsSameName(kind.ToString()) == true)
                 return p;
         }
         return null;

--- a/src/ALCops.PlatformCop/CodeFixes/MandatoryFieldMissingOnApiPage.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/MandatoryFieldMissingOnApiPage.cs
@@ -78,7 +78,7 @@ public sealed class MandatoryFieldMissingOnApiPageCodeFix : CodeFixProvider
             .Select(a =>
                 a.DescendantNodes()
                  .OfType<PageGroupSyntax>()
-                 .FirstOrDefault(g => string.Equals(g.ControlKeyword.ValueText, "repeater", StringComparison.OrdinalIgnoreCase)))
+                 .FirstOrDefault(g => g.ControlKeyword.ValueText is { } kwText && SemanticFacts.IsSameName(kwText, "repeater")))
             .Where(r => r is not null)
             .ToArray();
 
@@ -94,8 +94,8 @@ public sealed class MandatoryFieldMissingOnApiPageCodeFix : CodeFixProvider
         foreach (var mandatoryField in MandatoryFields)
         {
             bool exists = existingFields.Any(f =>
-                string.Equals(f.Name.Identifier.ValueText, mandatoryField.ControlName, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(f.Expression.ToString(), $"Rec.{mandatoryField.RecField}", StringComparison.OrdinalIgnoreCase));
+                f.Name.Identifier.ValueText is { } fieldName && SemanticFacts.IsSameName(fieldName, mandatoryField.ControlName) &&
+                SemanticFacts.IsSameName(f.Expression.ToString(), $"Rec.{mandatoryField.RecField}"));
 
             if (!exists)
                 missing.Add(mandatoryField);

--- a/src/ALCops.PlatformCop/CodeFixes/MandatoryFieldMissingOnApiPage.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/MandatoryFieldMissingOnApiPage.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Reflection;
+using ALCops.Common.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
@@ -78,7 +79,7 @@ public sealed class MandatoryFieldMissingOnApiPageCodeFix : CodeFixProvider
             .Select(a =>
                 a.DescendantNodes()
                  .OfType<PageGroupSyntax>()
-                 .FirstOrDefault(g => g.ControlKeyword.ValueText is { } kwText && SemanticFacts.IsSameName(kwText, "repeater")))
+                 .FirstOrDefault(g => g.ControlKeyword.ValueText.IsSameName("repeater")))
             .Where(r => r is not null)
             .ToArray();
 
@@ -94,7 +95,7 @@ public sealed class MandatoryFieldMissingOnApiPageCodeFix : CodeFixProvider
         foreach (var mandatoryField in MandatoryFields)
         {
             bool exists = existingFields.Any(f =>
-                f.Name.Identifier.ValueText is { } fieldName && SemanticFacts.IsSameName(fieldName, mandatoryField.ControlName) &&
+                f.Name.Identifier.ValueText.IsSameName(mandatoryField.ControlName) &&
                 SemanticFacts.IsSameName(f.Expression.ToString(), $"Rec.{mandatoryField.RecField}"));
 
             if (!exists)

--- a/src/ALCops.PlatformCop/CodeFixes/OperatorAndPlaceholderInFilterExpression.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/OperatorAndPlaceholderInFilterExpression.cs
@@ -153,9 +153,6 @@ public sealed class OperatorAndPlaceholderInFilterExpressionCodeFix : CodeFixPro
         if (identifierName is null)
             return false;
 
-        return string.Equals(
-            identifierName.Identifier.Text,
-            SetFilterMethodName,
-            StringComparison.OrdinalIgnoreCase);
+        return SemanticFacts.IsSameName(identifierName.Identifier.Text, SetFilterMethodName);
     }
 }

--- a/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -148,7 +148,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
             return GetPrimaryKeyFieldNames(recordType);
 
         var fields = collector.AccessedFields.ToList();
-        fields.Sort(StringComparer.OrdinalIgnoreCase);
+        fields.Sort(SemanticFacts.NameComparer);
         return fields;
     }
 
@@ -213,7 +213,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
         /// Built-in Record methods where the first argument is a field selector (not a consumed value).
         /// Remaining arguments (if any) may contain consumed field accesses and are still visited.
         /// </summary>
-        private static readonly HashSet<string> FirstArgFieldSelectorMethods = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> FirstArgFieldSelectorMethods = new(SemanticFacts.NameEqualityComparer)
         {
             "SetRange", "SetFilter",
             "GetRangeMin", "GetRangeMax", "GetFilter",
@@ -225,7 +225,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
         /// <summary>
         /// Built-in Record methods where ALL arguments are field selectors (none are consumed values).
         /// </summary>
-        private static readonly HashSet<string> AllArgsFieldSelectorMethods = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> AllArgsFieldSelectorMethods = new(SemanticFacts.NameEqualityComparer)
         {
             "SetCurrentKey",
             "AddLoadFields", "LoadFields", "AreFieldsLoaded"
@@ -233,7 +233,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
 
         private readonly string _variableName;
 
-        public HashSet<string> AccessedFields { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> AccessedFields { get; } = new(SemanticFacts.NameEqualityComparer);
 
         public FieldAccessCollector(string variableName)
         {

--- a/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UsePartialRecordsOnRead.cs
@@ -268,7 +268,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
 
             ISymbol? instanceSymbol = operation.Instance?.GetSymbol();
             return instanceSymbol != null
-                && string.Equals(instanceSymbol.Name, _variableName, StringComparison.OrdinalIgnoreCase);
+                && SemanticFacts.IsSameName(instanceSymbol.Name, _variableName);
         }
 
         public override void VisitFieldAccess(IFieldAccess operation)
@@ -291,7 +291,7 @@ public sealed class UsePartialRecordsOnReadCodeFixProvider : CodeFixProvider
 
             ISymbol? instanceSymbol = operation.Instance?.GetSymbol();
             if (instanceSymbol is null ||
-                !string.Equals(instanceSymbol.Name, _variableName, StringComparison.OrdinalIgnoreCase))
+                !SemanticFacts.IsSameName(instanceSymbol.Name, _variableName))
                 return;
 
             AccessedFields.Add(fieldSymbol.Name);


### PR DESCRIPTION
## Summary

Replaces raw `StringComparison.OrdinalIgnoreCase` / `StringComparer.OrdinalIgnoreCase` with the SDK-provided `SemanticFacts` API family for all AL identifier comparisons. This is a pure refactoring with zero behavioral change (all SemanticFacts APIs delegate to OrdinalIgnoreCase internally).

## Changes

### Commit 1: Documentation
- Expanded `analyzer-development.instructions.md` with full SemanticFacts API table (IsSameName, NameEqualityComparer, NameEqualityComparison, NameComparer)
- Added cross-reference in `codefix-development.instructions.md`

### Commit 2: `SemanticFacts.IsSameName`
- Replaced ~40 instances of `string.Equals(..., OrdinalIgnoreCase)` / `.Equals(..., OrdinalIgnoreCase)` with `SemanticFacts.IsSameName()`
- Added null guards (`is { } var &&` pattern) where nullable tokens were passed to the non-nullable API

### Commit 3: `SemanticFacts.NameEqualityComparer`
- Replaced ~60 instances of `StringComparer.OrdinalIgnoreCase` in HashSet, Dictionary, FrozenDictionary, and ImmutableHashSet constructors
- Replaced 2 sort comparers with `SemanticFacts.NameComparer`

### Commit 4: `SemanticFacts.NameEqualityComparison`
- Replaced 6 instances of `StringComparison.OrdinalIgnoreCase` in StartsWith/EndsWith/Contains/IndexOf calls on AL identifiers

## Scope exclusions (kept as OrdinalIgnoreCase)
- Property value comparisons (enum string values like "Always", "Never")
- File path and assembly name comparisons
- Language code hashsets
- Permission char string searches ("RIMD")
- User-configured affix list membership checks (`.Contains(affix, StringComparer)`)
- XmlDocumentationProcedureConsistency.cs
- Internal reflection (EnumProvider.cs)

## Testing
- Full build: 0 errors, 18 warnings (unchanged)
- Full test suite: all tests pass (997 passed, 13 skipped, 0 failed)

Closes #292