### PR TITLE
Fix false positive for LC0086 on OptionCaption = '<style>'

### DIFF
--- a/.github/instructions/lc0086-page-style-string-literal.instructions.md
+++ b/.github/instructions/lc0086-page-style-string-literal.instructions.md
@@ -32,7 +32,7 @@ Version gate: `Fall2024OrGreater` (PageStyle introduced in BC25) · Full netstan
 | Severity | Warning | Actionable code smell, not a correctness issue |
 | Version gate | `Fall2024OrGreater` | PageStyle datatype didn't exist before BC25 |
 | Registration | `RegisterSyntaxNodeAction` on `StringLiteralValue` | Syntax-level check, no operation tree needed |
-| Caption suppression | Always skip Caption properties | Captions are user-facing text; `Caption = 'Standard'` is legitimate |
+| Caption suppression | Always skip Caption and OptionCaption properties | Caption-like properties are user-facing text; `Caption = 'Standard'` and `OptionCaption = 'None'` are legitimate |
 | Enum suppression | Skip Enum and EnumValue contexts | Enum names/captions are identifiers, not style expressions |
 | Unlocked labels | Skip (no diagnostic) | Unlocked labels are translatable text, not style constants |
 | StyleExpr direct | Skip `StyleExpr = 'Standard'` | Already using the string in the correct property; the fix is to change the property value type, not the location |
@@ -49,7 +49,7 @@ Uses `RegisterSyntaxNodeAction` on `SyntaxKind.StringLiteralValue` to analyze ev
 ### Analysis flow
 
 1. Skip obsolete symbols
-2. Skip Caption properties (`IPropertySymbol` with `PropertyKind.Caption`)
+2. Skip Caption-like properties (`IPropertySymbol` with `PropertyKind.Caption` or `OptionCaption`)
 3. Skip Enum and EnumValue symbol contexts
 4. Extract string value, skip empty strings
 5. **Case-sensitive lookup** in StyleKind dictionary (only PascalCase matches)
@@ -88,7 +88,7 @@ The shared `EnumProvider.StyleKind.CanonicalNames` uses `StringComparer.OrdinalI
 
 | Context | Suppressed | Rationale |
 |---|---|---|
-| Caption properties | Yes | User-facing text, not style values |
+| Caption/OptionCaption properties | Yes | User-facing text, not style values |
 | Enum/EnumValue symbols | Yes | Enum identifiers, not style expressions |
 | Unlocked labels | Yes | Translatable text, not style constants |
 | StyleExpr direct assignment | Yes | Already in the correct property location |
@@ -102,7 +102,7 @@ The shared `EnumProvider.StyleKind.CanonicalNames` uses `StringComparer.OrdinalI
 ## Test coverage
 
 **HasDiagnostic (4 cases):** Label (locked), Page (StyleExpr assignment), IfStatement, ExitStatement.
-**NoDiagnostic (10 cases):** AssignToStyleExpr, AssignToTableField, AssignToTableFieldLocal, AssignToTableFieldRec, Enum, Label (unlocked), LockedLabelLowercase, LockedLabelUppercase, Page (Caption), RecordMethodInvocation.
+**NoDiagnostic (11 cases):** AssignToStyleExpr, AssignToTableField, AssignToTableFieldLocal, AssignToTableFieldRec, Enum, Label (unlocked), LockedLabelLowercase, LockedLabelUppercase, Page (Caption), RecordMethodInvocation, TableFieldCaptions.
 
 ## Differences from BC.LinterCop LC0086
 

--- a/src/ALCops.LinterCop.Test/Rules/PageStyleStringLiteral/NoDiagnostic/TableFieldCaptions.al
+++ b/src/ALCops.LinterCop.Test/Rules/PageStyleStringLiteral/NoDiagnostic/TableFieldCaptions.al
@@ -1,0 +1,12 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "Option"; Option)
+        {
+            Caption = 'Option', Locked = true;
+            OptionMembers = None;
+            OptionCaption = [|'None'|], Locked = true;
+        }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/PageStyleStringLiteral/PageStyleStringLiteral.cs
+++ b/src/ALCops.LinterCop.Test/Rules/PageStyleStringLiteral/PageStyleStringLiteral.cs
@@ -49,10 +49,11 @@ namespace ALCops.LinterCop.Test
         [TestCase("LockedLabelUppercase")]
         [TestCase("Page")]
         [TestCase("RecordMethodInvocation")]
+		[TestCase("TableFieldCaptions")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["AssignToStyleExpr", "AssignToTableField", "AssignToTableFieldLocal", "AssignToTableFieldRec", "Enum", "Label", "LockedLabelLowercase", "LockedLabelUppercase", "Page", "RecordMethodInvocation"],
+                ["AssignToStyleExpr", "AssignToTableField", "AssignToTableFieldLocal", "AssignToTableFieldRec", "Enum", "Label", "LockedLabelLowercase", "LockedLabelUppercase", "Page", "RecordMethodInvocation", "TableFieldCaptions"],
                 testCase,
                 "14.0",
                 "No support for PageStyle datatype in versions below 14.0."

--- a/src/ALCops.LinterCop/Analyzers/PageStyleStringLiteral.cs
+++ b/src/ALCops.LinterCop/Analyzers/PageStyleStringLiteral.cs
@@ -54,8 +54,10 @@ public sealed class PageStyleStringLiteral : DiagnosticAnalyzer
             return;
 
         // Suppress string literals used in Caption properties
-        // Captions are user-facing text and may legitimately contain words that совпidentally match PageStyle names
-        if (ctx.ContainingSymbol is IPropertySymbol ps && ps.PropertyKind == EnumProvider.PropertyKind.Caption)
+        // Captions are user-facing text and may legitimately contain words that coincidentally match PageStyle names
+        PropertyKind[] captionKinds = [EnumProvider.PropertyKind.Caption, EnumProvider.PropertyKind.OptionCaption];
+
+        if (ctx.ContainingSymbol is IPropertySymbol ps && captionKinds.Contains(ps.PropertyKind))
             return;
 
         // Suppress enum and enum value contexts


### PR DESCRIPTION
This PR fixes a false positive in LC0086 for OptionCaption = '<style>'.

- Updated the PageStyleStringLiteral analyzer to avoid flagging valid OptionCaption = '<style>' cases.
- Added a new no-diagnostic test fixture: TableFieldCaptions.al.
- Extended PageStyleStringLiteral rule tests to cover this scenario.
- Updated the LC0086 instruction documentation accordingly.

Fixes #376 