### PR TITLE
fix: handle table names containing dots in AC0031 CodeFix

### DIFF
--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasDiagnostic/DottedTableName.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasDiagnostic/DottedTableName.al
@@ -1,7 +1,6 @@
 codeunit 50000 MyCodeunit
 {
-
-    procedure Test()
+    procedure MyProcedure()
     var
         MyTable: Record "ABC Example Header.Line";
     begin
@@ -11,14 +10,8 @@ codeunit 50000 MyCodeunit
 
 table 50000 "ABC Example Header.Line"
 {
-    Caption = '', Locked = true;
-
     fields
     {
-        field(1; MyField; Integer)
-        {
-            Caption = '', Locked = true;
-            DataClassification = ToBeClassified;
-        }
+        field(1; MyField; Integer) { }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasDiagnostic/DottedTableName.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasDiagnostic/DottedTableName.al
@@ -1,0 +1,24 @@
+codeunit 50000 MyCodeunit
+{
+
+    procedure Test()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        [|MyTable.FindFirst();|]
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/current.al
@@ -1,0 +1,24 @@
+codeunit 50000 MyCodeunit
+{
+
+    trigger OnRun()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        [|MyTable.FindFirst();|]
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/current.al
@@ -11,14 +11,8 @@ codeunit 50000 MyCodeunit
 
 table 50000 "ABC Example Header.Line"
 {
-    Caption = '', Locked = true;
-
     fields
     {
-        field(1; MyField; Integer)
-        {
-            Caption = '', Locked = true;
-            DataClassification = ToBeClassified;
-        }
+        field(1; MyField; Integer) { }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/expected.al
@@ -1,0 +1,24 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata "ABC Example Header.Line" = r;
+    trigger OnRun()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        MyTable.FindFirst();
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/AddNewPermissionsPropertyDottedName/expected.al
@@ -11,14 +11,8 @@ codeunit 50000 MyCodeunit
 
 table 50000 "ABC Example Header.Line"
 {
-    Caption = '', Locked = true;
-
     fields
     {
-        field(1; MyField; Integer)
-        {
-            Caption = '', Locked = true;
-            DataClassification = ToBeClassified;
-        }
+        field(1; MyField; Integer) { }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/MergePermissionCharDottedName/current.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/MergePermissionCharDottedName/current.al
@@ -1,0 +1,19 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata "ABC Example Header.Line" = r;
+
+    procedure Test()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        [|MyTable.Modify();|]
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/MergePermissionCharDottedName/expected.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/HasFix/MergePermissionCharDottedName/expected.al
@@ -1,0 +1,19 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata "ABC Example Header.Line" = rm;
+
+    procedure Test()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        MyTable.Modify();
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/NoDiagnostic/DottedTableNameWithPermissions.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/NoDiagnostic/DottedTableNameWithPermissions.al
@@ -2,7 +2,7 @@ codeunit 50000 MyCodeunit
 {
     Permissions = tabledata "ABC Example Header.Line" = r;
 
-    procedure Test()
+    procedure MyProcedure()
     var
         MyTable: Record "ABC Example Header.Line";
     begin
@@ -12,14 +12,8 @@ codeunit 50000 MyCodeunit
 
 table 50000 "ABC Example Header.Line"
 {
-    Caption = '', Locked = true;
-
     fields
     {
-        field(1; MyField; Integer)
-        {
-            Caption = '', Locked = true;
-            DataClassification = ToBeClassified;
-        }
+        field(1; MyField; Integer) { }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/NoDiagnostic/DottedTableNameWithPermissions.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/NoDiagnostic/DottedTableNameWithPermissions.al
@@ -1,0 +1,25 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata "ABC Example Header.Line" = r;
+
+    procedure Test()
+    var
+        MyTable: Record "ABC Example Header.Line";
+    begin
+        [|MyTable.FindFirst();|]
+    end;
+}
+
+table 50000 "ABC Example Header.Line"
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataAccessRequiresPermissions/TableDataAccessRequiresPermissions.cs
@@ -29,6 +29,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("XmlPorts")]
         [TestCase("Queries")]
         [TestCase("Reports")]
+        [TestCase("DottedTableName")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -60,6 +61,7 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("GetBySystemIdWithPermissions")]
         [TestCase("CountWithPermissions")]
         [TestCase("ImplicitSelfCallWithInherentPermissions")]
+        [TestCase("DottedTableNameWithPermissions")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
@@ -84,6 +86,8 @@ namespace ALCops.ApplicationCop.Test
         [TestCase("AddEntryAlphabetical")]
         [TestCase("AddEntryAlphabeticalFirst")]
         [TestCase("AddEntryAppend")]
+        [TestCase("AddNewPermissionsPropertyDottedName")]
+        [TestCase("MergePermissionCharDottedName")]
         public async Task HasFix(string testCase)
         {
             var currentCode = await File.ReadAllTextAsync(

--- a/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
+++ b/src/ALCops.ApplicationCop/CodeFixes/TableDataAccessRequiresPermissions.cs
@@ -125,32 +125,37 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         // Resolve table name using C#-like namespace resolution
         var compilationUnit = objectSyntax.FirstAncestorOrSelf<CompilationUnitSyntax>();
-        var resolvedTableName = ResolveTableNameForFix(props.TableName, props.TableNamespace, compilationUnit);
+        var resolved = ResolveTableNameForFix(props.TableName, props.TableNamespace, compilationUnit);
 
         ctx.RegisterCodeFix(
-            CreateCodeAction(objectIdentity, resolvedTableName, props.PermissionChar, document, generateFixAll: true),
+            CreateCodeAction(objectIdentity, resolved, props.TableName, props.PermissionChar, document, generateFixAll: true),
             diagnostic);
     }
 
     private static TableDataAccessRequiresPermissionsCodeAction CreateCodeAction(
-        (SyntaxKind Kind, string? Name) objectIdentity, string tableName, char permissionChar,
-        Document document, bool generateFixAll)
+        (SyntaxKind Kind, string? Name) objectIdentity, ResolvedTableName resolved,
+        string rawTableName, char permissionChar, Document document, bool generateFixAll)
     {
+        var displayName = resolved.QualifyingNamespace is not null
+            ? $"{resolved.QualifyingNamespace}.{resolved.TableName}"
+            : resolved.TableName;
+
         var title = string.Format(
             ApplicationCopAnalyzers.TableDataAccessRequiresPermissionsCodeAction,
             permissionChar,
-            tableName);
+            displayName);
 
         return new TableDataAccessRequiresPermissionsCodeAction(
             title,
-            ct => ApplyFix(document, objectIdentity, tableName, permissionChar, ct),
+            ct => ApplyFix(document, objectIdentity, resolved, rawTableName, permissionChar, ct),
             nameof(TableDataAccessRequiresPermissionsCodeFixProvider),
             generateFixAll);
     }
 
     private static async Task<Document> ApplyFix(Document document,
         (SyntaxKind Kind, string? Name) objectIdentity,
-        string tableName, char permissionChar, CancellationToken cancellationToken)
+        ResolvedTableName resolved, string rawTableName,
+        char permissionChar, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -170,11 +175,11 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
         if (permissionsProperty is null)
         {
-            newPropertyList = AddNewPermissionsProperty(propertyList, tableName, permissionChar);
+            newPropertyList = AddNewPermissionsProperty(propertyList, resolved, permissionChar);
         }
         else
         {
-            newPropertyList = UpdateExistingPermissionsProperty(propertyList, permissionsProperty, tableName, permissionChar);
+            newPropertyList = UpdateExistingPermissionsProperty(propertyList, permissionsProperty, resolved, rawTableName, permissionChar);
         }
 
         var newRoot = root.ReplaceNode(propertyList, newPropertyList);
@@ -205,10 +210,10 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
     }
 
     private static PropertyListSyntax AddNewPermissionsProperty(
-        PropertyListSyntax propertyList, string tableName, char permissionChar)
+        PropertyListSyntax propertyList, ResolvedTableName resolved, char permissionChar)
     {
         var permissionEntry = PermissionSyntaxHelper.CreatePermissionSyntax(
-            tableName, permissionChar.ToString());
+            resolved.TableName, resolved.QualifyingNamespace, permissionChar.ToString());
         var permissionValue = SyntaxFactory.PermissionPropertyValue()
             .AddPermissionProperties(permissionEntry);
         var property = SyntaxFactory.Property(
@@ -220,12 +225,18 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
 
     private static PropertyListSyntax UpdateExistingPermissionsProperty(
         PropertyListSyntax propertyList, PropertySyntax permissionsProperty,
-        string tableName, char permissionChar)
+        ResolvedTableName resolved, string rawTableName, char permissionChar)
     {
         if (permissionsProperty.Value is not PermissionPropertyValueSyntax permissionValue)
             return propertyList;
 
-        var existingEntry = PermissionSyntaxHelper.FindExistingEntry(permissionValue, tableName);
+        // FindExistingEntry compares against GetObjectNameFromPermission output (always unquoted).
+        // Construct the search name in the same format: raw name for simple, namespace.raw for qualified.
+        var searchName = resolved.QualifyingNamespace is not null
+            ? $"{resolved.QualifyingNamespace}.{rawTableName}"
+            : rawTableName;
+
+        var existingEntry = PermissionSyntaxHelper.FindExistingEntry(permissionValue, searchName);
         PermissionPropertyValueSyntax newPermissionValue;
 
         if (existingEntry is not null)
@@ -236,7 +247,7 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
         else
         {
             // Table not listed: add a new entry
-            newPermissionValue = AddNewEntry(permissionValue, tableName, permissionChar);
+            newPermissionValue = AddNewEntry(permissionValue, resolved, rawTableName, permissionChar);
         }
 
         var newProperty = permissionsProperty.WithValue(newPermissionValue);
@@ -257,15 +268,21 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
     }
 
     private static PermissionPropertyValueSyntax AddNewEntry(
-        PermissionPropertyValueSyntax permissionValue, string tableName, char permissionChar)
+        PermissionPropertyValueSyntax permissionValue, ResolvedTableName resolved,
+        string rawTableName, char permissionChar)
     {
         var permissions = permissionValue.PermissionProperties;
         var isSorted = PermissionSyntaxHelper.ArePermissionsSorted(permissions);
         var isMultiLine = PermissionSyntaxHelper.IsMultiLineFormat(permissionValue);
-        var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(permissions, tableName, isSorted);
+
+        // FindInsertionIndex compares against GetObjectNameFromPermission output (unquoted).
+        var sortName = resolved.QualifyingNamespace is not null
+            ? $"{resolved.QualifyingNamespace}.{rawTableName}"
+            : rawTableName;
+        var insertIndex = PermissionSyntaxHelper.FindInsertionIndex(permissions, sortName, isSorted);
 
         var newEntry = PermissionSyntaxHelper.CreatePermissionSyntax(
-            tableName, permissionChar.ToString());
+            resolved.TableName, resolved.QualifyingNamespace, permissionChar.ToString());
 
         SeparatedSyntaxList<PermissionSyntax> newPermissions;
         if (isMultiLine)
@@ -298,16 +315,16 @@ public sealed class TableDataAccessRequiresPermissionsCodeFixProvider : CodeFixP
                 SemanticFacts.IsSameName(valueText, nameof(PropertyKind.Permissions)));
     }
 
-    private static string ResolveTableNameForFix(string tableName, string tableNamespace,
+    private static ResolvedTableName ResolveTableNameForFix(string tableName, string tableNamespace,
         CompilationUnitSyntax? compilationUnit)
     {
         if (compilationUnit is null || string.IsNullOrEmpty(tableNamespace))
-            return tableName;
+            return new ResolvedTableName(tableName.QuoteIdentifierIfNeededWithReflection(), null);
 
         var fileNamespace = PermissionTableNameResolver.GetFileNamespace(compilationUnit);
         var importedNamespaces = PermissionTableNameResolver.GetImportedNamespaces(compilationUnit);
 
-        return PermissionTableNameResolver.ResolveTableName(
+        return PermissionTableNameResolver.ResolveTableNameParts(
             tableName, tableNamespace, fileNamespace, importedNamespaces);
     }
 }

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -246,12 +246,25 @@ public static class PermissionSyntaxHelper
         if (qualifyingNamespace is not null)
         {
             var qualifiedName = SyntaxFactory.QualifiedName(
-                SyntaxFactory.IdentifierName(qualifyingNamespace),
+                ParseNamespaceName(qualifyingNamespace),
                 SyntaxFactory.IdentifierName(tableName));
             return SyntaxFactory.ObjectNameOrId(qualifiedName);
         }
 
         return SyntaxFactory.ObjectNameOrId(SyntaxFactory.IdentifierName(tableName));
+    }
+
+    /// <summary>
+    /// Builds a <see cref="NameSyntax"/> from a namespace string that may contain dots
+    /// (e.g., "MyPTE.Sales" becomes <c>QualifiedName(IdentifierName("MyPTE"), IdentifierName("Sales"))</c>).
+    /// </summary>
+    private static NameSyntax ParseNamespaceName(string namespaceName)
+    {
+        var segments = namespaceName.Split('.');
+        NameSyntax result = SyntaxFactory.IdentifierName(segments[0]);
+        for (int i = 1; i < segments.Length; i++)
+            result = SyntaxFactory.QualifiedName(result, SyntaxFactory.IdentifierName(segments[i]));
+        return result;
     }
 
     /// <summary>

--- a/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
+++ b/src/ALCops.Common/Permissions/PermissionSyntaxHelper.cs
@@ -114,12 +114,13 @@ public static class PermissionSyntaxHelper
 
     /// <summary>
     /// Creates a new PermissionSyntax node for the given table name and permission string.
-    /// Handles both simple names ("Customer") and qualified names ("MyNamespace.Customer").
+    /// When <paramref name="qualifyingNamespace"/> is non-null, creates a qualified name
+    /// (e.g., <c>MyNamespace."Customer"</c>); otherwise creates a simple identifier.
     /// </summary>
-    public static PermissionSyntax CreatePermissionSyntax(string tableName, string permissions)
+    public static PermissionSyntax CreatePermissionSyntax(string tableName, string? qualifyingNamespace, string permissions)
     {
         var objectType = SyntaxFactory.Token(EnumProvider.SyntaxKind.TableDataKeyword);
-        var objectReference = CreateObjectReference(tableName);
+        var objectReference = CreateObjectReference(tableName, qualifyingNamespace);
         var permissionsToken = SyntaxFactory.Identifier(permissions);
 
         return SyntaxFactory.Permission(objectType, objectReference, permissionsToken);
@@ -240,16 +241,13 @@ public static class PermissionSyntaxHelper
         return null;
     }
 
-    private static ObjectNameOrIdSyntax CreateObjectReference(string tableName)
+    private static ObjectNameOrIdSyntax CreateObjectReference(string tableName, string? qualifyingNamespace)
     {
-        var dotIndex = tableName.LastIndexOf('.');
-        if (dotIndex >= 0)
+        if (qualifyingNamespace is not null)
         {
-            var namespacePart = tableName.Substring(0, dotIndex);
-            var namePart = tableName.Substring(dotIndex + 1);
             var qualifiedName = SyntaxFactory.QualifiedName(
-                SyntaxFactory.IdentifierName(namespacePart),
-                SyntaxFactory.IdentifierName(namePart));
+                SyntaxFactory.IdentifierName(qualifyingNamespace),
+                SyntaxFactory.IdentifierName(tableName));
             return SyntaxFactory.ObjectNameOrId(qualifiedName);
         }
 

--- a/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
+++ b/src/ALCops.Common/Permissions/PermissionTableNameResolver.cs
@@ -4,6 +4,22 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace ALCops.Common.Permissions;
 
+#if NETSTANDARD2_1
+public readonly struct ResolvedTableName
+{
+    public string TableName { get; }
+    public string? QualifyingNamespace { get; }
+
+    public ResolvedTableName(string tableName, string? qualifyingNamespace)
+    {
+        TableName = tableName;
+        QualifyingNamespace = qualifyingNamespace;
+    }
+}
+#else
+public readonly record struct ResolvedTableName(string TableName, string? QualifyingNamespace);
+#endif
+
 /// <summary>
 /// Resolves the appropriate table name for use in a Permissions property,
 /// using C#-like namespace resolution: simple name when the table's namespace
@@ -28,6 +44,26 @@ public static class PermissionTableNameResolver
             return tableName.QuoteIdentifierIfNeededWithReflection();
 
         return $"{tableNamespace}.{tableName.QuoteIdentifierIfNeededWithReflection()}";
+    }
+
+    /// <summary>
+    /// Returns the table name and optional qualifying namespace as separate values,
+    /// avoiding the need to re-parse a combined string.
+    /// </summary>
+    public static ResolvedTableName ResolveTableNameParts(string tableName, string? tableNamespace, string? containingNamespace, IEnumerable<string> importedNamespaces)
+    {
+        var quotedName = tableName.QuoteIdentifierIfNeededWithReflection();
+
+        if (string.IsNullOrEmpty(tableNamespace))
+            return new ResolvedTableName(quotedName, null);
+
+        if (containingNamespace is not null && SemanticFacts.IsSameName(tableNamespace, containingNamespace))
+            return new ResolvedTableName(quotedName, null);
+
+        if (importedNamespaces.Any(ns => SemanticFacts.IsSameName(ns, tableNamespace)))
+            return new ResolvedTableName(quotedName, null);
+
+        return new ResolvedTableName(quotedName, tableNamespace);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #339

- The AC0031 CodeFix previously used `LastIndexOf('.')` to detect namespace qualification when constructing permission syntax, treating dots within quoted table names (e.g., `"ABC Example Header.Line"`) as namespace separators
- This produced invalid AL syntax like `tabledata "ABC Example Header"."Line" = r` instead of `tabledata "ABC Example Header.Line" = r`
- Restructured the API to pass namespace and table name as separate parameters via a new `ResolvedTableName` struct, eliminating the fragile parse-from-combined-string pattern

## Changes

- **`PermissionTableNameResolver.cs`**: Added `ResolvedTableName` struct (with `#if NETSTANDARD2_1` guard) and `ResolveTableNameParts` method that returns structured data instead of a combined string
- **`PermissionSyntaxHelper.cs`**: Updated `CreatePermissionSyntax` and `CreateObjectReference` to accept separate namespace and table name parameters — no more dot-splitting
- **`TableDataAccessRequiresPermissionsCodeFixProvider.cs`**: Threaded `ResolvedTableName` through the entire call chain; ensured `FindExistingEntry` and `FindInsertionIndex` receive names in the correct (unquoted) format

## Test plan

- [x] New `HasDiagnostic` test: table with dot in name, missing permissions
- [x] New `NoDiagnostic` test: table with dot in name, permissions declared
- [x] New `HasFix` test: add new Permissions property for dotted table name
- [x] New `HasFix` test: merge permission char into existing entry for dotted table name
- [x] All 38 AC0031 tests pass (34 existing + 4 new)
- [x] Full test suite: 1,103 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)