### PR TITLE
fix(AC0032): support unlimited nesting of xmlport tableelement nodes

### DIFF
--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -68,7 +68,7 @@ src/ALCops.Common/
 | `CollectFromInvocations` | Builds object-scope record map (vars + data items), walks method bodies, resolves DB calls via syntax + symbol lookup |
 | `TryGetPermissionFromInvocation` | Resolves a single invocation: fast path via variable map, fallback via GetSymbolInfo |
 | `TryGetPermissionViaSymbolInfo` | Fallback for complex receivers: uses GetSymbolInfo to resolve method and receiver type |
-| `CollectFromDataItems` | Iterates report FlattenedDataItems, query FlattenedDataItems (via reflection), and xmlport nodes |
+| `CollectFromDataItems` | Iterates report/query FlattenedDataItems and xmlport FlattenedXmlPortNodes (all via reflection) for implicit read permissions |
 | `CollectFromQueryDataItems` | Uses reflection to access internal `FlattenedDataItems` on QueryTypeSymbol |
 | `AddNestedQueryDataItemsToVarMap` | Adds nested query data items to the object-scope record map via reflection |
 | `AddXmlPortNodeToVarMap` | Adds an xmlport table element to the object-scope record map if it references a non-temporary table |
@@ -88,7 +88,7 @@ Each `SyntaxNodeAction` callback is self-contained with no shared mutable state.
 | Variable map + syntax resolution | Resolves ~66% of DB calls via dictionary lookup from `IMethodSymbol.LocalVariables`/`.Parameters`; avoids expensive `GetOperation` calls entirely |
 | Global variable map from `GetMembers()` | Captures object-level Record variables that account for ~34% of invocations not resolvable from locals/params |
 | Data items in object-scope record map | Report data items and xmlport table elements act as implicit record variables in trigger code; added to the same map for fast-path resolution via `GetTypeSymbol()` |
-| XmlPort nested nodes via `FlattenedNodes` | `GetMembers()` returns only top-level schema nodes; nested table elements (inside textelement) require iterating `IXmlPortNodeSymbol.FlattenedNodes` |
+| XmlPort nested nodes via `GetFlattenedXmlPortNodes` | `GetMembers()` returns only top-level schema nodes; `IXmlPortNodeSymbol.FlattenedNodes` only returns immediate children (not recursive). Uses reflection on the internal `SourceXmlPortTypeSymbol.FlattenedNodes` property which truly flattens all depths |
 | `GetSymbolInfo` fallback for complex receivers | Handles function return values, array indexing, property access; only ~1% of invocations need this path |
 | No `GetOperation` / `OperationWalker` | `GetOperation` in `SyntaxNodeAction` costs ~0.3ms/call (no pre-computed cache); variable map approach is 4.5x faster |
 | No cross-callback shared state | Eliminates the fragile two-phase accumulator pattern that caused false positives during incremental compilation |
@@ -142,7 +142,7 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 ## Test coverage
 
 **HasDiagnostic (10 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord, ParameterPartialUnused, ReportDataItemPartialUnused.
-**NoDiagnostic (20 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable, ParameterOperations, UppercasePermissions, ParameterAllOperations, LocalVarSpacedTable, GlobalVarSpacedTable, ReportDataItemModify, ReportDataItemAliasModify, XmlPortTableElementModify, ReturnParameterRead, ReportNestedDataItemRead, QueryNestedDataItemRead.
+**NoDiagnostic (21 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable, ParameterOperations, UppercasePermissions, ParameterAllOperations, LocalVarSpacedTable, GlobalVarSpacedTable, ReportDataItemModify, ReportDataItemAliasModify, XmlPortTableElementModify, XmlPortNestedTableElementModify, ReturnParameterRead, ReportNestedDataItemRead, QueryNestedDataItemRead.
 **HasFix (4 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty, ReplaceChars.
 
 ## Known limitations

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/XmlPortNestedTableElementModify.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/XmlPortNestedTableElementModify.al
@@ -1,0 +1,97 @@
+xmlport 50000 MyXmlport
+{
+    Permissions = [|tabledata Alpha = rim|],
+                  [|tabledata Beta = rim|],
+                  [|tabledata Charlie = rim|],
+                  [|tabledata Delta = rim|];
+
+    schema
+    {
+        tableelement(Alpha; Alpha)
+        {
+            tableelement(Beta; Beta)
+            {
+                tableelement(Charlie; Charlie)
+                {
+                    tableelement(Delta; Delta)
+                    {
+                        fieldelement(DeltaField; Delta.MyField)
+                        {
+                        }
+                    }
+
+                    trigger OnBeforeInsertRecord()
+                    begin
+                        Charlie.Modify();
+                    end;
+                }
+
+                trigger OnBeforeInsertRecord()
+                begin
+                    Beta.Modify();
+                end;
+            }
+
+            trigger OnBeforeInsertRecord()
+            begin
+                Alpha.Modify();
+            end;
+        }
+    }
+}
+
+table 50000 Alpha
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50001 Beta
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50002 Charlie
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+table 50003 Delta
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -57,6 +57,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("ReportDataItemModify")]
         [TestCase("ReportDataItemAliasModify")]
         [TestCase("XmlPortTableElementModify")]
+        [TestCase("XmlPortNestedTableElementModify")]
         [TestCase("ReturnParameterRead")]
         [TestCase("ReportNestedDataItemRead")]
         [TestCase("QueryNestedDataItemRead")]

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -76,7 +76,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         IApplicationObjectTypeSymbol containingObject,
         List<RequiredPermission> requiredPermissions)
     {
-        // Build object-scope record map (global vars, report data items, xmlport table elements)
+        // Build object-scope record map (global vars, data items, xmlport table elements)
         Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap = null;
         foreach (var member in containingObject.GetMembers())
         {
@@ -86,33 +86,10 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             {
                 objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
                 objectScopeRecordMap.TryAdd(globalVar.Name, globalRecordType);
-                continue;
             }
-
-            // Report data items act as implicit record variables in trigger code
-            if (member.Kind == EnumProvider.SymbolKind.ReportDataItem
-                && member.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is not true
-                && member.GetTypeSymbol() is IRecordTypeSymbol dataItemRecordType
-                && !dataItemRecordType.Temporary)
-            {
-                objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
-                objectScopeRecordMap.TryAdd(member.Name, dataItemRecordType);
-                continue;
-            }
-
-            // Query data items act as implicit record variables in trigger code
-            if (member.Kind == EnumProvider.SymbolKind.QueryDataItem
-                && member.GetTypeSymbol() is IRecordTypeSymbol queryDataItemRecordType
-                && !queryDataItemRecordType.Temporary)
-            {
-                objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
-                objectScopeRecordMap.TryAdd(member.Name, queryDataItemRecordType);
-                continue;
-            }
-
         }
 
-        // Add all nested data items (report and query) to the object-scope record map
+        // Add all nested data items (report and query, unlimited depth) to the object-scope record map
         foreach (var dataItem in containingObject.GetFlattenedDataItems())
         {
             if (dataItem.GetBooleanPropertyValue(EnumProvider.PropertyKind.UseTemporary) is not true

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -110,18 +110,6 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
                 continue;
             }
 
-            // XmlPort table elements act as implicit record variables in trigger code
-            if (member.Kind == EnumProvider.SymbolKind.XmlPortNode
-                && member is IXmlPortNodeSymbol xmlPortNode)
-            {
-                AddXmlPortNodeToVarMap(xmlPortNode, ref objectScopeRecordMap);
-
-                // Nested nodes (tableelement inside textelement) are not direct members
-                foreach (var nestedNode in xmlPortNode.FlattenedNodes)
-                    AddXmlPortNodeToVarMap(nestedNode, ref objectScopeRecordMap);
-
-                continue;
-            }
         }
 
         // Add all nested data items (report and query) to the object-scope record map
@@ -134,6 +122,12 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
                 objectScopeRecordMap ??= new(StringComparer.OrdinalIgnoreCase);
                 objectScopeRecordMap.TryAdd(dataItem.Name, nestedRecordType);
             }
+        }
+
+        // Add all nested xmlport table elements (unlimited depth) to the object-scope record map
+        foreach (var xmlNode in containingObject.GetFlattenedXmlPortNodes())
+        {
+            AddXmlPortNodeToVarMap(xmlNode, ref objectScopeRecordMap);
         }
 
         foreach (var node in ctx.Node.DescendantNodes())
@@ -334,24 +328,11 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             }
         }
 
-        // XmlPort nodes
-        foreach (var member in containingObject.GetMembers())
+        // XmlPort nodes: use GetFlattenedXmlPortNodes to include all nested levels
+        foreach (var xmlNode in containingObject.GetFlattenedXmlPortNodes())
         {
-            if (member.Kind == EnumProvider.SymbolKind.XmlPortNode)
-            {
-                foreach (var r in RequiredPermissionDetector.GetFromXmlPortNode(member, includeSystemTables: true))
-                    requiredPermissions.Add(r);
-
-                // Nested nodes (tableelement inside textelement) are not direct members
-                if (member is IXmlPortNodeSymbol topNode)
-                {
-                    foreach (var nestedNode in topNode.FlattenedNodes)
-                    {
-                        foreach (var r in RequiredPermissionDetector.GetFromXmlPortNode(nestedNode, includeSystemTables: true))
-                            requiredPermissions.Add(r);
-                    }
-                }
-            }
+            foreach (var r in RequiredPermissionDetector.GetFromXmlPortNode(xmlNode, includeSystemTables: true))
+                requiredPermissions.Add(r);
         }
     }
 

--- a/src/ALCops.Common/Extensions/ApplicationObjectTypeSymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/ApplicationObjectTypeSymbolInterfaceExtensions.cs
@@ -45,6 +45,25 @@ public static class ApplicationObjectTypeSymbolInterfaceExtensions
     }
 
     /// <summary>
+    /// Gets the flattened list of all xmlport nodes (including deeply nested) for xmlport objects.
+    /// Uses reflection to access the internal <c>SourceXmlPortTypeSymbol.FlattenedNodes</c> property,
+    /// which recursively includes all nested tableelement/textelement/fieldelement nodes at any depth.
+    /// Returns an empty enumerable for non-xmlport objects or if the property is unavailable.
+    /// </summary>
+    public static IEnumerable<IXmlPortNodeSymbol> GetFlattenedXmlPortNodes(this IApplicationObjectTypeSymbol containingObject)
+    {
+        var flattenedNodes = ((object)containingObject).GetPropertyIfExists<System.Collections.IEnumerable>("FlattenedNodes");
+        if (flattenedNodes is null)
+            yield break;
+
+        foreach (var item in flattenedNodes)
+        {
+            if (item is IXmlPortNodeSymbol node)
+                yield return node;
+        }
+    }
+
+    /// <summary>
     /// Gets the flattened list of all data items (including nested) for report and query objects.
     /// For reports on net8.0+, uses the public <see cref="IReportTypeSymbol.FlattenedDataItems"/> property.
     /// For queries (and reports on netstandard2.1), uses reflection to access the internal FlattenedDataItems.


### PR DESCRIPTION
## Summary

Fixes false positives in AC0032 (Unused Permissions) for deeply nested `tableelement` nodes in xmlports.

### Problem

```al
xmlport 50100 MyXmlport
{
    Permissions = tabledata Alpha = rim, tabledata Beta = rim, tabledata Charlie = rim;
    schema
    {
        tableelement(Alpha; Alpha)
        {
            tableelement(Beta; Beta)
            {
                tableelement(Charlie; Charlie) { }
            }
        }
    }
}
```

AC0032 incorrectly reported Charlie (and any deeper levels) as unused because `IXmlPortNodeSymbol.FlattenedNodes` only returns immediate children, not all descendants recursively.

### Fix

Uses reflection to access the internal `SourceXmlPortTypeSymbol.FlattenedNodes` property which truly flattens all depths. This is consistent with the approach used for report/query `FlattenedDataItems` in PR #300.

### Changes

- **`ApplicationObjectTypeSymbolInterfaceExtensions.cs`**: Added `GetFlattenedXmlPortNodes()` extension method using reflection
- **`TableDataAccessUnusedPermissions.cs`**: Replaced manual two-level iteration with `GetFlattenedXmlPortNodes()` in both `CollectFromInvocations` and `CollectFromDataItems`
- **New test**: `XmlPortNestedTableElementModify.al` with 4 levels of nesting (Alpha > Beta > Charlie > Delta)
- **Updated instruction file**: Design decisions and test coverage

### Testing

All 35 AC0032 tests pass with zero regressions.

Closes #299