### PR TITLE
fix: checkout repo in Test Report so test-reporter can list tracked files

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -19,6 +19,11 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
       || github.event.workflow_run.conclusion == 'failure'
     steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Download test result artifacts
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Problem

The `Test Report` workflow (`test-report.yml`, introduced in #345 / commit 6e14a0d) runs via `workflow_run` **without checking out the repository**. It downloads the per-version `test-results-*` artifacts with a manual `download-artifact` step (`merge-multiple: true`) to build a single unified report, then passes only `path:` to `dorny/test-reporter`.

`dorny/test-reporter` only uses the GitHub REST API to list tracked files (for resolving source paths in failure annotations) when **it** downloads the artifact via the `artifact:` input. With the manual-download + `path:` setup it falls back to `git ls-files`, which fails:

```
Listing all files tracked by git
  /usr/bin/git ls-files -z
  fatal: not a git repository (or any of the parent directories): .git
Error: The process '/usr/bin/git' failed with exit code 128
```

Because `test-report.yml` runs from `main`, this currently fails for **every** PR.

## Fix

Add an `actions/checkout@v6` step before the artifact download, pinned to `workflow_run.head_sha`, so:
- `git ls-files` finds a repository, and
- annotations resolve against the exact tested commit (including new files in fork PRs).

The single unified report behavior is preserved (no switch to the per-artifact `artifact:` input).

## Notes

- Checkout runs **before** `download-artifact` so its default cleaning does not remove the downloaded `TestResults`.
- Only `contents: read` is needed, which the job already grants.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>