### PR TITLE
fix(AC0030): handle method calls without parentheses

### DIFF
--- a/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/HasDiagnostic/FindFirstMethodWithoutParentheses.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/HasDiagnostic/FindFirstMethodWithoutParentheses.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|FindFirst|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Code[20]) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/HasDiagnostic/GetMethodWithoutParentheses.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/HasDiagnostic/GetMethodWithoutParentheses.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|Get|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Code[20]) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/NoDiagnostic/FindFirstMethodWithoutParentheses.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/NoDiagnostic/FindFirstMethodWithoutParentheses.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if MyTable.[|FindFirst|] then;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Code[20]) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/NoDiagnostic/GetMethodWithoutParentheses.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/NoDiagnostic/GetMethodWithoutParentheses.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        if MyTable.[|Get|] then;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Code[20]) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/UseReturnValueForDatabaseReadMethods.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/UseReturnValueForDatabaseReadMethods/UseReturnValueForDatabaseReadMethods.cs
@@ -21,6 +21,8 @@ namespace ALCops.ApplicationCop.Test
         [Test]
         [TestCase("GetMethod")]
         [TestCase("GetBySystemIdMethod")]
+        [TestCase("GetMethodWithoutParentheses")]
+        [TestCase("FindFirstMethodWithoutParentheses")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -32,6 +34,8 @@ namespace ALCops.ApplicationCop.Test
         [Test]
         [TestCase("GetMethod")]
         [TestCase("GetBySystemIdMethod")]
+        [TestCase("GetMethodWithoutParentheses")]
+        [TestCase("FindFirstMethodWithoutParentheses")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.ApplicationCop/Analyzers/UseReturnValueForDatabaseReadMethods.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/UseReturnValueForDatabaseReadMethods.cs
@@ -41,10 +41,9 @@ public class UseReturnValueForDatabaseReadMethods : DiagnosticAnalyzer
         if (ctx.Operation.Syntax.Parent.Kind == EnumProvider.SyntaxKind.ExpressionStatement)
         {
             var methodName = invocation.TargetMethod.Name;
-            if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax)
-                return;
-
-            var location = invocationSyntax.Expression.GetLocation();
+            var location = invocation.Syntax is InvocationExpressionSyntax invocationSyntax
+                ? invocationSyntax.Expression.GetLocation()
+                : invocation.Syntax.GetLocation();
 
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.UseReturnValueForDatabaseReadMethods,


### PR DESCRIPTION
## Summary
- Fix false negative in `UseReturnValueForDatabaseReadMethods` when database read methods (`Get`, `FindFirst`, `FindLast`, `Find`) are called without parentheses
- AL allows `MyTable.Get` instead of `MyTable.Get()` — the operation callback fires for both, but the syntax cast to `InvocationExpressionSyntax` failed for the no-parens form
- Extract diagnostic location from either `InvocationExpressionSyntax` (with parens) or `MemberAccessExpressionSyntax` (without parens)

Partial fix for #326

## Test plan
- [x] Added `HasDiagnostic` test fixtures for `GetMethodWithoutParentheses` and `FindFirstMethodWithoutParentheses`
- [x] Added `NoDiagnostic` test fixtures for the same (return value used via `if ... then`)
- [x] All 8 tests pass (4 existing + 4 new)
- [x] CI build and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)