### PR TITLE
fix: require workflow_dispatch for alpha releases on main

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,7 +1,7 @@
 name: Build and Release
 
 # Release channels:
-#   Alpha  - auto on every push to main            (1.0.0-alpha.1, 1.0.0-alpha.2, ...)
+#   Alpha  - manual workflow_dispatch on main      (1.0.0-alpha.1, 1.0.0-alpha.2, ...)
 #   Beta   - manual workflow_dispatch on release/* (1.0.0-beta.1, 1.0.0-beta.2, ...)
 #   Stable - auto on tag push v*                   (1.0.0)
 
@@ -54,8 +54,7 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     if: >-
-      github.ref == 'refs/heads/main'
-      || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/'))
+      (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
       || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
 
     steps:


### PR DESCRIPTION
## Summary

- Alpha releases on `main` now require a manual `workflow_dispatch` trigger instead of auto-publishing on every push
- Matches how beta releases already work on `release/*` branches
- Pushes to `main` still trigger build-and-test for CI feedback, just not the release job

### What changed

The `release` job condition in `build-and-release.yml` changed from:

```yaml
github.ref == 'refs/heads/main'
|| (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/'))
|| (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
```

To:

```yaml
(github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
|| (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
```

## Test plan

- [ ] Verify that `workflow_dispatch` on `main` still triggers the release job
- [ ] Verify that a plain push to `main` runs build-and-test but NOT the release job
- [ ] Verify that `workflow_dispatch` on `release/*` branches is unaffected
- [ ] Verify that tag pushes (`v*`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)