### PR TITLE
fix(PC0021): match TransferFields relations case-insensitively for namespaces

### DIFF
--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/HasDiagnostic/TableExt_NamespaceCasingMismatch.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/HasDiagnostic/TableExt_NamespaceCasingMismatch.al
@@ -1,0 +1,37 @@
+// The stored relation is Microsoft.Sales.History/"Sales Cr.Memo Header" ->
+// Microsoft.EServices.EDocument/"E-Invoice Export Header". Here the namespace is declared
+// with different literal casing ("microsoft.sales.history"). AL namespaces are
+// case-insensitive, so the relation must still match and the diagnostic must still fire.
+namespace microsoft.sales.history;
+
+table 50140 "Sales Cr.Memo Header"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+}
+
+table 50141 "E-Invoice Export Header"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+}
+
+tableextension 50142 MyCrMemoExt extends "Sales Cr.Memo Header"
+{
+    fields
+    {
+        [|field(50100; MyFieldA; Integer) { }|]
+    }
+}
+
+tableextension 50143 MyEInvExt extends "E-Invoice Export Header"
+{
+    fields
+    {
+        [|field(50100; MyFieldB; Integer) { }|] // Same ID (50100) as in MyCrMemoExt, different name
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/TransferFieldsNameMismatch.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/TransferFieldsNameMismatch.cs
@@ -33,10 +33,11 @@ namespace ALCops.PlatformCop.Test
         [TestCase("InvocationWithTableExtension")]
         [TestCase("TableExt_Multiple_SameBase")]
         [TestCase("TableExtension")]
+        [TestCase("TableExt_NamespaceCasingMismatch")]
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["InvocationWithTableExtension", "TableExt_Multiple_SameBase", "TableExtension", "TableExtensionTypeWithLength"],
+                ["InvocationWithTableExtension", "TableExt_Multiple_SameBase", "TableExtension", "TableExtensionTypeWithLength", "TableExt_NamespaceCasingMismatch"],
                 testCase,
                 "13.0",
                 "No support for tableextensions when target itself is already declared in the same module");

--- a/src/ALCops.PlatformCop/Analyzers/TransferFieldsRelations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TransferFieldsRelations.cs
@@ -38,13 +38,16 @@ internal static class TransferFieldsRelations
         var ns = table.GetContainingNamespaceQualifiedNameWithReflection() ?? string.Empty;
         var name = table.Name ?? string.Empty;
 
-        if (StringComparer.Ordinal.Equals(configured.Name, name) &&
-            StringComparer.Ordinal.Equals(configured.Namespace, ns))
+        // AL namespaces and object identifiers are case-insensitive, but the runtime-resolved
+        // namespace casing (symbol.ContainingNamespace.QualifiedName) is not stable across
+        // compilations, so both comparisons must be case-insensitive.
+        if (SemanticFacts.IsSameName(configured.Name, name) &&
+            SemanticFacts.IsSameName(configured.Namespace, ns))
             return true;
 
-        // Keep backwards comptibility for objects without namespace
+        // Keep backwards compatibility for objects without namespace
         if (string.IsNullOrEmpty(ns) &&
-            StringComparer.Ordinal.Equals(configured.Name, name))
+            SemanticFacts.IsSameName(configured.Name, name))
             return true;
 
         return false;

--- a/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
@@ -220,12 +220,12 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
 
         var sourceTableExtensions =
             tableExtensions
-                .Where(te => te.Target is not null && te.Target.Name.Equals(relation.Source.Name))
+                .Where(te => te.Target is not null && SemanticFacts.IsSameName(te.Target.Name, relation.Source.Name))
                 .SelectMany(x => x.AddedFields);
 
         var targetTableExtensions =
             tableExtensions
-                .Where(te => te.Target is not null && te.Target.Name.Equals(relation.Target.Name))
+                .Where(te => te.Target is not null && SemanticFacts.IsSameName(te.Target.Name, relation.Target.Name))
                 .SelectMany(x => x.AddedFields);
 
         var sourceById = BuildFieldMapById(sourceTableExtensions);


### PR DESCRIPTION
## Problem

`TransferFieldsRelations.Matches` compared the stored relation namespace and object name against the runtime-resolved values using `StringComparer.Ordinal` (case-sensitive). AL namespaces and object identifiers are **case-insensitive**, and the runtime-resolved namespace casing (`symbol.ContainingNamespace.QualifiedName`) is **not stable** across compilations: the same logical namespace ships with different literal casing across Microsoft apps (e.g. `Microsoft.EServices.EDocument` vs `Microsoft.eServices.EDocument`).

When the stored and runtime casing differ, `Matches` returned `false`. On the table-extension path (`AnalyzeTableExtension` → `TryFindBySource`) this silently dropped the schema-compatibility diagnostic — a **false negative**.

## Changes

- `TransferFieldsRelations.Matches`: compare **both** namespace and object `Name` with `SemanticFacts.IsSameName` (repo convention; internally `OrdinalIgnoreCase`), keeping the empty-namespace backwards-compatibility branch unchanged.
- `TransferFieldsSchemaCompatibility` (lines 223/228): same fix for the table-extension name lookups, which had the same latent ordinal bug.
- New regression test `TableExt_NamespaceCasingMismatch` exercising the table-extension false-negative with a namespace declared in different literal casing than the stored relation.

## Design decision

The Fix1 doc recommended `StringComparer.OrdinalIgnoreCase`. This repo's convention (CLAUDE.md) is to use `SemanticFacts` for all AL identifier comparisons, and the sibling file already does. Verified in the NAV SDK source that `SemanticFacts.NameEqualityComparer` is internally `StringComparer.OrdinalIgnoreCase`, so behaviour matches the doc's intent while staying convention-consistent and self-documenting. No culture-aware comparison introduced; `Matches` stays allocation-free; `ObjectName` shape and `#if NETSTANDARD2_1` guards unchanged.

## Validation

- Regression test **fails before** the fix (`no issue reported for PC0021`) and **passes after**, proving it's genuine.
- Full `ALCops.PlatformCop.Test` suite green: **457/457**.

## Instruction files

No existing TransferFields rule instruction file; per the maintenance policy a small bug fix does not require creating a new one. Rationale is captured in inline code comments.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>