### PR TITLE
fix: run Test Report after Scheduled Build

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -2,7 +2,7 @@ name: Test Report
 
 on:
   workflow_run:
-    workflows: ['Pull Request', 'Build and Release']
+    workflows: ['Pull Request', 'Build and Release', 'Scheduled Build']
     types:
       - completed
 


### PR DESCRIPTION
## Problem

After PR #345 moved test reporting to a `workflow_run`-triggered `test-report.yml`, the report runs for PRs and releases but **not** for scheduled builds. Example: [run 27900481586](https://github.com/ALCops/Analyzers/actions/runs/27900481586) shows `Scheduled Build` completing and uploading `test-results-*` artifacts, but `Test Report` never runs.

## Root cause

`test-report.yml` listened only for `['Pull Request', 'Build and Release']`. The scheduled keepalive's top-level workflow is named **`Scheduled Build`** (it calls `build-test.yml` as a reusable workflow, so the `workflow_run` match is the caller name, not `Build and Test`). Since `Scheduled Build` wasn't listed, the trigger never fired — even though the artifacts were produced correctly.

## Fix

Add `'Scheduled Build'` to the `workflow_run.workflows` array.

## Verification note

`workflow_run` reads its definition from the **default branch**, so this only takes effect after merge to `main`. Confirm via the next 06:00 UTC scheduled run or a manual `Scheduled Build` dispatch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>