### PR TITLE
fix(PC0035): suppress CalcFields-in-loop warning on temporary records

### DIFF
--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -25,6 +25,7 @@ Version gate: None (SetAutoCalcFields available since runtime 1.0)
 |---|---|---|
 | Loop types | FindSet/Find + repeat-until, while-do, report OnAfterGetRecord | All patterns that iterate over records |
 | Variable matching | Only flag CalcFields on the variable driving the loop | Avoids false positives (Example #2 from spec) |
+| Temporary records | Suppress (both `temporary` keyword and `TableType = Temporary`) | SetAutoCalcFields rewrites the SQL SELECT; temporary records are in-memory and never issue it, so the suggestion is a no-op. Detected via `RequiredPermissionDetector.IsEffectivelyTemporary` on `invocation.Instance.Type`. See issue #364 |
 | Conditional paths | Skip entirely (if/case) | Cannot guarantee conditional CalcFields always executes; avoids false positives |
 | Cross-method tracking | Out of scope v1 | Complex, may lack source code for dependencies |
 | RecordRef | N/A | RecordRef does not have a CalcFields method in the SDK |
@@ -57,7 +58,7 @@ This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (
 
 ### CalcFields detection
 
-`VisitInvocationExpression` checks: `IsInLoop() && _conditionalDepth == 0 && IsCalcFieldsCall(...)` and verifies the instance variable is in the current set of loop variables (at any nesting level).
+`VisitInvocationExpression` checks: `IsInLoop() && _conditionalDepth == 0 && IsCalcFieldsCall(...)` and verifies the instance variable is in the current set of loop variables (at any nesting level). It then calls `IsTemporaryRecord(...)`, which resolves `invocation.Instance?.Type as IRecordTypeSymbol` and delegates to `RequiredPermissionDetector.IsEffectivelyTemporary`. Temporary records (either the `temporary` keyword or a `TableType = Temporary` backing table) are skipped, because `SetAutoCalcFields` is a no-op on in-memory records.
 
 ### CodeFix strategy
 
@@ -70,7 +71,7 @@ This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (
 ## Test coverage
 
 **HasDiagnostic (7 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop, NestedLoopInConditional.
-**NoDiagnostic (7 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord, CalcFieldsInIfBlock, CalcFieldsInCaseBlock, CalcFieldsInIfElseBlock.
+**NoDiagnostic (10 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord, CalcFieldsInIfBlock, CalcFieldsInCaseBlock, CalcFieldsInIfElseBlock, TemporaryVariable, TemporaryTableType, ReportTemporaryTableType.
 **HasFix (2 cases):** FindSetRepeatUntil, MultipleFields.
 
 ## Known limitations

--- a/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
+++ b/src/ALCops.Common/Permissions/RequiredPermissionDetector.cs
@@ -139,8 +139,8 @@ public static class RequiredPermissionDetector
     /// <summary>
     /// Returns true if the record is temporary by any means: the <c>temporary</c> keyword on the
     /// variable (<see cref="IRecordTypeSymbol.Temporary"/>) or a backing table declared with
-    /// <c>TableType = Temporary</c>. Temporary records never touch the database, so they require
-    /// no permissions regardless of how the temporary table is implemented.
+    /// <c>TableType = Temporary</c>. Temporary records are in-memory and never touch the database,
+    /// regardless of how the temporary table is implemented.
     /// </summary>
     public static bool IsEffectivelyTemporary(IRecordTypeSymbol record) =>
         record.Temporary

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/ReportTemporaryTableType.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/ReportTemporaryTableType.al
@@ -1,0 +1,33 @@
+report 50100 MyReport
+{
+    dataset
+    {
+        dataitem(MyTempTable; MyTempTable)
+        {
+            trigger OnAfterGetRecord()
+            begin
+                [|MyTempTable.CalcFields(MyFlowField)|];
+            end;
+        }
+    }
+}
+
+table 50100 MyTempTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTempTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/TemporaryTableType.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/TemporaryTableType.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTempTable: Record MyTempTable;
+    begin
+        while MyTempTable.FindSet() do begin
+            [|MyTempTable.CalcFields(MyFlowField)|];
+        end;
+    end;
+}
+
+table 50100 MyTempTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTempTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/TemporaryVariable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoDiagnostic/TemporaryVariable.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        if MyTable.FindSet() then
+            repeat
+                [|MyTable.CalcFields(MyFlowField)|];
+            until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -44,6 +44,9 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("CalcFieldsInIfBlock")]
     [TestCase("CalcFieldsInCaseBlock")]
     [TestCase("CalcFieldsInIfElseBlock")]
+    [TestCase("TemporaryVariable")]
+    [TestCase("TemporaryTableType")]
+    [TestCase("ReportTemporaryTableType")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop/Analyzers/UseSetAutoCalcFieldsForLoops.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
+using ALCops.Common.Permissions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
@@ -117,7 +118,9 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
             if (IsInLoop() && _conditionalDepth == 0 && IsCalcFieldsCall(operation))
             {
                 var instanceName = GetInstanceVariableName(operation);
-                if (instanceName is not null && IsLoopVariable(instanceName))
+                if (instanceName is not null &&
+                    IsLoopVariable(instanceName) &&
+                    !IsTemporaryRecord(operation))
                 {
                     _diagnostics.Add(new CalcFieldsDiagnosticInfo(
                         operation.Syntax.GetLocation(),
@@ -262,6 +265,18 @@ public sealed class UseSetAutoCalcFieldsForLoops : DiagnosticAnalyzer
 
             return targetMethod.MethodKind == EnumProvider.MethodKind.BuiltInMethod &&
                    SemanticFacts.IsSameName(targetMethod.Name, "CalcFields");
+        }
+
+        /// <summary>
+        /// Returns true when the record the CalcFields call targets is temporary by any means:
+        /// the <c>temporary</c> keyword on the variable, or a backing table declared with
+        /// <c>TableType = Temporary</c>. SetAutoCalcFields rewrites the SQL SELECT and is a no-op
+        /// on in-memory temporary records, so the suggestion would be wrong there.
+        /// </summary>
+        private static bool IsTemporaryRecord(IInvocationExpression invocation)
+        {
+            return invocation.Instance?.Type is IRecordTypeSymbol recordType &&
+                   RequiredPermissionDetector.IsEffectivelyTemporary(recordType);
         }
 
         private static string? GetInstanceVariableName(IInvocationExpression invocation)


### PR DESCRIPTION
Fixes #364

## Problem

PC0035 flags `CalcFields` inside loops and suggests `SetAutoCalcFields` before the loop. But `SetAutoCalcFields` works by rewriting the SQL `SELECT` with JOINs so FlowFields are computed when a record is fetched from the database. Temporary records are in-memory and never issue that `SELECT`, so `SetAutoCalcFields` is a **no-op** on them, while `CalcFields` still evaluates each FlowField's `CalcFormula` against the real source tables. Suggesting the swap on a temporary record is therefore wrong.

## Fix

Suppress PC0035 when the `CalcFields` target is effectively temporary, via the shared `RequiredPermissionDetector.IsEffectivelyTemporary` helper. This covers **both** runtime forms of temporary (the reporter's case was the first):

1. Variable declared with the `temporary` keyword (`Record Customer temporary`) — `IRecordTypeSymbol.Temporary`.
2. Table object declared `TableType = Temporary` — `ITableTypeSymbol.TableType == TableTypeKind.Temporary`. `IRecordTypeSymbol.Temporary` is `false` here (the SDK sets that flag only from the variable keyword, per `Binder.cs`), so both must be checked.

The check runs at the `CalcFields` call site on `invocation.Instance?.Type`, covering variable-driven loops (repeat-until / while-do) and report `OnAfterGetRecord`.

No CodeFix change needed: no diagnostic means no fix is offered.

## Tests

Added 3 NoDiagnostic fixtures: `TemporaryVariable` (case 1), `TemporaryTableType` (case 2), `ReportTemporaryTableType` (case 2 via report trigger). Targeted suite: 21/21 passing.

## Docs

Documentation update for `alcops.dev` is prepared separately (not part of this PR).