### PR TITLE
fix: move test reporting to workflow_run for fork PR support

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -41,8 +41,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      checks: write
-      pull-requests: write
     with:
       draft-check: false
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -413,35 +413,3 @@ jobs:
           path: |
             **/TestResults_${{ matrix.version }}.trx
 
-  report:
-    if: ${{ always() && (!inputs.draft-check || github.event.pull_request.draft == false) }}
-    needs: [setup, build, test]
-    runs-on: ubuntu-latest
-    name: Report
-    permissions:
-      contents: read
-      actions: read
-      checks: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download all test artifacts
-        uses: actions/download-artifact@v8
-        with:
-          pattern: test-*
-          merge-multiple: true
-
-      - name: Publish unified test report
-        uses: dorny/test-reporter@v3
-        with:
-          name: Test results
-          report-title: 'ALCops Test Results'
-          path: "**/*.trx"
-          reporter: dotnet-trx
-          use-actions-summary: 'false'
-          list-suites: 'failed'
-          list-tests: 'failed'
-          collapsed: 'never'
-          fail-on-error: true
-          fail-on-empty: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,8 +24,6 @@ on:
 permissions:
   contents: read
   actions: read
-  checks: write
-  pull-requests: write
 
 jobs:
   build-and-test:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,35 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ['Pull Request', 'Build and Release']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    name: Report
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      || github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Publish unified test report
+        uses: dorny/test-reporter@v3
+        with:
+          artifact: /test-results-(.*)/
+          name: 'Test results $1'
+          report-title: 'ALCops Test Results'
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          use-actions-summary: 'false'
+          list-suites: 'failed'
+          list-tests: 'failed'
+          collapsed: 'never'
+          fail-on-error: true
+          fail-on-empty: true

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -19,13 +19,21 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
       || github.event.workflow_run.conclusion == 'failure'
     steps:
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: test-results-*
+          merge-multiple: true
+          path: TestResults
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
       - name: Publish unified test report
         uses: dorny/test-reporter@v3
         with:
-          artifact: /test-results-(.*)/
-          name: 'Test results $1'
+          name: Test results
           report-title: 'ALCops Test Results'
-          path: '**/*.trx'
+          path: 'TestResults/**/*.trx'
           reporter: dotnet-trx
           use-actions-summary: 'false'
           list-suites: 'failed'


### PR DESCRIPTION
## Problem

`dorny/test-reporter@v3` fails with `Resource not accessible by integration` on PRs from forked repositories. This happens because the `GITHUB_TOKEN` for `pull_request` events from forks is always read-only, regardless of declared permissions.

See: https://github.com/ALCops/Analyzers/actions/runs/27687569579/job/81892542018?pr=344

## Root cause

GitHub does not expose repository secrets (including elevated tokens) to workflows triggered by `pull_request` from forks. The `token` input on dorny cannot help because it would resolve to the default read-only token.

## Solution

Move test reporting to a separate `workflow_run`-triggered workflow, which runs in the context of the base repository with write permissions. This is [dorny's documented pattern](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories) for public repositories.

## Changes

- **`build-test.yml`**: Remove the `report` job (test artifacts are still uploaded)
- **`test-report.yml`**: New workflow triggered by `Pull Request` and `Build and Release` workflow completions. Uses dorny's `artifact` input with regex to match `test-results-*` artifacts
- **`pull-request.yml`**: Remove `checks: write` and `pull-requests: write` permissions (no longer needed)
- **`build-and-release.yml`**: Remove `checks: write` and `pull-requests: write` from called workflow permissions

## Notes

- The test-report workflow only runs when the triggering workflow concludes with `success` or `failure` (not on cancellation)
- There will be a small delay before test results appear on PRs, since the report workflow starts after CI completes
- No changes to the build or test pipeline itself