### PR TITLE
fix(LC0082): exclude math operators from Count() comparison checks

### DIFF
--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -953,8 +953,12 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.EqualsToken)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _greaterThanToken =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.GreaterThanToken)));
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _greaterThanEqualsToken =
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.GreaterThanEqualsToken)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _lessThanToken =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.LessThanToken)));
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _lessThanEqualsToken =
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.LessThanEqualsToken)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _endOfLineTrivia =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.EndOfLineTrivia)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _enumExtensionType =
@@ -1251,7 +1255,9 @@ public static class EnumProvider
         public static NavCodeAnalysis.SyntaxKind EmptyProperty => _emptyProperty.Value;
         public static NavCodeAnalysis.SyntaxKind EqualsToken => _equalsToken.Value;
         public static NavCodeAnalysis.SyntaxKind GreaterThanToken => _greaterThanToken.Value;
+        public static NavCodeAnalysis.SyntaxKind GreaterThanEqualsToken => _greaterThanEqualsToken.Value;
         public static NavCodeAnalysis.SyntaxKind LessThanToken => _lessThanToken.Value;
+        public static NavCodeAnalysis.SyntaxKind LessThanEqualsToken => _lessThanEqualsToken.Value;
         public static NavCodeAnalysis.SyntaxKind EndOfLineTrivia => _endOfLineTrivia.Value;
         public static NavCodeAnalysis.SyntaxKind EnumExtensionType => _enumExtensionType.Value;
         public static NavCodeAnalysis.SyntaxKind EnumDataType => _enumDataType.Value;

--- a/src/ALCops.LinterCop.Test/Rules/UseQueryOrFindWithNextInsteadOfCount/NoDiagnostic/RecordCountMathOperator.al
+++ b/src/ALCops.LinterCop.Test/Rules/UseQueryOrFindWithNextInsteadOfCount/NoDiagnostic/RecordCountMathOperator.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        i: Integer;
+    begin
+        i := [|MyTable.Count() - 1|];
+        i := [|MyTable.Count() + 1|];
+        i := [|MyTable.Count() / 1|];
+        i := [|MyTable.Count() * 1|];
+        i := [|MyTable.Count() MOD 1|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/UseQueryOrFindWithNextInsteadOfCount/UseQueryOrFindWithNextInsteadOfCount.cs
+++ b/src/ALCops.LinterCop.Test/Rules/UseQueryOrFindWithNextInsteadOfCount/UseQueryOrFindWithNextInsteadOfCount.cs
@@ -36,6 +36,7 @@ namespace ALCops.LinterCop.Test
 
         [Test]
         [TestCase("RecordCountEqualsTwo")]
+        [TestCase("RecordCountMathOperator")]
         [TestCase("RecordTemporaryCountEqualsOne")]
         public async Task NoDiagnostic(string testCase)
         {

--- a/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
+++ b/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
@@ -75,7 +75,7 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
 
         if (IsEligibleUseQueryOrFindWithNext(recordTypeSymbol))
         {
-            if (IsOneComparison(leftValue, rightValue))
+            if (IsOneComparison(binaryExpression, leftValue, rightValue))
             {
                 ReportUseFindWithNextDiagnostic(ctx, invocation, GetOperatorKind(binaryExpression.OperatorToken.Kind));
                 return;
@@ -112,8 +112,17 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
     private static bool IsGreaterThanOneComparison(BinaryExpressionSyntax expr, int left) =>
         expr.OperatorToken.Kind == EnumProvider.SyntaxKind.GreaterThanToken && left == One;
 
-    private static bool IsOneComparison(int left, int right) =>
-        left == One || right == One;
+    private static bool IsComparisonOperator(SyntaxKind kind) =>
+        kind is var k &&
+        (k == EnumProvider.SyntaxKind.EqualsToken ||
+         k == EnumProvider.SyntaxKind.NotEqualsToken ||
+         k == EnumProvider.SyntaxKind.LessThanToken ||
+         k == EnumProvider.SyntaxKind.GreaterThanToken ||
+         k == EnumProvider.SyntaxKind.LessThanEqualsToken ||
+         k == EnumProvider.SyntaxKind.GreaterThanEqualsToken);
+
+    private static bool IsOneComparison(BinaryExpressionSyntax expr, int left, int right) =>
+        IsComparisonOperator(expr.OperatorToken.Kind) && (left == One || right == One);
 
     private static bool IsLessThanTwoComparison(BinaryExpressionSyntax expr, int right) =>
         expr.OperatorToken.Kind == EnumProvider.SyntaxKind.LessThanToken && right == Two;


### PR DESCRIPTION
## Summary

Fixes false positive LC0082 when `Count()` is used in arithmetic expressions (e.g., `Count() - 1`, `Count() * 2`).

## Problem

`IsOneComparison` only checked if one operand equals `1`, without verifying the binary operator is a comparison operator. This caused `Count() - 1`, `Count() + 1`, `Count() / 1`, `Count() * 1`, and `Count() MOD 1` to falsely trigger LC0082.

## Solution

- Added `IsComparisonOperator()` method that validates the operator is one of: `=`, `<>`, `<`, `>`, `<=`, `>=`
- Updated `IsOneComparison` to accept `BinaryExpressionSyntax` and check the operator before returning true
- Added `GreaterThanEqualsToken` and `LessThanEqualsToken` to `EnumProvider.SyntaxKind`

## Test coverage

- New NoDiagnostic test case `RecordCountMathOperator` covering 5 arithmetic operators: `-`, `+`, `/`, `*`, `MOD`
- All 20 existing Count-related tests continue to pass

## Reference

Ported from [BusinessCentral.LinterCop PR #1200](https://github.com/StefanMaron/BusinessCentral.LinterCop/pull/1200).

Closes #304