### PR TITLE
fix(LC0047): improve diagnostic location for method calls without parentheses

### DIFF
--- a/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/ExplicitlySetRunTrigger.cs
+++ b/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/ExplicitlySetRunTrigger.cs
@@ -24,6 +24,10 @@ namespace ALCops.LinterCop.Test
         [TestCase("Insert")]
         [TestCase("Modify")]
         [TestCase("ModifyAll")]
+        [TestCase("DeleteWithoutParentheses")]
+        [TestCase("DeleteAllWithoutParentheses")]
+        [TestCase("InsertWithoutParentheses")]
+        [TestCase("ModifyWithoutParentheses")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/DeleteAllWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/DeleteAllWithoutParentheses.al
@@ -1,0 +1,12 @@
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|DeleteAll|];
+    end;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/DeleteWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/DeleteWithoutParentheses.al
@@ -1,0 +1,12 @@
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|Delete|];
+    end;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/InsertWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/InsertWithoutParentheses.al
@@ -1,0 +1,12 @@
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|Insert|];
+    end;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/ModifyWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/ExplicitlySetRunTrigger/HasDiagnostic/ModifyWithoutParentheses.al
@@ -1,0 +1,12 @@
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.[|Modify|];
+    end;
+}
+
+table 50100 MyTable { fields { field(1; MyField; Integer) { } } }

--- a/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
+++ b/src/ALCops.LinterCop/Analyzers/ExplicitlySetRunTrigger.cs
@@ -54,11 +54,13 @@ public sealed class ExplicitlySetRunTrigger : DiagnosticAnalyzer
 
     private static Location GetInvocationNameLocation(IInvocationExpression invocation)
     {
-        if (invocation.Syntax is InvocationExpressionSyntax invocationSyntax &&
-            invocationSyntax.Expression is MemberAccessExpressionSyntax memberAccess)
-        {
+        var syntax = invocation.Syntax;
+
+        if (syntax is InvocationExpressionSyntax invocationSyntax)
+            syntax = invocationSyntax.Expression;
+
+        if (syntax is MemberAccessExpressionSyntax memberAccess)
             return memberAccess.Name.GetLocation();
-        }
 
         return invocation.Syntax.GetLocation();
     }


### PR DESCRIPTION
## Summary
- Fix imprecise diagnostic squiggle location in `ExplicitlySetRunTrigger` for method calls without parentheses
- AL allows `MyTable.Delete` instead of `MyTable.Delete()` — the diagnostic was correctly reported, but the squiggle underlined the entire expression instead of just the method name
- Refactor `GetInvocationNameLocation` to unwrap `InvocationExpressionSyntax` first, then handle `MemberAccessExpressionSyntax` uniformly for both forms

Partial fix for #326

## Test plan
- [x] Added `HasDiagnostic` test fixtures for `DeleteWithoutParentheses`, `InsertWithoutParentheses`, `ModifyWithoutParentheses`, `DeleteAllWithoutParentheses`
- [x] All 19 tests pass (15 existing + 4 new)
- [x] CI build and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)