### PR TITLE
#380 fix(lintercop): avoid false positives for lc0095 interface impl parameter casing

### DIFF
--- a/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
@@ -40,7 +40,7 @@ public static class MethodSymbolInterfaceExtensions
         if (methodSymbol is null || interfaceMethodSymbol is null)
             return false;
 
-        if (!string.Equals(methodSymbol.Name, interfaceMethodSymbol.Name, StringComparison.Ordinal))
+        if (!string.Equals(methodSymbol.Name, interfaceMethodSymbol.Name, StringComparison.OrdinalIgnoreCase))
             return false;
 
         if (methodSymbol.Parameters.Length != interfaceMethodSymbol.Parameters.Length)

--- a/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
@@ -40,7 +40,7 @@ public static class MethodSymbolInterfaceExtensions
         if (methodSymbol is null || interfaceMethodSymbol is null)
             return false;
 
-        if (!string.Equals(methodSymbol.Name, interfaceMethodSymbol.Name, StringComparison.OrdinalIgnoreCase))
+        if (!SemanticFacts.IsSameName(methodSymbol.Name, interfaceMethodSymbol.Name))
             return false;
 
         if (methodSymbol.Parameters.Length != interfaceMethodSymbol.Parameters.Length)

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/InterfaceImplementationWrongCasing.al
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/NoDiagnostic/InterfaceImplementationWrongCasing.al
@@ -1,0 +1,13 @@
+codeunit 50102 MyCodeunit implements MyInterface
+{
+    procedure Myprocedure([|myInteger: Integer|]; Mytext: Text; MyDAte: Date)
+    begin
+        Mytext := 'Hello';
+        MyDAte := Today();
+    end;
+}
+
+interface MyInterface
+{
+    procedure MyProcedure(MyInteger: Integer; MyText: Text; MyDate: Date);
+}

--- a/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
+++ b/src/ALCops.LinterCop.Test/Rules/ParameterNotReferenced/ParameterNotReferenced.cs
@@ -43,6 +43,7 @@ namespace ALCops.LinterCop.Test
         [TestCase("LocalProcedure")]
         [TestCase("TriggerUnusedParam")]
         [TestCase("InterfaceImplementation")]
+		[TestCase("InterfaceImplementationWrongCasing")]
         [TestCase("EventDeclaration")]
         [TestCase("ObsoleteProcedure")]
         [TestCase("AllParametersUsed")]


### PR DESCRIPTION
#380 fix(lintercop): avoid false positives for lc0095 interface impl parameter casing