### PR TITLE
fix: detach CaptionRequired from Common base to resolve alc AL1003 (#389)

### DIFF
--- a/.github/instructions/analyzer-development.instructions.md
+++ b/.github/instructions/analyzer-development.instructions.md
@@ -168,9 +168,11 @@ All analyzers are decorated with `[DiagnosticAnalyzer]`.
 > on `app.json`. Adoption is a 3-line change: base type `: DiagnosticAnalyzer` →
 > `: {Cop}Analyzer`, `SupportedDiagnostics` → `SupportedDiagnosticsCore`, and
 > `Initialize(AnalysisContext)` → `InitializeAnalyzer(SafeAnalysisContext)` (no
-> `Register*` changes). Currently only `CaptionRequired` is converted. See
-> `analyzer-exception-harness.instructions.md`. The template below shows the
-> still-supported plain `DiagnosticAnalyzer` form.
+> `Register*` changes). **Currently no production analyzer adopts the harness**
+> (`CaptionRequired` was temporarily detached to fix issue #389 — the Common-based
+> bridge made `alc` fail with `AL1003` at type-load; re-adoption needs a loader-safe
+> fix first). See `analyzer-exception-harness.instructions.md`. The template below
+> shows the still-supported (and currently used) plain `DiagnosticAnalyzer` form.
 
 ### Minimal Template (Symbol-based)
 

--- a/.github/instructions/analyzer-exception-harness.instructions.md
+++ b/.github/instructions/analyzer-exception-harness.instructions.md
@@ -48,8 +48,16 @@ protected override void InitializeAnalyzer(SafeAnalysisContext context) => ...
 Keep the `[DiagnosticAnalyzer]` attribute. Do **not** list the cop's
 `AnalyzerException` descriptor in `SupportedDiagnosticsCore`; the base appends it.
 
-As of this change only `CaptionRequired` (ApplicationCop) is converted. The other
-analyzers adopt the harness incrementally via this same recipe.
+As of this change **no production analyzer currently adopts the harness.**
+`CaptionRequired` (ApplicationCop) was the first adopter but has been temporarily
+detached back to plain `DiagnosticAnalyzer` to fix issue #389: deriving from the
+Common-based bridge made the AL compiler (`alc`) fail to instantiate the cop with
+`AL1003` because `ALCops.Common.dll` is not resolved from the analyzer's own folder
+at type-load time. The harness framework, per-cop bridges, and `XX0000` descriptors
+remain in place. Re-adoption requires a loader-safe approach first (for example
+merging `ALCops.Common` into each cop assembly, or guaranteeing `ALCops.Common.dll`
+is the first `/analyzer:` argument). Only the harness tests (test-only throwing
+analyzers) currently exercise the recipe.
 
 ## Location strategy per context
 

--- a/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
@@ -4,21 +4,20 @@ using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
-using ALCops.Common.Diagnostics;
 
 namespace ALCops.ApplicationCop.Analyzers;
 
 [DiagnosticAnalyzer]
-public sealed class CaptionRequired : ApplicationCopAnalyzer
+public sealed class CaptionRequired : DiagnosticAnalyzer
 {
-    protected override ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsCore { get; } =
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(
             DiagnosticDescriptors.CaptionRequired);
 
     private static readonly HashSet<string> _predefinedActionCategoryNames =
         SyntaxFacts.PredefinedActionCategoryNames.Select(x => x.Key.ToLowerInvariant()).ToHashSet();
 
-    protected override void InitializeAnalyzer(SafeAnalysisContext context) =>
+    public override void Initialize(AnalysisContext context) =>
         context.RegisterSymbolAction(
             CheckForMissingCaptions,
             EnumProvider.SymbolKind.Page,


### PR DESCRIPTION
Fixes #389.

## Problem

Since v1.0.0, loading any cop via the AL compiler's `/analyzer:` argument fails with `AL1003`:

```
error AL1003: An instance of analyzer ALCops.ApplicationCop.Analyzers.CaptionRequired
cannot be created ... Could not load file or assembly 'ALCops.Common ...'
```

`alc` does not probe an analyzer's own folder for its dependencies. The #366 XX0000 harness changed `CaptionRequired` to derive from `ApplicationCopAnalyzer` → `ALCops.Common.Diagnostics.ALCopsDiagnosticAnalyzer`, so resolving the base type chain into `ALCops.Common.dll` at `Activator.CreateInstance` fails before Common's own later `/analyzer:` entry has loaded it. `CaptionRequired` was the only production adopter.

## Fix (quickfix)

Detach only `CaptionRequired`, reverting it to derive directly from the SDK's `DiagnosticAnalyzer` with standard `SupportedDiagnostics` + `Initialize`. This removes the instantiation-time Common dependency and restores v0.9.0 loading behavior (Common is still used at JIT time via `EnumProvider`/extensions, by which point it is loaded via its own `/analyzer:` entry).

**The harness framework is left fully in place** for a future, loader-safe re-adoption:
- `ALCops.Common/Diagnostics/*` (ALCopsDiagnosticAnalyzer, SafeAnalysisContext, SafeCompilationStartContext, AnalyzerExceptionReporter) — unchanged
- All 6 per-cop bridge classes + AC0000/XX0000 descriptors — unchanged
- AnalyzerExceptionHarness tests — unchanged; still validate the framework

## Docs

Updated `analyzer-exception-harness` and `analyzer-development` instruction files to note no production analyzer currently adopts the harness.

## Verification

- `dotnet build ALCops.sln` — 0 errors
- `dotnet test ALCops.sln` — all green (ApplicationCop 311 incl. CaptionRequired + harness tests)
- alc-level AL1003 reproduction is out of scope for this quickfix (agreed).

## Residual risk

This fixes the symptom for the single adopter. Any future analyzer that adopts the harness base without a loader fix (e.g. ILRepack/merge Common, or Common-first `/analyzer:` ordering) reintroduces AL1003. Documented for the follow-up.