### PR TITLE
fix(AC0032): handle method calls without parentheses

### DIFF
--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -142,7 +142,7 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 ## Test coverage
 
 **HasDiagnostic (10 cases):** EntireEntryUnused, PartialCharsUnused, MultipleUnusedEntries, NoCodeInCodeunit, UnusedOnReport, UnusedOnQuery, UnusedOnXmlPort, TemporaryRecord, ParameterPartialUnused, ReportDataItemPartialUnused.
-**NoDiagnostic (21 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable, ParameterOperations, UppercasePermissions, ParameterAllOperations, LocalVarSpacedTable, GlobalVarSpacedTable, ReportDataItemModify, ReportDataItemAliasModify, XmlPortTableElementModify, XmlPortNestedTableElementModify, ReturnParameterRead, ReportNestedDataItemRead, QueryNestedDataItemRead.
+**NoDiagnostic (25 cases):** AllPermissionsUsed, PageSourceTable, TestCodeunitDisabled, ReadUsed, ReportDataItemRead, QueryDataItemRead, PermissionSet, PermissionSetExtension, SystemTable, ParameterOperations, UppercasePermissions, ParameterAllOperations, LocalVarSpacedTable, GlobalVarSpacedTable, ReportDataItemModify, ReportDataItemAliasModify, XmlPortTableElementModify, XmlPortNestedTableElementModify, ReturnParameterRead, ReportNestedDataItemRead, QueryNestedDataItemRead, MethodWithoutParenthesesCount, MethodWithoutParenthesesFindFirst, MethodWithoutParenthesesIsEmpty, MethodWithoutParenthesesChained.
 **HasFix (4 cases):** RemoveEntireEntry, ReduceChars, RemoveEntireProperty, ReplaceChars.
 
 ## Known limitations
@@ -151,3 +151,9 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 2. **CalcFields/CalcSums**: Indirect table access through FlowFields is not traced
 3. **InherentPermissions overlap**: Table-level `InherentPermissions` may make an object-level entry redundant, but the analyzer does not flag this (different concern from unused)
 4. **Cross-object calls**: If codeunit A calls codeunit B, and B accesses a table, A's permission for that table appears unused (correct, because permissions don't flow through the call stack)
+
+## Design decisions (continued)
+
+| Decision | Rationale |
+|---|---|
+| Handle `MemberAccessExpressionSyntax` without parent `InvocationExpressionSyntax` | AL allows method calls without parentheses (e.g., `MyTable.Count`); the parser produces `MemberAccessExpressionSyntax` instead of `InvocationExpressionSyntax`. Both the collection loop and `HasPossibleDbInvocation` pre-filter must check for this. Fixed in #295. |

--- a/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
+++ b/.github/instructions/ac0032-table-data-access-unused-permissions.instructions.md
@@ -52,8 +52,8 @@ src/ALCops.Common/
    - Skip obsolete methods via `GetDeclaredSymbol` + `IsObsolete()`
    - For each method body: syntax pre-filter (`HasPossibleDbInvocation`)
    - Build per-method record variable map from `IMethodSymbol.LocalVariables` + `.Parameters`
-   - Walk method body for `InvocationExpressionSyntax`, resolve via variable map lookup (fast path)
-   - Fall back to `GetSymbolInfo` only for complex receivers (function calls, array indexing)
+   - Walk method body for both `InvocationExpressionSyntax` and standalone `MemberAccessExpressionSyntax` (method calls without parentheses)
+   - Unified `TryGetPermissionFromDbAccess` extracts method name + receiver from either form, resolves via variable map (fast path), falls back to `GetSymbolInfo` for complex receivers
 5. **Collect data items** (`CollectFromDataItems`):
    - Iterate `containingObject.GetMembers()` for ReportDataItem, QueryDataItem, XmlPortNode symbols
    - For XmlPortNode: also iterate `FlattenedNodes` to reach nested table elements
@@ -65,14 +65,12 @@ src/ALCops.Common/
 | Method | Purpose |
 |---|---|
 | `AnalyzeApplicationObject` | Entry point; checks Permissions, orchestrates collection and reporting |
-| `CollectFromInvocations` | Builds object-scope record map (vars + data items), walks method bodies, resolves DB calls via syntax + symbol lookup |
-| `TryGetPermissionFromInvocation` | Resolves a single invocation: fast path via variable map, fallback via GetSymbolInfo |
-| `TryGetPermissionViaSymbolInfo` | Fallback for complex receivers: uses GetSymbolInfo to resolve method and receiver type |
+| `CollectFromInvocations` | Builds object-scope record map (vars + data items), walks method bodies, resolves DB calls via unified handler |
+| `TryGetPermissionFromDbAccess` | Unified resolution for both syntax forms (with/without parentheses): pattern-matches to extract method name + receiver, uses variable-map fast path, falls back to `TryGetPermissionViaSymbolInfo` |
+| `TryGetPermissionViaSymbolInfo` | Fallback for complex receivers: uses GetSymbolInfo on the node and receiver expression to resolve method and receiver type |
 | `CollectFromDataItems` | Iterates report/query FlattenedDataItems and xmlport FlattenedXmlPortNodes (all via reflection) for implicit read permissions |
-| `CollectFromQueryDataItems` | Uses reflection to access internal `FlattenedDataItems` on QueryTypeSymbol |
-| `AddNestedQueryDataItemsToVarMap` | Adds nested query data items to the object-scope record map via reflection |
 | `AddXmlPortNodeToVarMap` | Adds an xmlport table element to the object-scope record map if it references a non-temporary table |
-| `HasPossibleDbInvocation` | Syntax pre-filter: checks if body has any invocation name matching a DB operation |
+| `HasPossibleDbInvocation` | Syntax pre-filter: checks if body has any invocation name matching a DB operation (handles both syntax forms) |
 | `AnalyzePermissionEntry` | Compares one declared entry against collected required permissions |
 | `PermissionMatchesTable` | Matches identifier/qualified/objectId syntax against `ITableTypeSymbol` |
 
@@ -156,4 +154,4 @@ When removing the first entry from a multi-entry list, `SeparatedSyntaxList.Remo
 
 | Decision | Rationale |
 |---|---|
-| Handle `MemberAccessExpressionSyntax` without parent `InvocationExpressionSyntax` | AL allows method calls without parentheses (e.g., `MyTable.Count`); the parser produces `MemberAccessExpressionSyntax` instead of `InvocationExpressionSyntax`. Both the collection loop and `HasPossibleDbInvocation` pre-filter must check for this. Fixed in #295. |
+| Handle `MemberAccessExpressionSyntax` without parent `InvocationExpressionSyntax` | AL allows method calls without parentheses (e.g., `MyTable.Count`); the parser produces `MemberAccessExpressionSyntax` instead of `InvocationExpressionSyntax`. Unified in `TryGetPermissionFromDbAccess` which pattern-matches both forms at entry, then uses a single resolution path. The `HasPossibleDbInvocation` pre-filter also checks both forms. |

--- a/.github/instructions/sdk-analyzer-infrastructure.instructions.md
+++ b/.github/instructions/sdk-analyzer-infrastructure.instructions.md
@@ -211,3 +211,44 @@ It is NOT safe when used to accumulate mutable state across `CodeBlockAction` ca
 | `SemanticModel.cs:43-45` | `GetSymbolInfo(SyntaxNode)` public API |
 | `SemanticModel.cs:302` | `GetSymbolInfo(ExpressionSyntax)` public API |
 | `SemanticModel.cs:1130` | `GetOperation(SyntaxNode)` public API |
+
+## Common pitfalls
+
+### AL method calls without parentheses
+
+**CRITICAL:** AL allows calling methods without parentheses (e.g., `MyTable.Count` instead of `MyTable.Count()`). When parentheses are omitted, the parser produces a `MemberAccessExpressionSyntax` instead of wrapping it in an `InvocationExpressionSyntax`.
+
+**Impact on analyzers:**
+
+1. **Manual syntax walks** that filter on `InvocationExpressionSyntax` will miss these calls entirely.
+2. **Operation-based analyzers** that cast `operation.Syntax` to `InvocationExpressionSyntax` will get a null/failed cast (the operation is still delivered as `IInvocationExpression`, but `.Syntax` points to `MemberAccessExpressionSyntax`).
+
+**Recommended patterns:**
+
+```csharp
+// Pattern 1: Manual syntax walk — handle both forms
+foreach (var descendant in body.DescendantNodes())
+{
+    if (descendant is InvocationExpressionSyntax invocation)
+    {
+        // Handle invocation with parentheses
+    }
+    else if (descendant is MemberAccessExpressionSyntax memberAccess
+        && memberAccess.Parent is not InvocationExpressionSyntax)
+    {
+        // Handle method call without parentheses
+    }
+}
+
+// Pattern 2: Operation-based — handle both syntax forms
+if (operation.Syntax is InvocationExpressionSyntax invocationSyntax)
+{
+    // Extract from InvocationExpressionSyntax
+}
+else if (operation.Syntax is MemberAccessExpressionSyntax memberAccessSyntax)
+{
+    // Extract from MemberAccessExpressionSyntax (no-parens form)
+}
+```
+
+**Best practice:** Prefer `RegisterOperationAction` which normalizes both forms into `IInvocationExpression`. Only use manual syntax walks when performance requires avoiding `GetOperation()` costs. When you do walk syntax, always handle both `InvocationExpressionSyntax` and parentheses-free `MemberAccessExpressionSyntax`.

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesChained.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesChained.al
@@ -1,0 +1,26 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        myText: Text;
+    begin
+        myText := Format(MyTable.Count);
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesCount.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesCount.al
@@ -1,0 +1,26 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        myInt: Integer;
+    begin
+        myInt := MyTable.Count;
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesFindFirst.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesFindFirst.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.FindFirst;
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesIsEmpty.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/NoDiagnostic/MethodWithoutParenthesesIsEmpty.al
@@ -1,0 +1,26 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = [|tabledata MyTable = r|];
+
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        result: Boolean;
+    begin
+        result := MyTable.IsEmpty;
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessUnusedPermissions/TableDataAccessUnusedPermissions.cs
@@ -61,6 +61,10 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("ReturnParameterRead")]
         [TestCase("ReportNestedDataItemRead")]
         [TestCase("QueryNestedDataItemRead")]
+        [TestCase("MethodWithoutParenthesesCount")]
+        [TestCase("MethodWithoutParenthesesFindFirst")]
+        [TestCase("MethodWithoutParenthesesIsEmpty")]
+        [TestCase("MethodWithoutParenthesesChained")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -155,53 +155,66 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
                 localRecordVarMap.TryAdd(returnValue.Name, returnRecordType);
             }
 
-            // Walk method body for DB invocations
+            // Walk method body for DB invocations (handles both with and without parentheses)
             foreach (var descendant in body.DescendantNodes())
             {
-                RequiredPermission? permission = null;
-
-                if (descendant is InvocationExpressionSyntax invocation)
+                if (descendant is InvocationExpressionSyntax
+                    || (descendant is MemberAccessExpressionSyntax ma && ma.Parent is not InvocationExpressionSyntax))
                 {
-                    permission = TryGetPermissionFromInvocation(
-                        invocation, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
-                }
-                else if (descendant is MemberAccessExpressionSyntax memberAccess
-                    && memberAccess.Parent is not InvocationExpressionSyntax)
-                {
-                    // Method call without parentheses (e.g., MyTable.Count instead of MyTable.Count())
-                    permission = TryGetPermissionFromMemberAccess(
-                        memberAccess, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
-                }
+                    var permission = TryGetPermissionFromDbAccess(
+                        descendant, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
 
-                if (permission is not null)
-                    requiredPermissions.Add(permission.Value);
+                    if (permission is not null)
+                        requiredPermissions.Add(permission.Value);
+                }
             }
         }
     }
 
-    private static RequiredPermission? TryGetPermissionFromInvocation(
-        InvocationExpressionSyntax invocation,
+    /// <summary>
+    /// Resolves a DB access from either syntax form:
+    /// - InvocationExpressionSyntax (with parentheses: MyTable.Find())
+    /// - MemberAccessExpressionSyntax without parent InvocationExpressionSyntax (no parens: MyTable.Count)
+    /// Uses variable-map fast path when possible, falls back to GetSymbolInfo for complex receivers.
+    /// </summary>
+    private static RequiredPermission? TryGetPermissionFromDbAccess(
+        SyntaxNode node,
         IApplicationObjectTypeSymbol containingObject,
         Dictionary<string, IRecordTypeSymbol>? localRecordVarMap,
         Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap,
         SyntaxNodeAnalysisContext ctx)
     {
-        // Extract method name and receiver from syntax
-        string? methodName = null;
-        string? receiverName = null;
-        bool hasComplexReceiver = false;
+        // Extract method name, receiver expression, and location from either syntax form
+        string? methodName;
+        ExpressionSyntax? receiverExpression;
+        bool hasImplicitSelf = false;
 
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        if (node is InvocationExpressionSyntax invocation)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax invMemberAccess)
+            {
+                methodName = invMemberAccess.Name.Identifier.ValueText;
+                receiverExpression = invMemberAccess.Expression;
+            }
+            else if (invocation.Expression is IdentifierNameSyntax simpleName)
+            {
+                methodName = simpleName.Identifier.ValueText;
+                receiverExpression = null;
+                hasImplicitSelf = true;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        else if (node is MemberAccessExpressionSyntax memberAccess)
         {
             methodName = memberAccess.Name.Identifier.ValueText;
-            if (memberAccess.Expression is IdentifierNameSyntax identifierName)
-                receiverName = identifierName.Identifier.ValueText?.UnquoteIdentifier();
-            else
-                hasComplexReceiver = true;
+            receiverExpression = memberAccess.Expression;
         }
-        else if (invocation.Expression is IdentifierNameSyntax simpleName)
+        else
         {
-            methodName = simpleName.Identifier.ValueText;
+            return null;
         }
 
         if (methodName is null)
@@ -211,48 +224,53 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (operation == DatabaseOperation.None)
             return null;
 
-        // Fast path: resolve receiver via variable map lookup
-        if (receiverName is not null)
-        {
-            IRecordTypeSymbol? recordType = null;
-
-            if (localRecordVarMap is not null)
-                localRecordVarMap.TryGetValue(receiverName, out recordType);
-
-            if (recordType is null && objectScopeRecordMap is not null)
-                objectScopeRecordMap.TryGetValue(receiverName, out recordType);
-
-            if (recordType is not null)
-            {
-                var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
-                if (tableType is not null)
-                    return new RequiredPermission(tableType, recordType, operation, invocation.GetLocation());
-                return null;
-            }
-        }
-
         // Implicit self (no receiver, inside table/tableext)
-        if (receiverName is null && !hasComplexReceiver)
+        if (hasImplicitSelf)
         {
             if (containingObject is IRecordTypeSymbol selfRecord && !selfRecord.Temporary)
             {
                 var tableType = selfRecord.OriginalDefinition as ITableTypeSymbol;
                 if (tableType is not null)
-                    return new RequiredPermission(tableType, selfRecord, operation, invocation.GetLocation());
+                    return new RequiredPermission(tableType, selfRecord, operation, node.GetLocation());
             }
             return null;
         }
 
-        // Fallback: complex receiver or unresolved simple name (use GetSymbolInfo)
-        return TryGetPermissionViaSymbolInfo(invocation, containingObject, ctx);
+        // Fast path: resolve receiver via variable map lookup
+        if (receiverExpression is IdentifierNameSyntax identifierName)
+        {
+            var receiverName = identifierName.Identifier.ValueText?.UnquoteIdentifier();
+            if (receiverName is not null)
+            {
+                IRecordTypeSymbol? recordType = null;
+
+                if (localRecordVarMap is not null)
+                    localRecordVarMap.TryGetValue(receiverName, out recordType);
+
+                if (recordType is null && objectScopeRecordMap is not null)
+                    objectScopeRecordMap.TryGetValue(receiverName, out recordType);
+
+                if (recordType is not null)
+                {
+                    var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
+                    if (tableType is not null)
+                        return new RequiredPermission(tableType, recordType, operation, node.GetLocation());
+                    return null;
+                }
+            }
+        }
+
+        // Fallback: complex receiver or unresolved name (use GetSymbolInfo)
+        return TryGetPermissionViaSymbolInfo(node, receiverExpression, containingObject, ctx);
     }
 
     private static RequiredPermission? TryGetPermissionViaSymbolInfo(
-        InvocationExpressionSyntax invocation,
+        SyntaxNode node,
+        ExpressionSyntax? receiverExpression,
         IApplicationObjectTypeSymbol containingObject,
         SyntaxNodeAnalysisContext ctx)
     {
-        var symbolInfo = ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken);
+        var symbolInfo = ctx.SemanticModel.GetSymbolInfo(node, ctx.CancellationToken);
         if (symbolInfo.Symbol is not IMethodSymbol targetMethod)
             return null;
 
@@ -263,12 +281,11 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (operation == DatabaseOperation.None)
             return null;
 
-        // Get receiver type via GetSymbolInfo on the receiver expression
         IRecordTypeSymbol? recordType = null;
 
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        if (receiverExpression is not null)
         {
-            var receiverSymbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess.Expression, ctx.CancellationToken);
+            var receiverSymbolInfo = ctx.SemanticModel.GetSymbolInfo(receiverExpression, ctx.CancellationToken);
             ITypeSymbol? receiverType = receiverSymbolInfo.Symbol switch
             {
                 IVariableSymbol v => v.Type,
@@ -290,84 +307,7 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         if (tableType is null)
             return null;
 
-        return new RequiredPermission(tableType, recordType, operation, invocation.GetLocation());
-    }
-
-    /// <summary>
-    /// Handles method calls without parentheses (e.g., MyTable.Count instead of MyTable.Count()).
-    /// AL allows omitting parentheses on method calls; the parser produces a MemberAccessExpressionSyntax
-    /// rather than wrapping it in an InvocationExpressionSyntax.
-    /// </summary>
-    private static RequiredPermission? TryGetPermissionFromMemberAccess(
-        MemberAccessExpressionSyntax memberAccess,
-        IApplicationObjectTypeSymbol containingObject,
-        Dictionary<string, IRecordTypeSymbol>? localRecordVarMap,
-        Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap,
-        SyntaxNodeAnalysisContext ctx)
-    {
-        string? methodName = memberAccess.Name.Identifier.ValueText;
-        if (methodName is null)
-            return null;
-
-        var operation = MethodOperationMap.GetOperation(methodName);
-        if (operation == DatabaseOperation.None)
-            return null;
-
-        // Fast path: resolve receiver via variable map lookup
-        if (memberAccess.Expression is IdentifierNameSyntax identifierName)
-        {
-            var receiverName = identifierName.Identifier.ValueText?.UnquoteIdentifier();
-            if (receiverName is not null)
-            {
-                IRecordTypeSymbol? recordType = null;
-
-                if (localRecordVarMap is not null)
-                    localRecordVarMap.TryGetValue(receiverName, out recordType);
-
-                if (recordType is null && objectScopeRecordMap is not null)
-                    objectScopeRecordMap.TryGetValue(receiverName, out recordType);
-
-                if (recordType is not null)
-                {
-                    var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
-                    if (tableType is not null)
-                        return new RequiredPermission(tableType, recordType, operation, memberAccess.GetLocation());
-                    return null;
-                }
-            }
-        }
-
-        // Fallback: complex receiver — use GetSymbolInfo on the member access itself
-        var symbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess, ctx.CancellationToken);
-        if (symbolInfo.Symbol is not IMethodSymbol targetMethod)
-            return null;
-
-        if (targetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
-            return null;
-
-        var resolvedOperation = MethodOperationMap.GetOperation(targetMethod.Name);
-        if (resolvedOperation == DatabaseOperation.None)
-            return null;
-
-        // Get receiver type from the expression part
-        var receiverSymbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess.Expression, ctx.CancellationToken);
-        ITypeSymbol? receiverType = receiverSymbolInfo.Symbol switch
-        {
-            IVariableSymbol v => v.Type,
-            IParameterSymbol p => p.ParameterType,
-            IMethodSymbol m => m.ReturnValueSymbol?.ReturnType,
-            _ => null
-        };
-
-        var resolvedRecordType = receiverType as IRecordTypeSymbol;
-        if (resolvedRecordType is null || resolvedRecordType.Temporary)
-            return null;
-
-        var resolvedTableType = resolvedRecordType.OriginalDefinition as ITableTypeSymbol;
-        if (resolvedTableType is null)
-            return null;
-
-        return new RequiredPermission(resolvedTableType, resolvedRecordType, resolvedOperation, memberAccess.GetLocation());
+        return new RequiredPermission(tableType, recordType, operation, node.GetLocation());
     }
 
     private static void CollectFromDataItems(

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataAccessUnusedPermissions.cs
@@ -158,11 +158,20 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
             // Walk method body for DB invocations
             foreach (var descendant in body.DescendantNodes())
             {
-                if (descendant is not InvocationExpressionSyntax invocation)
-                    continue;
+                RequiredPermission? permission = null;
 
-                var permission = TryGetPermissionFromInvocation(
-                    invocation, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
+                if (descendant is InvocationExpressionSyntax invocation)
+                {
+                    permission = TryGetPermissionFromInvocation(
+                        invocation, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
+                }
+                else if (descendant is MemberAccessExpressionSyntax memberAccess
+                    && memberAccess.Parent is not InvocationExpressionSyntax)
+                {
+                    // Method call without parentheses (e.g., MyTable.Count instead of MyTable.Count())
+                    permission = TryGetPermissionFromMemberAccess(
+                        memberAccess, containingObject, localRecordVarMap, objectScopeRecordMap, ctx);
+                }
 
                 if (permission is not null)
                     requiredPermissions.Add(permission.Value);
@@ -284,6 +293,83 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
         return new RequiredPermission(tableType, recordType, operation, invocation.GetLocation());
     }
 
+    /// <summary>
+    /// Handles method calls without parentheses (e.g., MyTable.Count instead of MyTable.Count()).
+    /// AL allows omitting parentheses on method calls; the parser produces a MemberAccessExpressionSyntax
+    /// rather than wrapping it in an InvocationExpressionSyntax.
+    /// </summary>
+    private static RequiredPermission? TryGetPermissionFromMemberAccess(
+        MemberAccessExpressionSyntax memberAccess,
+        IApplicationObjectTypeSymbol containingObject,
+        Dictionary<string, IRecordTypeSymbol>? localRecordVarMap,
+        Dictionary<string, IRecordTypeSymbol>? objectScopeRecordMap,
+        SyntaxNodeAnalysisContext ctx)
+    {
+        string? methodName = memberAccess.Name.Identifier.ValueText;
+        if (methodName is null)
+            return null;
+
+        var operation = MethodOperationMap.GetOperation(methodName);
+        if (operation == DatabaseOperation.None)
+            return null;
+
+        // Fast path: resolve receiver via variable map lookup
+        if (memberAccess.Expression is IdentifierNameSyntax identifierName)
+        {
+            var receiverName = identifierName.Identifier.ValueText?.UnquoteIdentifier();
+            if (receiverName is not null)
+            {
+                IRecordTypeSymbol? recordType = null;
+
+                if (localRecordVarMap is not null)
+                    localRecordVarMap.TryGetValue(receiverName, out recordType);
+
+                if (recordType is null && objectScopeRecordMap is not null)
+                    objectScopeRecordMap.TryGetValue(receiverName, out recordType);
+
+                if (recordType is not null)
+                {
+                    var tableType = recordType.OriginalDefinition as ITableTypeSymbol;
+                    if (tableType is not null)
+                        return new RequiredPermission(tableType, recordType, operation, memberAccess.GetLocation());
+                    return null;
+                }
+            }
+        }
+
+        // Fallback: complex receiver — use GetSymbolInfo on the member access itself
+        var symbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess, ctx.CancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol targetMethod)
+            return null;
+
+        if (targetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
+            return null;
+
+        var resolvedOperation = MethodOperationMap.GetOperation(targetMethod.Name);
+        if (resolvedOperation == DatabaseOperation.None)
+            return null;
+
+        // Get receiver type from the expression part
+        var receiverSymbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess.Expression, ctx.CancellationToken);
+        ITypeSymbol? receiverType = receiverSymbolInfo.Symbol switch
+        {
+            IVariableSymbol v => v.Type,
+            IParameterSymbol p => p.ParameterType,
+            IMethodSymbol m => m.ReturnValueSymbol?.ReturnType,
+            _ => null
+        };
+
+        var resolvedRecordType = receiverType as IRecordTypeSymbol;
+        if (resolvedRecordType is null || resolvedRecordType.Temporary)
+            return null;
+
+        var resolvedTableType = resolvedRecordType.OriginalDefinition as ITableTypeSymbol;
+        if (resolvedTableType is null)
+            return null;
+
+        return new RequiredPermission(resolvedTableType, resolvedRecordType, resolvedOperation, memberAccess.GetLocation());
+    }
+
     private static void CollectFromDataItems(
         IApplicationObjectTypeSymbol containingObject,
         List<RequiredPermission> requiredPermissions)
@@ -328,24 +414,32 @@ public class TableDataAccessUnusedPermissions : DiagnosticAnalyzer
 
     /// <summary>
     /// Syntax-level check: does the body contain any invocation with a name that maps to a DB operation?
+    /// Checks both InvocationExpressionSyntax (with parens) and standalone MemberAccessExpressionSyntax (without parens).
     /// </summary>
     private static bool HasPossibleDbInvocation(BlockSyntax body)
     {
         foreach (var node in body.DescendantNodes())
         {
-            if (!node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
-                continue;
-
-            var invocationSyntax = (InvocationExpressionSyntax)node;
-            string? methodName = invocationSyntax.Expression switch
+            if (node.IsKind(EnumProvider.SyntaxKind.InvocationExpression))
             {
-                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
-                IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
-                _ => null
-            };
+                var invocationSyntax = (InvocationExpressionSyntax)node;
+                string? methodName = invocationSyntax.Expression switch
+                {
+                    MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+                    IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
+                    _ => null
+                };
 
-            if (methodName is not null && MethodOperationMap.GetOperation(methodName) != DatabaseOperation.None)
-                return true;
+                if (methodName is not null && MethodOperationMap.GetOperation(methodName) != DatabaseOperation.None)
+                    return true;
+            }
+            else if (node is MemberAccessExpressionSyntax memberAccessNode
+                && memberAccessNode.Parent is not InvocationExpressionSyntax)
+            {
+                string? methodName = memberAccessNode.Name.Identifier.ValueText;
+                if (methodName is not null && MethodOperationMap.GetOperation(methodName) != DatabaseOperation.None)
+                    return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
## Problem

AC0032 reported false positives when Record methods were invoked without parentheses (e.g., `MyTable.Count` instead of `MyTable.Count()`). AL allows both syntactic forms, but without parentheses the parser produces a `MemberAccessExpressionSyntax` rather than an `InvocationExpressionSyntax`.

## Root Cause

`CollectFromInvocations` only walked `InvocationExpressionSyntax` nodes, completely missing the parentheses-free form. The `HasPossibleDbInvocation` pre-filter had the same blind spot.

## Fix

- Added handling for `MemberAccessExpressionSyntax` nodes whose parent is NOT an `InvocationExpressionSyntax`
- Updated `HasPossibleDbInvocation` to also check `MemberAccessExpressionSyntax` identifiers
- Both paths use the same fast-path variable map lookup + fallback to `GetSymbolInfo`

## Refactor: unified resolution method

In a follow-up commit, the separate `TryGetPermissionFromInvocation`, `TryGetPermissionFromMemberAccess`, and `TryGetPermissionViaSymbolInfo` methods were replaced with a single `TryGetPermissionFromDbAccess` that handles both syntax forms through one resolution path:

- Pattern-matches at entry to extract method name + receiver expression from either `InvocationExpressionSyntax` or standalone `MemberAccessExpressionSyntax`
- Single variable-map fast path for both forms
- Unified `GetSymbolInfo` fallback that accepts the receiver expression directly

Net result: **-62 lines**, elimination of ~80% code duplication.

## Tests

Added 4 NoDiagnostic test cases:
- `MethodWithoutParenthesesCount` — `MyTable.Count` in assignment
- `MethodWithoutParenthesesFindFirst` — `MyTable.FindFirst` as statement
- `MethodWithoutParenthesesIsEmpty` — `MyTable.IsEmpty` in assignment
- `MethodWithoutParenthesesChained` — `Format(MyTable.Count)` as argument

## Instruction updates

- Updated AC0032 instruction file with unified method documentation and design decisions
- Added "Common pitfalls" section to `sdk-analyzer-infrastructure.instructions.md` documenting this AL parser behavior

## Related

- Fixes #295
- Filed #326 for other rules potentially affected by the same pattern