### PR TITLE
fix: handle method calls without parentheses in cognitive complexity recursion detection

### DIFF
--- a/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/CognitiveComplexity.cs
+++ b/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/CognitiveComplexity.cs
@@ -24,6 +24,8 @@ namespace ALCops.LinterCop.Test
         [TestCase("IfStatementNested")]
         [TestCase("RecursionDirect")]
         [TestCase("RecursionIndirect")]
+        [TestCase("RecursionDirectWithoutParentheses")]
+        [TestCase("RecursionIndirectWithoutParentheses")]
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
@@ -33,7 +35,7 @@ namespace ALCops.LinterCop.Test
                 "This test requires .NET 8 or higher due to the use of Conditional Expressions.");
 
             SkipTestIfVersionIsTooLow(
-                ["RecursionDirect", "RecursionIndirect"],
+                ["RecursionDirect", "RecursionIndirect", "RecursionDirectWithoutParentheses", "RecursionIndirectWithoutParentheses"],
                 testCase,
                 "14.0",
                 "The this keyword is not supported in versions prior to 14.0.");

--- a/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/HasDiagnostic/RecursionDirectWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/HasDiagnostic/RecursionDirectWithoutParentheses.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|MyProcedure|]() // Cognitive Complexity: 15 (threshold >=15)
+    var
+        Condition: Boolean;
+    begin
+        MyProcedure;            // +1 (nesting = 0)
+        if true then            // +1 (nesting = 0)
+            if true then        // +2 (nesting = 1)
+                MyProcedure;    // +1 (no nesting penalty on recursion)
+
+        while true do           // +1 (nesting = 0)
+            MyProcedure;        // +1 (no nesting penalty on recursion)
+
+        if true then            // +1 (nesting = 0)
+            if Condition then   // +2 (nesting = 1)
+                MyProcedure     // +1 (no nesting penalty on recursion)
+            else                // +2 (nesting = 1)
+                MyProcedure;    // +1 (no nesting penalty on recursion)
+
+        repeat                  // +1 (nesting = 0)
+            this.MyProcedure;   // +1 (no nesting penalty on recursion)
+        until true;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/HasDiagnostic/RecursionIndirectWithoutParentheses.al
+++ b/src/ALCops.LinterCop.Test/Rules/CognitiveComplexity/HasDiagnostic/RecursionIndirectWithoutParentheses.al
@@ -1,0 +1,34 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|MyProcedure|]()         // Cognitive Complexity: 15 (threshold >=15)
+    var
+        Condition: Boolean;
+    begin
+        if true then                    // IfStatement: +1 (1 increment + 0 nesting penalty)
+            if true then                // IfStatement: +2 (1 increment + 1 nesting penalty)
+                SomeOtherProcedure;     // RecursionCycle: +1 (1 increment + 0 nesting penalty, no nesting penalty on recursion)
+
+        while true do                   // WhileStatement: +1 (1 increment + 0 nesting penalty)
+            SomeOtherProcedure;         // RecursionCycle: +1 (1 increment + 0 nesting penalty, no nesting penalty on recursion)
+
+        if true then                    // IfStatement: +1 (1 increment + 0 nesting penalty)
+            if Condition then           // IfStatement: +2 (1 increment + 1 nesting penalty)
+                SomeOtherProcedure      // RecursionCycle: +1 (1 increment + 0 nesting penalty, no nesting penalty on recursion)
+            else                        // ElseStatement: +2 (1 increment + 1 nesting penalty)
+                SomeOtherProcedure;     // RecursionCycle: +1 (1 increment + 0 nesting penalty, no nesting penalty on recursion)
+
+        repeat                          // RepeatStatement: +1 (1 increment + 0 nesting penalty)
+            this.SomeOtherProcedure;    // RecursionCycle: +1 (1 increment + 0 nesting penalty, no nesting penalty on recursion)
+        until true;
+    end;
+
+    procedure SomeOtherProcedure()
+    begin
+        AndAnotherOne;
+    end;
+
+    procedure AndAnotherOne()
+    begin
+        MyProcedure;
+    end;
+}

--- a/src/ALCops.LinterCop/Analyzers/CognitiveComplexity.cs
+++ b/src/ALCops.LinterCop/Analyzers/CognitiveComplexity.cs
@@ -289,9 +289,21 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
 
         var visited = new HashSet<int>();
 
-        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        foreach (var node in root.DescendantNodes())
         {
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+            SyntaxNode? target = null;
+
+            if (node is InvocationExpressionSyntax)
+                target = node;
+            else if (node is MemberAccessExpressionSyntax && node.Parent is not InvocationExpressionSyntax)
+                target = node;
+            else if (node is IdentifierNameSyntax && node.Parent is not InvocationExpressionSyntax && node.Parent is not MemberAccessExpressionSyntax)
+                target = node;
+
+            if (target is null)
+                continue;
+
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(target, context.CancellationToken);
             if (symbolInfo.Symbol is not IMethodSymbol invokedMethod)
                 continue;
 
@@ -299,7 +311,7 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
             if (IsPathTo(recursion, invokedMethod.Id, currentId, visited))
             {
                 increment++;
-                RaiseIncrementDiagnostic(context, GetKeywordLocation(invocation, invocation.SpanStart), "RecursionCycle", 0);
+                RaiseIncrementDiagnostic(context, GetKeywordLocation(target, target.SpanStart), "RecursionCycle", 0);
             }
         }
 
@@ -389,6 +401,12 @@ public sealed class CognitiveComplexity : DiagnosticAnalyzer
                     MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.GetLocation(),
                     _ => invocationExpression.GetLocation()
                 },
+
+            MemberAccessExpressionSyntax memberAccessExpression =>
+                memberAccessExpression.Name.Identifier.GetLocation(),
+
+            IdentifierNameSyntax identifierName =>
+                identifierName.Identifier.GetLocation(),
 
             _ => node.GetLocation().SourceTree!.GetLocation(new TextSpan(spanStart, 1))
         };

--- a/src/ALCops.LinterCop/Analyzers/CognitiveComplexityRecursionGraphService.cs
+++ b/src/ALCops.LinterCop/Analyzers/CognitiveComplexityRecursionGraphService.cs
@@ -58,10 +58,19 @@ internal sealed class CognitiveComplexityRecursionGraphService
 
         foreach (var node in body.DescendantNodes())
         {
-            if (node is not InvocationExpressionSyntax invocation)
+            SyntaxNode? target = null;
+
+            if (node is InvocationExpressionSyntax)
+                target = node;
+            else if (node is MemberAccessExpressionSyntax && node.Parent is not InvocationExpressionSyntax)
+                target = node;
+            else if (node is IdentifierNameSyntax && node.Parent is not InvocationExpressionSyntax && node.Parent is not MemberAccessExpressionSyntax)
+                target = node;
+
+            if (target is null)
                 continue;
 
-            var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+            var symbolInfo = semanticModel.GetSymbolInfo(target);
             if (symbolInfo.Symbol is IMethodSymbol invokedSymbol)
             {
                 builder.Add(invokedSymbol.Id);


### PR DESCRIPTION
## Summary
- Fix recursion detection in the `CognitiveComplexity` analyzer to handle method calls without parentheses
- Two locations needed fixing:
  1. **`CognitiveComplexityRecursionGraphService.BuildInvocationIds`** — builds the graph of which methods call which. Only walked `InvocationExpressionSyntax`, missing bare `MemberAccessExpressionSyntax` (`Rec.Method`) and `IdentifierNameSyntax` (`MyProc`)
  2. **`CognitiveComplexity.CalculateRecursionComplexity`** — scores recursion increments by walking the method body. Same issue: only walked `InvocationExpressionSyntax`
- Also added `MemberAccessExpressionSyntax` and `IdentifierNameSyntax` cases to `GetKeywordLocation` for precise diagnostic location on no-parens calls

Partial fix for #326

## Test plan
- [x] Added `HasDiagnostic` test fixtures: `RecursionDirectWithoutParentheses` and `RecursionIndirectWithoutParentheses`
- [x] All 14 CognitiveComplexity tests pass (12 existing + 2 new)
- [x] CI build and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)