### PR TITLE
feat: located analyzer-exception diagnostic (XX0000) replacing bare AD0001

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -160,7 +160,17 @@ For parameterized messages, use standard .NET format strings:
 
 ## Analyzer Class Pattern
 
-All analyzers inherit from `DiagnosticAnalyzer` and are decorated with `[DiagnosticAnalyzer]`.
+All analyzers are decorated with `[DiagnosticAnalyzer]`.
+
+> **Exception harness (XX0000).** Analyzers may instead derive from the per-cop
+> bridge `{Cop}Analyzer` (for example `ApplicationCopAnalyzer`) so that an
+> unhandled exception becomes a located `XX0000` diagnostic instead of `AD0001`
+> on `app.json`. Adoption is a 3-line change: base type `: DiagnosticAnalyzer` →
+> `: {Cop}Analyzer`, `SupportedDiagnostics` → `SupportedDiagnosticsCore`, and
+> `Initialize(AnalysisContext)` → `InitializeAnalyzer(SafeAnalysisContext)` (no
+> `Register*` changes). Currently only `CaptionRequired` is converted. See
+> `analyzer-exception-harness.instructions.md`. The template below shows the
+> still-supported plain `DiagnosticAnalyzer` form.
 
 ### Minimal Template (Symbol-based)
 

--- a/.github/instructions/analyzer-exception-harness.instructions.md
+++ b/.github/instructions/analyzer-exception-harness.instructions.md
@@ -1,0 +1,106 @@
+---
+applyTo: 'src/ALCops.Common/Diagnostics/**'
+---
+
+# Analyzer Exception Harness (XX0000)
+
+The harness converts an unhandled exception thrown by any ALCops analyzer into a
+**located `XX0000` diagnostic** (`AC0000`, `DC0000`, `FC0000`, `LC0000`,
+`PC0000`, `TA0000`) at the object/line being analyzed, instead of the SDK's
+generic `AD0001` on `app.json` line 1. This makes analyzer defects diagnosable:
+the message names the failing analyzer and the exception, and the location points
+at the input that triggered it.
+
+## Why it exists
+
+The NAV SDK's `AnalyzerExecutor` catches every analyzer exception and emits
+`AD0001` at `Location.None`. There is **no global `onAnalyzerException` hook** an
+analyzer can register from inside `Initialize`. The only interposition point is
+the delegate passed to each `Register*Action`. The harness wraps those delegates
+transparently so adopting analyzers need no per-callback try/catch (the manual
+`Rule0000ErrorInRule` pattern used in BusinessCentral.LinterCop).
+
+## Components (in `ALCops.Common/Diagnostics/`)
+
+| Type | Role |
+|---|---|
+| `ALCopsDiagnosticAnalyzer` | Abstract base. Seals `Initialize`/`SupportedDiagnostics`; exposes `InitializeAnalyzer(SafeAnalysisContext)` and `SupportedDiagnosticsCore`. Auto-appends the cop's `AnalyzerExceptionDescriptor` to `SupportedDiagnostics` and captures `GetType().Name` for the message. |
+| `SafeAnalysisContext` | `AnalysisContext` decorator. Overrides every public-abstract `Register*` method to forward to the inner context with the callback wrapped in try/catch. |
+| `SafeCompilationStartContext` | Same decoration for registrations nested inside `RegisterCompilationStartAction`. |
+| `AnalyzerExceptionReporter` | Builds the `XX0000` diagnostic (`Diagnostic.Create(descriptor, location ?? Location.None, analyzerName, exceptionType, exceptionMessage)`). |
+| `{Cop}Analyzer` (per cop) | Thin bridge supplying `AnalyzerExceptionDescriptor => DiagnosticDescriptors.AnalyzerException`. Common cannot reference per-cop descriptors, so this lives in each cop project. |
+
+## Adoption recipe (3 mechanical edits, no `Register*` changes)
+
+```csharp
+// 1. base type
+public sealed class MyRule : ApplicationCopAnalyzer   // was : DiagnosticAnalyzer
+
+// 2. supported diagnostics
+protected override ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } = ...
+//   was: public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+
+// 3. initialize
+protected override void InitializeAnalyzer(SafeAnalysisContext context) => ...
+//   was: public override void Initialize(AnalysisContext context)
+```
+
+Keep the `[DiagnosticAnalyzer]` attribute. Do **not** list the cop's
+`AnalyzerException` descriptor in `SupportedDiagnosticsCore`; the base appends it.
+
+As of this change only `CaptionRequired` (ApplicationCop) is converted. The other
+analyzers adopt the harness incrementally via this same recipe.
+
+## Location strategy per context
+
+| Context | Location |
+|---|---|
+| `SymbolAnalysisContext` | `Symbol.GetLocation()` |
+| `SyntaxNodeAnalysisContext` | `Node.GetLocation()` |
+| `CodeBlockAnalysisContext` | `CodeBlock.GetLocation()` |
+| `OperationAnalysisContext` | `Operation.Syntax.GetLocation()` |
+| Compilation / SemanticModel / SyntaxTree | `Location.None` (message still names the cop + rule) |
+
+Use `symbol.GetLocation()` (SDK `SymbolExtensions`), **not** `Symbol.Locations`
+— `ISymbol` has no `Locations` property in this SDK.
+
+## Design notes / known constraints
+
+- **Operation actions are special.** The public `params`
+  `AnalysisContext.RegisterOperationAction` routes through *internal* members we
+  cannot override. `SafeAnalysisContext` therefore **`new`-hides** both operation
+  overloads and forwards to `inner.RegisterOperationAction(wrapped, kinds)`. This
+  only wins because adopting analyzers type their `InitializeAnalyzer` parameter
+  as `SafeAnalysisContext`. Converting an operation-based analyzer requires no
+  call-site change beyond the 3-line recipe.
+- **`CompilationStartAnalysisContext`** exposes only public-abstract methods and
+  no operation registration, so `SafeCompilationStartContext` intercepts nested
+  registrations via virtual dispatch even when the callback variable is typed as
+  the SDK base type — no call-site changes in CompilationStart analyzers.
+- **Cancellation propagates.** All wrappers use
+  `catch (Exception ex) when (ex is not OperationCanceledException)`.
+- **SDK coupling (accepted, documented).** `SafeAnalysisContext` subclasses the
+  SDK's abstract `AnalysisContext`. If a future SDK adds a new **public-abstract**
+  `Register*` method, this type fails to **compile** until an override is added.
+  That compile-time break is intentional — it forces wrapping of any new surface.
+  Forwarding uses only the public registration API every analyzer already calls.
+- **netstandard2.1.** The harness uses only APIs present on all TFMs
+  (`netstandard2.1;net8.0;net10.0`); no `#if` guards. Verified to build on all
+  three.
+- **Performance.** try/catch with no throw is effectively free; one delegate
+  indirection per callback, built once at registration. Negligible against
+  ~100k method bodies.
+
+## Fallback (not built)
+
+If the decorator ever proves troublesome, the contingency is extension helpers
+(`Register*ActionSafe`) that wrap callbacks at the call site. They are robust and
+simple but require renaming every `Register*` call and a per-file
+`SupportedDiagnostics` edit. Documented here only; not implemented.
+
+## Test coverage
+
+`ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/` exercises the shipped
+wrapping paths with test-only throwing analyzers.
+
+**HasDiagnostic (3 cases):** SymbolAction, OperationAction, CompilationStartAction.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -91,6 +91,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0031-table-data-access-requires-permissions` | rule-scoped | AC0031 rule |
 | `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
 | `sdk-analyzer-infrastructure` | `'src/ALCops.*/Analyzers/**'` | NAV SDK internals: callback ordering, incremental compilation, GetOperation perf |
+| `analyzer-exception-harness` | `'src/ALCops.Common/Diagnostics/**'` | XX0000 harness: base class + context decorators that convert analyzer exceptions into located diagnostics |
 | `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |

--- a/.github/instructions/project-overview.instructions.md
+++ b/.github/instructions/project-overview.instructions.md
@@ -17,6 +17,7 @@ The solution (`ALCops.sln`) contains 13 projects in the `src/` directory. A 14th
   - `Extensions/` : Syntax node, symbol, compilation, and type extension methods
   - `Helpers/` : `ManifestHelper.cs`, `AppSourceCopConfigurationProvider.cs`
   - `Reflection/` : `CompilationHelper.cs`, `EnumProvider.cs`, `PropertyAccessor.cs`, `SymbolHelper.cs`, `VersionProvider.cs`, `StringHelper.cs`
+  - `Diagnostics/` : `ALCopsDiagnosticAnalyzer.cs` (exception-handling base class), `SafeAnalysisContext.cs` / `SafeCompilationStartContext.cs` (callback-wrapping decorators), `AnalyzerExceptionReporter.cs`. Convert analyzer exceptions into a located per-cop `XX0000` diagnostic instead of the SDK's `AD0001`. See `analyzer-exception-harness.instructions.md`.
   - `Constants.cs` : Shared constant values
 
 ### Analyzer projects (6)

--- a/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/AnalyzerExceptionHarness.cs
+++ b/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/AnalyzerExceptionHarness.cs
@@ -1,0 +1,95 @@
+using ALCops.Common.Diagnostics;
+using ALCops.Common.Reflection;
+using ALCops.ApplicationCop;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using RoslynTestKit;
+
+namespace ALCops.ApplicationCop.Test
+{
+    /// <summary>
+    /// Exercises the shared analyzer-exception harness (XX0000) via test-only
+    /// analyzers that deliberately throw from each registration surface the harness
+    /// wraps: a symbol action (matches CaptionRequired), an operation action (the
+    /// <c>new</c>-hiding path), and a CompilationStart-nested symbol action. Each
+    /// asserts AC0000 is reported at the analyzed object/line instead of AD0001.
+    /// </summary>
+    public class AnalyzerExceptionHarness : NavCodeAnalysisBase
+    {
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(AnalyzerExceptionHarness)));
+        }
+
+        [Test]
+        public async Task SymbolAction()
+        {
+            var fixture = RoslynFixtureFactory.Create<ThrowingSymbolAnalyzer>();
+            var code = await ReadCaseAsync(nameof(SymbolAction)).ConfigureAwait(false);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AnalyzerException);
+        }
+
+        [Test]
+        public async Task OperationAction()
+        {
+            var fixture = RoslynFixtureFactory.Create<ThrowingOperationAnalyzer>();
+            var code = await ReadCaseAsync(nameof(OperationAction)).ConfigureAwait(false);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AnalyzerException);
+        }
+
+        [Test]
+        public async Task CompilationStartAction()
+        {
+            var fixture = RoslynFixtureFactory.Create<ThrowingCompilationStartAnalyzer>();
+            var code = await ReadCaseAsync(nameof(CompilationStartAction)).ConfigureAwait(false);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.AnalyzerException);
+        }
+
+        private Task<string> ReadCaseAsync(string testCase) =>
+            File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, "HasDiagnostic", $"{testCase}.al"));
+    }
+
+    [DiagnosticAnalyzer]
+    public sealed class ThrowingSymbolAnalyzer : ApplicationCopAnalyzer
+    {
+        protected override System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } =
+            System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        protected override void InitializeAnalyzer(SafeAnalysisContext context) =>
+            context.RegisterSymbolAction(
+                _ => throw new InvalidOperationException("boom"),
+                EnumProvider.SymbolKind.Table);
+    }
+
+    [DiagnosticAnalyzer]
+    public sealed class ThrowingOperationAnalyzer : ApplicationCopAnalyzer
+    {
+        protected override System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } =
+            System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        protected override void InitializeAnalyzer(SafeAnalysisContext context) =>
+            context.RegisterOperationAction(
+                _ => throw new InvalidOperationException("boom"),
+                EnumProvider.OperationKind.InvocationExpression);
+    }
+
+    [DiagnosticAnalyzer]
+    public sealed class ThrowingCompilationStartAnalyzer : ApplicationCopAnalyzer
+    {
+        protected override System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } =
+            System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        protected override void InitializeAnalyzer(SafeAnalysisContext context) =>
+            context.RegisterCompilationStartAction(
+                start => start.RegisterSymbolAction(
+                    _ => throw new InvalidOperationException("boom"),
+                    EnumProvider.SymbolKind.Table));
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/CompilationStartAction.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/CompilationStartAction.al
@@ -1,0 +1,7 @@
+table 50101 [|CompStartThrow|]
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/OperationAction.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/OperationAction.al
@@ -1,0 +1,11 @@
+codeunit 50102 OpThrow
+{
+    procedure Caller()
+    begin
+        [|Callee()|];
+    end;
+
+    local procedure Callee()
+    begin
+    end;
+}

--- a/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/SymbolAction.al
+++ b/src/ALCops.ApplicationCop.Test/Rules/AnalyzerExceptionHarness/HasDiagnostic/SymbolAction.al
@@ -1,0 +1,7 @@
+table 50100 [|SymThrow|]
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -450,4 +450,13 @@
   <data name="ZeroEnumValueReservedForEmptyDescription" xml:space="preserve">
     <value>Zero (0) should be reserved as the empty Enum value. Business Central stores Enums as integers and does not support null; new records (and existing records after adding a field via table extension) default to 0, which makes non-empty meaning at 0 ambiguous.</value>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
@@ -4,20 +4,21 @@ using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using ALCops.Common.Diagnostics;
 
 namespace ALCops.ApplicationCop.Analyzers;
 
 [DiagnosticAnalyzer]
-public sealed class CaptionRequired : DiagnosticAnalyzer
+public sealed class CaptionRequired : ApplicationCopAnalyzer
 {
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+    protected override ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } =
         ImmutableArray.Create(
             DiagnosticDescriptors.CaptionRequired);
 
     private static readonly HashSet<string> _predefinedActionCategoryNames =
         SyntaxFacts.PredefinedActionCategoryNames.Select(x => x.Key.ToLowerInvariant()).ToHashSet();
 
-    public override void Initialize(AnalysisContext context) =>
+    protected override void InitializeAnalyzer(SafeAnalysisContext context) =>
         context.RegisterSymbolAction(
             CheckForMissingCaptions,
             EnumProvider.SymbolKind.Page,

--- a/src/ALCops.ApplicationCop/ApplicationCopAnalyzer.cs
+++ b/src/ALCops.ApplicationCop/ApplicationCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.ApplicationCop;
+
+/// <summary>
+/// Base class for every ApplicationCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (AC0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class ApplicationCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}

--- a/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticDescriptors.cs
@@ -335,6 +335,16 @@ public static class DiagnosticDescriptors
         description: ApplicationCopAnalyzers.ZeroEnumValueReservedForEmptyDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.ZeroEnumValueReservedForEmpty));
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: ApplicationCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: ApplicationCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: ApplicationCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/applicationcop/{0}/", identifier.ToLower());
@@ -381,5 +391,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.ApplicationCop/DiagnosticIds.cs
+++ b/src/ALCops.ApplicationCop/DiagnosticIds.cs
@@ -2,6 +2,7 @@ namespace ALCops.ApplicationCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "AC0000";
     public static readonly string LookupPageIdAndDrillDownPageId = "AC0001";
     public static readonly string NotBlankRequiredOnPrimaryKeyField = "AC0002";
     public static readonly string NotBlankNotAllowedOnPrimaryKeyField = "AC0003";

--- a/src/ALCops.Common/Diagnostics/ALCopsDiagnosticAnalyzer.cs
+++ b/src/ALCops.Common/Diagnostics/ALCopsDiagnosticAnalyzer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace ALCops.Common.Diagnostics;
+
+/// <summary>
+/// Base class for every ALCops analyzer. It transparently wraps the analysis
+/// callbacks so that an unhandled exception thrown by a rule is reported as a
+/// located <c>XX0000</c> diagnostic (see <see cref="AnalyzerExceptionDescriptor"/>)
+/// instead of surfacing as the SDK's <c>AD0001</c> on <c>app.json</c> line 1.
+///
+/// Analyzers derive from the per-cop bridge (for example
+/// <c>ApplicationCopAnalyzer</c>) rather than from this type directly, override
+/// <see cref="SupportedDiagnosticsCore"/> instead of
+/// <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/>, and override
+/// <see cref="InitializeAnalyzer"/> instead of
+/// <see cref="DiagnosticAnalyzer.Initialize"/>.
+/// </summary>
+public abstract class ALCopsDiagnosticAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The cop-specific <c>XX0000</c> descriptor reported when a rule in this cop
+    /// throws an unhandled exception. Supplied by the per-cop bridge class.
+    /// </summary>
+    protected abstract DiagnosticDescriptor AnalyzerExceptionDescriptor { get; }
+
+    /// <summary>
+    /// The descriptors produced by the concrete analyzer. The
+    /// <see cref="AnalyzerExceptionDescriptor"/> is appended automatically, so
+    /// derived analyzers must not list it themselves.
+    /// </summary>
+    protected abstract ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; }
+
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            ImmutableArray<DiagnosticDescriptor> core = SupportedDiagnosticsCore;
+            return core.Contains(AnalyzerExceptionDescriptor)
+                ? core
+                : core.Add(AnalyzerExceptionDescriptor);
+        }
+    }
+
+    public sealed override void Initialize(AnalysisContext context) =>
+        InitializeAnalyzer(new SafeAnalysisContext(context, AnalyzerExceptionDescriptor, GetType().Name));
+
+    /// <summary>
+    /// Registers the analyzer's actions. The supplied <see cref="SafeAnalysisContext"/>
+    /// wraps every registered callback so unhandled exceptions become located
+    /// <c>XX0000</c> diagnostics.
+    /// </summary>
+    protected abstract void InitializeAnalyzer(SafeAnalysisContext context);
+}

--- a/src/ALCops.Common/Diagnostics/AnalyzerExceptionReporter.cs
+++ b/src/ALCops.Common/Diagnostics/AnalyzerExceptionReporter.cs
@@ -1,0 +1,25 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.Common.Diagnostics;
+
+/// <summary>
+/// Builds the <c>XX0000</c> diagnostic reported when an analyzer callback throws
+/// an unhandled exception. The message mirrors the useful part of the SDK's
+/// <c>AD0001</c> text but is attached to the real location.
+/// </summary>
+internal static class AnalyzerExceptionReporter
+{
+    public static Diagnostic CreateDiagnostic(
+        DiagnosticDescriptor descriptor,
+        Location? location,
+        string analyzerName,
+        Exception exception) =>
+        Diagnostic.Create(
+            descriptor,
+            location ?? Location.None,
+            analyzerName,
+            exception.GetType().ToString(),
+            exception.Message);
+}

--- a/src/ALCops.Common/Diagnostics/SafeAnalysisContext.cs
+++ b/src/ALCops.Common/Diagnostics/SafeAnalysisContext.cs
@@ -1,0 +1,137 @@
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.Common.Diagnostics;
+
+/// <summary>
+/// An <see cref="AnalysisContext"/> decorator that forwards every registration to
+/// the real context but wraps each callback in a try/catch. When a callback throws
+/// an unhandled exception (other than cancellation), it is reported as a located
+/// <c>XX0000</c> diagnostic instead of bubbling up to the SDK as <c>AD0001</c>.
+///
+/// Note on the SDK coupling: this type subclasses the SDK's abstract
+/// <see cref="AnalysisContext"/>. If a future SDK version adds a new public-abstract
+/// <c>Register*</c> method, this class will fail to compile until an override is
+/// added here. That compile-time break is intentional - it forces wrapping of any
+/// new registration surface.
+/// </summary>
+public sealed class SafeAnalysisContext : AnalysisContext
+{
+    private readonly AnalysisContext _inner;
+    private readonly DiagnosticDescriptor _descriptor;
+    private readonly string _analyzerName;
+
+    internal SafeAnalysisContext(AnalysisContext inner, DiagnosticDescriptor descriptor, string analyzerName)
+    {
+        _inner = inner;
+        _descriptor = descriptor;
+        _analyzerName = analyzerName;
+    }
+
+    public override void RegisterSymbolAction(Action<SymbolAnalysisContext> action, ImmutableArray<SymbolKind> symbolKinds) =>
+        _inner.RegisterSymbolAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.Symbol.GetLocation(), _analyzerName, ex));
+                }
+            },
+            symbolKinds);
+
+    public override void RegisterSyntaxNodeAction(Action<SyntaxNodeAnalysisContext> action, ImmutableArray<SyntaxKind> syntaxKinds) =>
+        _inner.RegisterSyntaxNodeAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.Node.GetLocation(), _analyzerName, ex));
+                }
+            },
+            syntaxKinds);
+
+    public override void RegisterCodeBlockAction(Action<CodeBlockAnalysisContext> action) =>
+        _inner.RegisterCodeBlockAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.CodeBlock.GetLocation(), _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterCompilationAction(Action<CompilationAnalysisContext> action) =>
+        _inner.RegisterCompilationAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterSemanticModelAction(Action<SemanticModelAnalysisContext> action) =>
+        _inner.RegisterSemanticModelAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterSyntaxTreeAction(Action<SyntaxTreeAnalysisContext> action) =>
+        _inner.RegisterSyntaxTreeAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterCompilationStartAction(Action<CompilationStartAnalysisContext> action) =>
+        _inner.RegisterCompilationStartAction(
+            startContext => action(new SafeCompilationStartContext(startContext, _descriptor, _analyzerName)));
+
+    // CodeBlockStart exposes its own start context with nested registrations. No
+    // ALCops analyzer uses it today; forward unwrapped so it stays functional.
+    public override void RegisterCodeBlockStartAction(Action<CodeBlockStartAnalysisContext> action) =>
+        _inner.RegisterCodeBlockStartAction(action);
+
+    // Operation registration cannot be intercepted through the public abstract
+    // surface (the params overload routes through internal members we cannot
+    // override). These 'new' overloads win because analyzers reference the
+    // SafeAnalysisContext type, and they forward to the inner context's public
+    // params overload, which the real context implements.
+    public new void RegisterOperationAction(Action<OperationAnalysisContext> action, params OperationKind[] operationKinds) =>
+        _inner.RegisterOperationAction(WrapOperation(action), operationKinds);
+
+    public new void RegisterOperationAction(Action<OperationAnalysisContext> action, ImmutableArray<OperationKind> operationKinds) =>
+        _inner.RegisterOperationAction(WrapOperation(action), operationKinds.ToArray());
+
+    private Action<OperationAnalysisContext> WrapOperation(Action<OperationAnalysisContext> action) =>
+        ctx =>
+        {
+            try { action(ctx); }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                    _descriptor, ctx.Operation.Syntax.GetLocation(), _analyzerName, ex));
+            }
+        };
+}

--- a/src/ALCops.Common/Diagnostics/SafeCompilationStartContext.cs
+++ b/src/ALCops.Common/Diagnostics/SafeCompilationStartContext.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.Common.Diagnostics;
+
+/// <summary>
+/// A <see cref="CompilationStartAnalysisContext"/> decorator that wraps the
+/// nested registrations made inside a <c>RegisterCompilationStartAction</c>
+/// callback. Because every registration method on
+/// <see cref="CompilationStartAnalysisContext"/> is public-abstract, these
+/// overrides intercept the nested callbacks via virtual dispatch even when the
+/// analyzer's callback variable is typed as the SDK base type - so no call-site
+/// changes are needed in analyzers that use <c>RegisterCompilationStartAction</c>.
+/// </summary>
+public sealed class SafeCompilationStartContext : CompilationStartAnalysisContext
+{
+    private readonly CompilationStartAnalysisContext _inner;
+    private readonly DiagnosticDescriptor _descriptor;
+    private readonly string _analyzerName;
+
+    internal SafeCompilationStartContext(
+        CompilationStartAnalysisContext inner,
+        DiagnosticDescriptor descriptor,
+        string analyzerName)
+        : base(inner.Compilation, inner.Options, inner.CancellationToken)
+    {
+        _inner = inner;
+        _descriptor = descriptor;
+        _analyzerName = analyzerName;
+    }
+
+    public override void RegisterSymbolAction(Action<SymbolAnalysisContext> action, ImmutableArray<SymbolKind> symbolKinds) =>
+        _inner.RegisterSymbolAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.Symbol.GetLocation(), _analyzerName, ex));
+                }
+            },
+            symbolKinds);
+
+    public override void RegisterSyntaxNodeAction(Action<SyntaxNodeAnalysisContext> action, ImmutableArray<SyntaxKind> syntaxKinds) =>
+        _inner.RegisterSyntaxNodeAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.Node.GetLocation(), _analyzerName, ex));
+                }
+            },
+            syntaxKinds);
+
+    public override void RegisterCodeBlockAction(Action<CodeBlockAnalysisContext> action) =>
+        _inner.RegisterCodeBlockAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, ctx.CodeBlock.GetLocation(), _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterCompilationEndAction(Action<CompilationAnalysisContext> action) =>
+        _inner.RegisterCompilationEndAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterSemanticModelAction(Action<SemanticModelAnalysisContext> action) =>
+        _inner.RegisterSemanticModelAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    public override void RegisterSyntaxTreeAction(Action<SyntaxTreeAnalysisContext> action) =>
+        _inner.RegisterSyntaxTreeAction(
+            ctx =>
+            {
+                try { action(ctx); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ctx.ReportDiagnostic(AnalyzerExceptionReporter.CreateDiagnostic(
+                        _descriptor, Location.None, _analyzerName, ex));
+                }
+            });
+
+    // CodeBlockStart exposes its own start context with nested registrations. No
+    // ALCops analyzer uses it today; forward unwrapped so it stays functional.
+    public override void RegisterCodeBlockStartAction(Action<CodeBlockStartAnalysisContext> action) =>
+        _inner.RegisterCodeBlockStartAction(action);
+}

--- a/src/ALCops.DocumentationCop/ALCops.DocumentationCopAnalyzers.resx
+++ b/src/ALCops.DocumentationCop/ALCops.DocumentationCopAnalyzers.resx
@@ -207,4 +207,13 @@
   <data name="InternalEventRequiresDocumentationDescription" xml:space="preserve">
     <value>Internal events can be part of the exposed API (internalsVisibleTo) and should be explicitly documented to justify their availability. XML documentation comments communicate intent, usage, and guarantees to consumers of the extension.</value>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.DocumentationCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.DocumentationCop/DiagnosticDescriptors.cs
@@ -105,6 +105,16 @@ public static class DiagnosticDescriptors
         description: DocumentationCopAnalyzers.InternalEventRequiresDocumentationDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.InternalEventRequiresDocumentation));
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: DocumentationCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: DocumentationCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: DocumentationCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/documentationcop/{0}/", identifier.ToLower());
@@ -151,5 +161,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.DocumentationCop/DiagnosticIds.cs
+++ b/src/ALCops.DocumentationCop/DiagnosticIds.cs
@@ -2,6 +2,7 @@ namespace ALCops.DocumentationCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "DC0000";
     public static readonly string CommitRequiresComment = "DC0001";
     public static readonly string WriteToFlowFieldRequiresComment = "DC0002";
     public static readonly string EmptyStatementRequiresComment = "DC0003";

--- a/src/ALCops.DocumentationCop/DocumentationCopAnalyzer.cs
+++ b/src/ALCops.DocumentationCop/DocumentationCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.DocumentationCop;
+
+/// <summary>
+/// Base class for every DocumentationCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (DC0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class DocumentationCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -162,4 +162,13 @@
   <data name="PermissionDeclarationOrderCodeAction" xml:space="preserve">
     <value>ALCops: Sort permission declarations alphabetically</value>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
@@ -47,6 +47,16 @@ public static class DiagnosticDescriptors
         helpLinkUri: GetHelpUri(DiagnosticIds.PermissionDeclarationOrder));
 
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: FormattingCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: FormattingCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: FormattingCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/formattingcop/{0}/", identifier.ToLower());
@@ -93,5 +103,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.FormattingCop/DiagnosticIds.cs
+++ b/src/ALCops.FormattingCop/DiagnosticIds.cs
@@ -2,6 +2,7 @@ namespace ALCops.FormattingCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "FC0000";
     public static readonly string SemicolonAfterMethodOrTriggerDeclaration = "FC0001";
     public static readonly string CasingMismatch = "FC0002";
     public static readonly string UseParenthesisForFunctionCall = "FC0003";

--- a/src/ALCops.FormattingCop/FormattingCopAnalyzer.cs
+++ b/src/ALCops.FormattingCop/FormattingCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.FormattingCop;
+
+/// <summary>
+/// Base class for every FormattingCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (FC0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class FormattingCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -411,4 +411,13 @@
   <data name="ParameterNotReferencedCodeAction" xml:space="preserve">
     <value>ALCops: Remove unreferenced parameter</value>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -314,6 +314,16 @@ public static class DiagnosticDescriptors
         description: LinterCopAnalyzers.UseSecretTextForSensitiveTextDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseSecretTextForSensitiveText));
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: LinterCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: LinterCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/lintercop/{0}/", identifier.ToLower());
@@ -360,5 +370,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.LinterCop/DiagnosticIds.cs
+++ b/src/ALCops.LinterCop/DiagnosticIds.cs
@@ -2,6 +2,7 @@ namespace ALCops.LinterCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "LC0000";
     public static readonly string ObjectIdInDeclaration = "LC0003";
     public static readonly string RecordInstanceIsolationLevel = "LC0031";
     public static readonly string MaintainabilityIndexMetric = "LC0007";

--- a/src/ALCops.LinterCop/LinterCopAnalyzer.cs
+++ b/src/ALCops.LinterCop/LinterCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.LinterCop;
+
+/// <summary>
+/// Base class for every LinterCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (LC0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class LinterCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -495,4 +495,13 @@
   <data name="UseValidateForFieldAssignmentCodeAction" xml:space="preserve">
     <value>ALCops: Use Validate() for field assignment</value>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -365,6 +365,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.UseValidateForFieldAssignmentDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseValidateForFieldAssignment));
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: PlatformCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: PlatformCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/platformcop/{0}/", identifier.ToLower());
@@ -411,5 +421,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -2,6 +2,7 @@ namespace ALCops.PlatformCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "PC0000";
     public static readonly string EditableFlowField = "PC0001";
     public static readonly string AutoIncrementInTemporaryTable = "PC0002";
     public static readonly string SetRangeWithFilterOperators = "PC0003";

--- a/src/ALCops.PlatformCop/PlatformCopAnalyzer.cs
+++ b/src/ALCops.PlatformCop/PlatformCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.PlatformCop;
+
+/// <summary>
+/// Base class for every PlatformCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (PC0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class PlatformCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}

--- a/src/ALCops.TestAutomationCop/ALCops.TestAutomationCopAnalyzers.resx
+++ b/src/ALCops.TestAutomationCop/ALCops.TestAutomationCopAnalyzers.resx
@@ -129,4 +129,13 @@
     <value>Codeunits with Subtype = Test define the executable surface for automated tests and must contain only explicit test entry points. Any global procedure declared in a test codeunit is implicitly exposed as callable logic and therefore must represent an actual test, explicitly marked with the [Test] attribute. A global procedure without this attribute indicates either an incomplete test or misplaced reusable logic.</value>
     <comment/>
   </data>
+  <data name="AnalyzerExceptionTitle" xml:space="preserve">
+    <value>Analyzer threw an unhandled exception</value>
+  </data>
+  <data name="AnalyzerExceptionMessageFormat" xml:space="preserve">
+    <value>Analyzer '{0}' threw an exception of type '{1}': {2}</value>
+  </data>
+  <data name="AnalyzerExceptionDescription" xml:space="preserve">
+    <value>An ALCops analyzer threw an unhandled exception while analyzing this object. This is a defect in the analyzer, not in the analyzed code. The diagnostic is reported at the object or line being analyzed (instead of the generic AD0001 on app.json) so the culprit can be located. Please report it to the ALCops maintainers with the object name and exception details.</value>
+  </data>
 </root>

--- a/src/ALCops.TestAutomationCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.TestAutomationCop/DiagnosticDescriptors.cs
@@ -15,6 +15,16 @@ public static class DiagnosticDescriptors
         description: TestAutomationCopAnalyzers.GlobalMethodRequiresTestAttributeDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.GlobalMethodRequiresTestAttribute));
 
+    public static readonly DiagnosticDescriptor AnalyzerException = new(
+        id: DiagnosticIds.AnalyzerException,
+        title: TestAutomationCopAnalyzers.AnalyzerExceptionTitle,
+        messageFormat: TestAutomationCopAnalyzers.AnalyzerExceptionMessageFormat,
+        category: Category.Internal,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: TestAutomationCopAnalyzers.AnalyzerExceptionDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.AnalyzerException));
+
     public static string GetHelpUri(string identifier)
     {
         return string.Format(CultureInfo.InvariantCulture, "https://alcops.dev/docs/analyzers/testautomationCop/{0}/", identifier.ToLower());
@@ -61,5 +71,11 @@ public static class DiagnosticDescriptors
         /// Example: Avoid exposing internal APIs, hard-coded credentials, or missing permission checks.
         /// </summary>
         public const string Security = "Security";
+
+        /// <summary>
+        /// Internal issues: failures inside ALCops analyzers themselves
+        /// (for example an unhandled exception in a rule), not problems in user code.
+        /// </summary>
+        public const string Internal = "Internal";
     }
 }

--- a/src/ALCops.TestAutomationCop/DiagnosticIds.cs
+++ b/src/ALCops.TestAutomationCop/DiagnosticIds.cs
@@ -2,5 +2,6 @@ namespace ALCops.TestAutomationCop;
 
 public static class DiagnosticIds
 {
+    public static readonly string AnalyzerException = "TA0000";
     public static readonly string GlobalMethodRequiresTestAttribute = "TA0001";
 }

--- a/src/ALCops.TestAutomationCop/TestAutomationCopAnalyzer.cs
+++ b/src/ALCops.TestAutomationCop/TestAutomationCopAnalyzer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using ALCops.Common.Diagnostics;
+
+namespace ALCops.TestAutomationCop;
+
+/// <summary>
+/// Base class for every TestAutomationCop analyzer. Supplies the cop-specific
+/// <see cref="DiagnosticDescriptors.AnalyzerException"/> (TA0000) reported when a
+/// rule throws an unhandled exception. See <see cref="ALCopsDiagnosticAnalyzer"/>.
+/// </summary>
+public abstract class TestAutomationCopAnalyzer : ALCopsDiagnosticAnalyzer
+{
+    protected sealed override DiagnosticDescriptor AnalyzerExceptionDescriptor =>
+        DiagnosticDescriptors.AnalyzerException;
+}


### PR DESCRIPTION
## Summary

When an ALCops analyzer throws (e.g. a `NullReferenceException`), the NAV SDK catches it and emits the generic **`AD0001` on `app.json` line 1** — giving no clue which object/line caused the failure. This PR makes analyzer exceptions **diagnosable**: they surface as a located per-cop **`XX0000`** diagnostic (`AC0000`…`TA0000`) at the analyzed object/line, with a message naming the failing analyzer and exception.

## Approach

A reusable harness in `ALCops.Common/Diagnostics/`:

- **`ALCopsDiagnosticAnalyzer`** — abstract base. Seals `Initialize`/`SupportedDiagnostics`; exposes `InitializeAnalyzer(SafeAnalysisContext)` + `SupportedDiagnosticsCore`; auto-appends the cop's `XX0000` descriptor.
- **`SafeAnalysisContext` / `SafeCompilationStartContext`** — decorators that wrap every registered callback in try/catch and report `XX0000` at a context-appropriate location.
- **`AnalyzerExceptionReporter`** — builds the diagnostic.
- Per-cop **`{Cop}Analyzer`** bridge + `XX0000` descriptor, `Internal` category, and resx strings wired into **all 6 cops**.

Adopting an analyzer is a uniform **3-line edit** (no `Register*` changes). Only **`CaptionRequired`** (ApplicationCop) is converted in this PR; the other 92 analyzers adopt incrementally later via the documented recipe.

## Design notes

- **Severity `Info`, enabled** — visible, never breaks treat-warnings-as-errors builds.
- **Operation actions** use `new`-hiding (the public params overload routes through internal SDK members); works because adopters type the param as `SafeAnalysisContext`.
- **SDK coupling accepted + documented** — a new public-abstract `Register*` in a future SDK is a deliberate compile-time break (forces wrapping the new surface).
- Builds on **netstandard2.1/net8.0/net10.0**, no `#if` guards.

## Tests

`Rules/AnalyzerExceptionHarness/` adds test-only throwing analyzers covering the symbol, operation (`new`-hiding), and CompilationStart-nested paths; each asserts `AC0000` at the expected location. Full suite: **1170 tests pass**, all 6 cops build in CI triple-target mode.

## Docs (separate repo)

`XX0000.md` pages + index rows for all 6 cops are prepared on `../alcops.dev` but **not** committed here (that repo has unrelated in-progress changes); to be landed via its own PR.

## Out of scope

- Converting the remaining 92 analyzers.
- Fixing the underlying `CaptionRequired` NRE — `AC0000` now reveals the culprit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>