### PR TITLE
fix: update ALCops.RoslynTestKit to 1.3.0 across test projects

### DIFF
--- a/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
+++ b/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
         <Reference Include="$(PkgALCops_RoslynTestKit)/lib/netstandard2.1/RoslynTestKit.dll">
             <Private>True</Private>
         </Reference>

--- a/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
+++ b/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
@@ -60,7 +60,7 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->

--- a/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
+++ b/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
@@ -60,7 +60,7 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->

--- a/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
+++ b/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
@@ -60,7 +60,7 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->

--- a/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
+++ b/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
@@ -60,7 +60,7 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->

--- a/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
+++ b/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
@@ -60,7 +60,7 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->


### PR DESCRIPTION
Bumps the `ALCops.RoslynTestKit` package to 1.3.0 across all test projects.

Moved into `main` from the `release/v1.0.0` branch (commit `204c1f8`) so the work lands without implying a v1.0.0 release. This is the base of a set of 4 split PRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>