### PR TITLE
fix(AC0004): Skip Confirm diagnostic on PageExtension objects

### DIFF
--- a/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/ConfirmImplementConfirmManagement.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/ConfirmImplementConfirmManagement.cs
@@ -37,6 +37,12 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("PageExtension")]
         public async Task NoDiagnostic(string testCase)
         {
+            SkipTestIfVersionIsTooLow(
+                ["PageExtension"],
+                testCase,
+                "13.0",
+                "No support for tableextensions when target itself is already declared in the same module");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/ConfirmImplementConfirmManagement.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/ConfirmImplementConfirmManagement.cs
@@ -34,6 +34,7 @@ namespace ALCops.ApplicationCop.Test
         [Test]
         [TestCase("ObsoletePending")]
         [TestCase("Page")]
+        [TestCase("PageExtension")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/NoDiagnostic/PageExtension.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/ConfirmImplementConfirmManagement/NoDiagnostic/PageExtension.al
@@ -1,0 +1,11 @@
+pageextension 50100 MyPageExtension extends MyPage
+{
+    procedure MyProcedure()
+    begin
+        if [|Confirm('Are You Sure?')|] then;
+    end;
+}
+
+page 50100 MyPage
+{
+}

--- a/src/ALCops.ApplicationCop/Analyzers/BuiltInMethodImplementThroughCodeunit.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/BuiltInMethodImplementThroughCodeunit.cs
@@ -41,6 +41,11 @@ public sealed class BuiltInMethodImplementThroughCodeunit : DiagnosticAnalyzer
                     return;
                 }
 
+                if (containingType.NavTypeKind == EnumProvider.NavTypeKind.PageExtension)
+                {
+                    return;
+                }
+
                 ctx.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.ConfirmImplementConfirmManagement,
                     ctx.Operation.Syntax.GetLocation()));


### PR DESCRIPTION
## Summary

Skip AC0004 (`ConfirmImplementConfirmManagement`) on PageExtension objects, matching the existing behavior for non-API Page objects.

## Changes

- Added `NavTypeKind.PageExtension` check in `BuiltInMethodImplementThroughCodeunit` analyzer to skip the Confirm diagnostic on page extensions
- Added `NoDiagnostic/PageExtension.al` test fixture
- Added `PageExtension` test case to the test class

## Rationale

PageExtension objects run in the same UI context as Pages. Calling `Confirm` directly is valid because the page extension has access to the same confirmation UI as its base page. The `ConfirmManagement` codeunit doesn't add value in this context.

## Related

- Closes #313
- Follow-up audit issue: #315 (other analyzers with potential gaps for extension objects)