### PR TITLE
test: enable default-disabled rule tests via per-rule rulesets (#350)

### DIFF
--- a/.github/instructions/ac0013-field-groups-required.instructions.md
+++ b/.github/instructions/ac0013-field-groups-required.instructions.md
@@ -49,7 +49,7 @@ Uses `RegisterCompilationStartAction` to discover which tables are referenced by
 
 ## Test coverage
 
-Tests are commented out (TODO: `WithRuleSetPath` in RoslynTestKit needed since rule is `isEnabledByDefault: false`).
+The rule is `isEnabledByDefault: false`, so the test class enables it via a co-located `FieldGroupsRequired.ruleset.json` fixture passed through `AnalyzerTestFixtureConfig.RuleSetPath` (requires RoslynTestKit that applies the ruleset to the compilation).
 
-**HasDiagnostic (3 cases, commented out):** BrickIsMissing, DropDownIsMissing, TemporaryTable (referenced by page).
+**HasDiagnostic (3 cases):** BrickIsMissing, DropDownIsMissing, TemporaryTable (referenced by page).
 **NoDiagnostic (2 cases):** HasBrickAndDropDown, TemporaryTable (no page reference).

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -333,6 +333,40 @@ public async Task NoDiagnosticWithTargetOnPrem(string testCase)
 
 This requires `using Microsoft.Dynamics.Nav.CodeAnalysis;` for `CompilationOptions` and `CompilationTarget`.
 
+## Testing rules that are `isEnabledByDefault: false`
+
+Rules declared with `isEnabledByDefault: false` never run in tests unless a ruleset explicitly enables them. Inject a co-located ruleset JSON fixture via `AnalyzerTestFixtureConfig.RuleSetPath` (requires RoslynTestKit 1.4.0+, which loads the ruleset and applies it to the compilation's diagnostic options).
+
+Add a `{RuleName}.ruleset.json` next to the test class in its `Rules/{RuleName}/` folder:
+
+```json
+{
+  "name": "Enable AC0013",
+  "description": "Enables AC0013 for tests.",
+  "rules": [ { "id": "AC0013", "action": "Info" } ]
+}
+```
+
+Set `action` to the rule's default severity (`Info`, `Warning`, etc.) to enable it. Then wire it in `Setup` (compute `_testCasePath` **before** creating the fixture, since the path feeds `RuleSetPath`):
+
+```csharp
+[SetUp]
+public void Setup()
+{
+    _testCasePath = Path.Combine(
+        Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+        Path.Combine("Rules", nameof(MyRule)));
+
+    _fixture = RoslynFixtureFactory.Create<Analyzers.MyRule>(
+        new AnalyzerTestFixtureConfig
+        {
+            RuleSetPath = Path.Combine(_testCasePath, $"{nameof(MyRule)}.ruleset.json")
+        });
+}
+```
+
+The ruleset JSON resolves via the same source-tree absolute path as the `.al` fixtures, so no `CopyToOutputDirectory` is required. For code-fix tests, pass `RuleSetPath` on `CodeFixTestFixtureConfig` too.
+
 ## Naming Conventions
 
 | Element | Convention | Example |

--- a/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
+++ b/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
         <Reference Include="$(PkgALCops_RoslynTestKit)/lib/netstandard2.1/RoslynTestKit.dll">
             <Private>True</Private>
         </Reference>

--- a/src/ALCops.ApplicationCop.Test/Rules/FieldGroupsRequired/FieldGroupsRequired.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/FieldGroupsRequired/FieldGroupsRequired.cs
@@ -10,26 +10,29 @@ namespace ALCops.ApplicationCop.Test
         [SetUp]
         public void Setup()
         {
-            _fixture = RoslynFixtureFactory.Create<Analyzers.FieldGroupsRequired>();
-
             _testCasePath = Path.Combine(
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                     Path.Combine("Rules", nameof(FieldGroupsRequired)));
+
+            _fixture = RoslynFixtureFactory.Create<Analyzers.FieldGroupsRequired>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(FieldGroupsRequired)}.ruleset.json")
+                });
         }
 
-        //TODO: Expose .WithRuleSetPath in RoslynTestKit, so we can enable/disable diagnostics in tests
-        // [Test]
-        // [TestCase("BrickIsMissing")]
-        // [TestCase("DropDownIsMissing")]
-        // [TestCase("TemporaryTable")]
-        // public async Task HasDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("BrickIsMissing")]
+        [TestCase("DropDownIsMissing")]
+        [TestCase("TemporaryTable")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.FieldGroupsRequired);
-        // }
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.FieldGroupsRequired);
+        }
 
         [Test]
         [TestCase("HasBrickAndDropDown")]

--- a/src/ALCops.ApplicationCop.Test/Rules/FieldGroupsRequired/FieldGroupsRequired.ruleset.json
+++ b/src/ALCops.ApplicationCop.Test/Rules/FieldGroupsRequired/FieldGroupsRequired.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable AC0013",
+    "description": "Enables the default-disabled FieldGroupsRequired rule so it can be tested.",
+    "rules": [
+        {
+            "id": "AC0013",
+            "action": "Info"
+        }
+    ]
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/LabelLockedMustHaveTokSuffix/LabelLockedMustHaveTokSuffix.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/LabelLockedMustHaveTokSuffix/LabelLockedMustHaveTokSuffix.cs
@@ -10,33 +10,36 @@ namespace ALCops.ApplicationCop.Test
         [SetUp]
         public void Setup()
         {
-            _fixture = RoslynFixtureFactory.Create<Analyzers.LabelTokLockedConvention>();
-
             _testCasePath = Path.Combine(
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                     Path.Combine("Rules", nameof(LabelLockedMustHaveTokSuffix)));
+
+            _fixture = RoslynFixtureFactory.Create<Analyzers.LabelTokLockedConvention>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(LabelLockedMustHaveTokSuffix)}.ruleset.json")
+                });
         }
 
-        //TODO: Expose .WithRuleSetPath in RoslynTestKit, so we can enable/disable diagnostics in tests
-        // [Test]
-        // [TestCase("Label")]
-        // public async Task HasDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("Label")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.LabelLockedMustHaveTokSuffix);
-        // }
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.LabelLockedMustHaveTokSuffix);
+        }
 
-        // [Test]
-        // [TestCase("Label")]
-        // public async Task NoDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("Label")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.LabelLockedMustHaveTokSuffix);
-        // }
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.LabelLockedMustHaveTokSuffix);
+        }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/LabelLockedMustHaveTokSuffix/LabelLockedMustHaveTokSuffix.ruleset.json
+++ b/src/ALCops.ApplicationCop.Test/Rules/LabelLockedMustHaveTokSuffix/LabelLockedMustHaveTokSuffix.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable AC0021",
+    "description": "Enables the default-disabled LabelLockedMustHaveTokSuffix rule so it can be tested.",
+    "rules": [
+        {
+            "id": "AC0021",
+            "action": "Info"
+        }
+    ]
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataPerCompanyDeclaration/TableDataPerCompanyDeclaration.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataPerCompanyDeclaration/TableDataPerCompanyDeclaration.cs
@@ -10,34 +10,37 @@ namespace ALCops.ApplicationCop.Test
         [SetUp]
         public void Setup()
         {
-            _fixture = RoslynFixtureFactory.Create<Analyzers.TableDataPerCompanyDeclaration>();
-
             _testCasePath = Path.Combine(
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                         Path.Combine("Rules", nameof(TableDataPerCompanyDeclaration)));
+
+            _fixture = RoslynFixtureFactory.Create<Analyzers.TableDataPerCompanyDeclaration>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(TableDataPerCompanyDeclaration)}.ruleset.json")
+                });
         }
 
-        //TODO: Expose .WithRuleSetPath in RoslynTestKit, so we can enable/disable diagnostics in tests
-        // [Test]
-        // [TestCase("DataPerCompanyPropertyMissing")]
-        // public async Task HasDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("DataPerCompanyPropertyMissing")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataPerCompanyDeclaration);
-        // }
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataPerCompanyDeclaration);
+        }
 
-        // [Test]
-        // [TestCase("DataPerCompanyFalse")]
-        // [TestCase("DataPerCompanyTrue")]
-        // public async Task NoDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("DataPerCompanyFalse")]
+        [TestCase("DataPerCompanyTrue")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataPerCompanyDeclaration);
-        // }
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TableDataPerCompanyDeclaration);
+        }
     }
 }

--- a/src/ALCops.ApplicationCop.Test/Rules/TableDataPerCompanyDeclaration/TableDataPerCompanyDeclaration.ruleset.json
+++ b/src/ALCops.ApplicationCop.Test/Rules/TableDataPerCompanyDeclaration/TableDataPerCompanyDeclaration.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable AC0008",
+    "description": "Enables the default-disabled TableDataPerCompanyDeclaration rule so it can be tested.",
+    "rules": [
+        {
+            "id": "AC0008",
+            "action": "Info"
+        }
+    ]
+}

--- a/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
+++ b/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1"
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
+++ b/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1"
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
+++ b/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1"
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
+++ b/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1"
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.PlatformCop.Test/Rules/AccessPropertyExplicitlySet/AccessPropertyExplicitlySet.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/AccessPropertyExplicitlySet/AccessPropertyExplicitlySet.cs
@@ -10,34 +10,37 @@ namespace ALCops.PlatformCop.Test
         [SetUp]
         public void Setup()
         {
-            _fixture = RoslynFixtureFactory.Create<Analyzers.AccessPropertyExplicitlySet>();
-
             _testCasePath = Path.Combine(
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                     Path.Combine("Rules", nameof(AccessPropertyExplicitlySet)));
+
+            _fixture = RoslynFixtureFactory.Create<Analyzers.AccessPropertyExplicitlySet>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(AccessPropertyExplicitlySet)}.ruleset.json")
+                });
         }
 
-        //TODO: Expose .WithRuleSetPath in RoslynTestKit, so we can enable/disable diagnostics in tests
-        // [Test]
-        // [TestCase("CodeunitObject")]
-        // public async Task HasDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("CodeunitObject")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AccessPropertyExplicitlySet);
-        // }
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AccessPropertyExplicitlySet);
+        }
 
-        // [Test]
-        // [TestCase("CodeunitObject")]
-        // [TestCase("TableFieldWithoutAccess")]
-        // public async Task NoDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("CodeunitObject")]
+        [TestCase("TableFieldWithoutAccess")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.AccessPropertyExplicitlySet);
-        // }
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.AccessPropertyExplicitlySet);
+        }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/AccessPropertyExplicitlySet/AccessPropertyExplicitlySet.ruleset.json
+++ b/src/ALCops.PlatformCop.Test/Rules/AccessPropertyExplicitlySet/AccessPropertyExplicitlySet.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable PC0006",
+    "description": "Enables the default-disabled AccessPropertyExplicitlySet rule so it can be tested.",
+    "rules": [
+        {
+            "id": "PC0006",
+            "action": "Warning"
+        }
+    ]
+}

--- a/src/ALCops.PlatformCop.Test/Rules/ExtensiblePropertyExplicitlySet/ExtensiblePropertyExplicitlySet.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/ExtensiblePropertyExplicitlySet/ExtensiblePropertyExplicitlySet.cs
@@ -12,59 +12,61 @@ namespace ALCops.PlatformCop.Test
         [SetUp]
         public void Setup()
         {
-            _fixture = RoslynFixtureFactory.Create<Analyzers.ExtensiblePropertyExplicitlySet>();
-
             _testCasePath = Path.Combine(
                 Directory.GetParent(
                     Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
                     Path.Combine("Rules", nameof(ExtensiblePropertyExplicitlySet)));
+
+            _fixture = RoslynFixtureFactory.Create<Analyzers.ExtensiblePropertyExplicitlySet>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(ExtensiblePropertyExplicitlySet)}.ruleset.json")
+                });
         }
 
-        //TODO: Expose .WithRuleSetPath in RoslynTestKit, so we can enable/disable diagnostics in tests
-        // [Test]
-        // [TestCase("EnumObject")]
-        // [TestCase("PageObject")]
-        // [TestCase("ReportObject")]
-        // [TestCase("TableObject")]
-        // public async Task HasDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("PageObject")]
+        [TestCase("ReportObject")]
+        [TestCase("TableObject")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ExtensiblePropertyExplicitlySet);
-        // }
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.ExtensiblePropertyExplicitlySet);
+        }
 
-        // [Test]
-        // [TestCase("PageObject")]
-        // [TestCase("TableObject")]
-        // public async Task NoDiagnostic(string testCase)
-        // {
-        //     var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("PageObject")]
+        [TestCase("TableObject")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
 
-        //     _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ExtensiblePropertyExplicitlySet);
-        // }
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.ExtensiblePropertyExplicitlySet);
+        }
 
-        // [Test]
-        // [TestCase("EnumObject")]
-        // [TestCase("PageObject")]
-        // [TestCase("ReportObject")]
-        // [TestCase("TableObject")]
-        // public async Task HasFix(string testCase)
-        // {
-        //     var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
-        //         .ConfigureAwait(false);
+        [Test]
+        [TestCase("PageObject")]
+        [TestCase("ReportObject")]
+        [TestCase("TableObject")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
 
-        //     var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
-        //         .ConfigureAwait(false);
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
 
-        //     var fixture = RoslynFixtureFactory.Create<ExtensiblePropertyExplicitlySetCodeFix>(
-        //         new CodeFixTestFixtureConfig
-        //         {
-        //             AdditionalAnalyzers = [_analyzer]
-        //         });
+            var fixture = RoslynFixtureFactory.Create<ExtensiblePropertyExplicitlySetCodeFix>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer],
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(ExtensiblePropertyExplicitlySet)}.ruleset.json")
+                });
 
-        //     fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.ExtensiblePropertyExplicitlySet);
-        // }
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.ExtensiblePropertyExplicitlySet);
+        }
     }
 }

--- a/src/ALCops.PlatformCop.Test/Rules/ExtensiblePropertyExplicitlySet/ExtensiblePropertyExplicitlySet.ruleset.json
+++ b/src/ALCops.PlatformCop.Test/Rules/ExtensiblePropertyExplicitlySet/ExtensiblePropertyExplicitlySet.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable PC0005",
+    "description": "Enables the default-disabled ExtensiblePropertyExplicitlySet rule so it can be tested.",
+    "rules": [
+        {
+            "id": "PC0005",
+            "action": "Warning"
+        }
+    ]
+}

--- a/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
+++ b/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
@@ -60,12 +60,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.3.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.1.1"
+        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />


### PR DESCRIPTION
Enables tests for default-disabled rules using per-rule rulesets.

Moved into `main` from `release/v1.0.0` (commit `2ec84ec`, originally PR #350) so it lands without implying a v1.0.0 release.

**Depends on #351** (RoslynTestKit 1.3.0 bump): the test `.csproj` changes here build on that bump. This PR is therefore based on `chore/roslyntestkit-1.3.0`. **After #351 merges, retarget this PR's base to `main`** (`gh pr edit --base main`); GitHub will then show only this PR's diff.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>