### PR TITLE
fix(PC0022): handle xmlport textelement in overflow detection

### DIFF
--- a/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/GetMethodXmlPortTextElement.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/GetMethodXmlPortTextElement.al
@@ -1,0 +1,20 @@
+xmlport 50100 MyXmlport
+{
+    schema
+    {
+        textelement(root)
+        {
+            textelement(MyTextelement) { }
+        }
+    }
+
+    trigger OnPreXmlPort()
+    begin
+        MyTable.Get([|MyTextelement|]);
+    end;
+
+    var
+        MyTable: Record MyTable;
+}
+
+table 50100 MyTable { fields { field(1; "No."; Code[20]) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/SetFilterFieldCodeXmlPortTextElement.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/SetFilterFieldCodeXmlPortTextElement.al
@@ -1,0 +1,20 @@
+xmlport 50100 MyXmlport
+{
+    schema
+    {
+        textelement(root)
+        {
+            textelement(MyTextelement) { }
+        }
+    }
+
+    trigger OnPreXmlPort()
+    begin
+        MyTable.SetFilter(MyField, '<>%1', [|MyTextelement|]);
+    end;
+
+    var
+        MyTable: Record MyTable;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Code[20]) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/ValidateFieldCodeXmlPortTextElement.al
+++ b/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/HasDiagnostic/ValidateFieldCodeXmlPortTextElement.al
@@ -1,0 +1,20 @@
+xmlport 50100 MyXmlport
+{
+    schema
+    {
+        textelement(root)
+        {
+            textelement(MyTextelement) { }
+        }
+    }
+
+    trigger OnPreXmlPort()
+    begin
+        MyTable.Validate(MyField, [|MyTextelement|]);
+    end;
+
+    var
+        MyTable: Record MyTable;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Code[20]) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/PossibleOverflowAssigning.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/PossibleOverflowAssigning/PossibleOverflowAssigning.cs
@@ -25,8 +25,11 @@ namespace ALCops.PlatformCop.Test
         [TestCase("ExitStatementLabel")]
         [TestCase("GetMethodStringLiteral")]
         [TestCase("GetMethodStrSubstNo")]
+        [TestCase("GetMethodXmlPortTextElement")]
         [TestCase("SetFilterFieldCode")]
+        [TestCase("SetFilterFieldCodeXmlPortTextElement")]
         [TestCase("ValidateFieldCode")]
+        [TestCase("ValidateFieldCodeXmlPortTextElement")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/Analyzers/PossibleOverflowAssigning.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PossibleOverflowAssigning.cs
@@ -385,6 +385,7 @@ public sealed class PossibleOverflowAssigning : DiagnosticAnalyzer
             case var _ when kind == EnumProvider.OperationKind.ReturnValueReferenceExpression:
             case var _ when kind == EnumProvider.OperationKind.ParameterReferenceExpression:
             case var _ when kind == EnumProvider.OperationKind.FieldAccess:
+            case var _ when kind == EnumProvider.OperationKind.XmlPortDataItemAccess:
                 return expression.Type.GetTypeLength(ref isError);
             case var _ when kind == EnumProvider.OperationKind.BinaryOperatorExpression:
                 IBinaryOperatorExpression operatorExpression = (IBinaryOperatorExpression)expression;


### PR DESCRIPTION
## Summary

Fixes #309

PC0022 (`PossibleOverflowAssigning`) was not raising a diagnostic when an XmlPort `textelement` (unbounded `Text`) was passed to `.Get()`, `.Validate()`, or `.SetFilter()` on a length-constrained field (e.g., `Code[20]`).

## Root cause

`CalculateMaxExpressionLength` handles specific `OperationKind` values to resolve expression lengths. The `XmlPortDataItemAccess` kind (used for all xmlport node accesses including textelements) was not handled, causing the method to fall through to `isError = true` and silently suppress the diagnostic.

## Fix

Added `XmlPortDataItemAccess` to the expression kind switch in `CalculateMaxExpressionLength`, so textelement type length (`int.MaxValue` for unbounded Text) is correctly resolved and compared against the target field length.

## Test coverage

Added 3 HasDiagnostic test fixtures:
- `GetMethodXmlPortTextElement` - textelement passed to `.Get()` with Code[20] PK
- `ValidateFieldCodeXmlPortTextElement` - textelement passed to `.Validate()` on Code[20] field
- `SetFilterFieldCodeXmlPortTextElement` - textelement passed to `.SetFilter()` on Code[20] field

All 1,061 tests pass (0 failures, 13 skipped).