### PR TITLE
fix(LC0091): namespace-aware translation IDs for SDK 18.0.38.52553

### DIFF
--- a/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
+++ b/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
@@ -29,7 +29,7 @@ These decisions were made during the initial design and should be preserved unle
 | Cop placement | LinterCop (LC prefix) | General code quality rule; reuses same ID as original |
 | Severity | Warning | Missing translations directly affect user experience |
 | Extension root symbol | `ExtensionObjectFoldingUtilities.GetTranslationRootSymbol` SDK API | Fixes the multi-extension bug in the original rule; correctly handles all cases |
-| Translation ID generation | `LanguageFileUtilities.GetLanguageSymbolId` / `GetLabelTextConstLanguageSymbolId` | Stable public SDK APIs using FNV hash |
+| Translation ID generation | `LanguageFileUtilities` via **runtime reflection** (`GetTranslationFileId` on new SDKs, public 2-param `GetLanguageSymbolId` / `GetLabelTextConstLanguageSymbolId` on older SDKs) | The public methods gained an optional `useNamespaces` param in `18.0.38.52553`; C# bakes optional-param call sites at compile time, so a direct call breaks across SDK versions (see Known issues). Reflection picks the right method at runtime and supports namespace-aware IDs. |
 | ManifestHelper exception handling | Catch `FileNotFoundException` and treat as null manifest | `ManifestHelper.GetManifest` loads `Microsoft.Dynamics.Nav.Analyzers.Common` assembly via reflection; this assembly isn't present in test contexts |
 | Null manifest behavior | Proceed with analysis (don't skip) | Tests create minimal compilations without manifests; real projects always have manifests |
 | XLIFF caching | Load once in CompilationStartAction | Avoid re-parsing per symbol |
@@ -100,6 +100,16 @@ This is NOT an SDK bug; it's a consequence of running analyzers in a test enviro
 
 The SDK's `OperationExtensions.GetSymbol()` can throw `InvalidCastException` for `BoundObjectAccess` instances. This analyzer doesn't use operation-level analysis, so it's not affected.
 
+### SDK 18.0.38.52553: optional-parameter break on translation-ID methods (version drift)
+
+`LanguageFileUtilities.GetLanguageSymbolId(ISymbol, IRootTypeSymbol?)` and `GetLabelTextConstLanguageSymbolId(ISymbol, IRootTypeSymbol?)` gained an optional `bool useNamespaces = false` parameter in AL `18.0.38.52553` (part of the `TranslationsWithNamespaces` compiler feature). C# compiles optional-parameter defaults into the **call site**, so the analyzer DLL — built once against the lowest net10.0 SDK (`18.0.36.x`, 2-param) and, in CI, run against `18.0.38.52553` (binary reference, `ContinuousIntegrationBuild=true`) — referenced a 2-param overload that no longer exists at runtime → `MissingMethodException` → no `LC0091` emitted (all `HasDiagnostic` tests failed; `NoDiagnostic` trivially passed). A local `ProjectReference` build compiles+runs against the same SDK and does **not** reproduce it; it is a compile-vs-runtime version drift.
+
+**Workaround:** compute all translation IDs through runtime reflection (see the `Translation ID computation (SDK version compat)` region in the analyzer). No arity is baked into the call site:
+- New SDKs (feature present): internal `GetTranslationFileId(name, kind, containingSymbol, isMissingCaption, rootSymbol, useNamespaces)` + public `UseTranslationsWithNamespaces(ISymbol)`. This produces namespace-aware trans-unit IDs (namespace-prefixed, unhashed segments joined by `" - "`, hashed only when > 400 chars), matching the compiler and avoiding false positives on namespace-enabled projects.
+- Older SDKs (methods absent): fall back to the public 2-param methods.
+
+`EnumProvider.SymbolKind.NamedType` was added for the label-const path (mirrors `GetLabelTextConstLanguageSymbolId`, which forces `SymbolKind.NamedType`).
+
 ## Symbol kinds and translatable properties
 
 | Symbol Kind | Properties Checked |
@@ -127,9 +137,11 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 **HasDiagnostic (7 cases):** LocalLabel, GlobalLabel, TableFieldCaption, EnumValueCaption, PageControlToolTip, PageAnalysisViewCaption, ReportLabel.
 **HasDiagnosticWithLanguagesToTranslateNoXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK"], no XLIFF files.
 **HasDiagnosticWithLanguagesToTranslatePartialXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK","de-DE"], only da-DK XLIFF.
+**HasDiagnosticWithNamespaces (1 case):** NamespaceTableCaption (gated `RequireMinimumVersion("18.0.38.52553")`; `TranslationsWithNamespaces` feature enabled via `CompilationOptions.WithCompilerFeatures`, empty XLIFF → namespace-mode path reports).
 **NoDiagnostic (2 cases):** LockedLabel, LockedReportLabel.
 **NoDiagnosticTranslated (1 case):** TranslatedReportLabel (XLIFF contains proper translation with matching trans-unit ID).
 **NoDiagnosticNoXliff (1 case):** No XLIFF files present, no LanguagesToTranslate setting.
+**NoDiagnosticWithNamespaces (1 case):** NamespaceTableCaptionTranslated (gated `RequireMinimumVersion("18.0.38.52553")`; translated XLIFF with the namespace-aware trans-unit ID `Namespace MyCompany.App - Table MyTable - Property Caption` → no false positive).
 
 ## Test infrastructure
 

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -823,6 +823,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.Method)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _module =
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.Module)));
+        private static readonly Lazy<NavCodeAnalysis.SymbolKind> _namedType =
+            new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.NamedType)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _page =
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.Page)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _pageExtension =
@@ -884,6 +886,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.SymbolKind LocalVariable => _localVariable.Value;
         public static NavCodeAnalysis.SymbolKind Method => _method.Value;
         public static NavCodeAnalysis.SymbolKind Module => _module.Value;
+        public static NavCodeAnalysis.SymbolKind NamedType => _namedType.Value;
         public static NavCodeAnalysis.SymbolKind Page => _page.Value;
         public static NavCodeAnalysis.SymbolKind PageExtension => _pageExtension.Value;
         public static NavCodeAnalysis.SymbolKind PermissionSet => _permissionSet.Value;

--- a/src/ALCops.Common/Reflection/TranslationIdHelper.cs
+++ b/src/ALCops.Common/Reflection/TranslationIdHelper.cs
@@ -1,0 +1,105 @@
+#if !NETSTANDARD2_1
+using System.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Translation;
+
+namespace ALCops.Common.Reflection;
+
+/// <summary>
+/// COMPAT: Computes the XLIFF trans-unit ID for a translatable symbol across SDK versions.
+///
+/// In AL SDK 18.0.38.52553 the public <c>LanguageFileUtilities</c> translation-ID methods
+/// (<c>GetLanguageSymbolId</c> / <c>GetLabelTextConstLanguageSymbolId</c>) gained an optional
+/// <c>bool useNamespaces = false</c> parameter. C# bakes optional-parameter defaults into the call
+/// site, so a direct call compiled against an older SDK (2-param) throws
+/// <see cref="MissingMethodException"/> when the analyzer runs against the newer SDK (3-param).
+/// All ID computation therefore goes through reflection so no arity is baked into the call site.
+///
+/// <list type="bullet">
+/// <item>New SDK: use internal <c>GetTranslationFileId(...)</c> + public
+/// <c>UseTranslationsWithNamespaces(ISymbol)</c> so the computed ID matches the compiler-generated
+/// trans-unit ID (including namespace-aware IDs).</item>
+/// <item>Old SDK: fall back to the public 2-param <c>GetLanguageSymbolId</c> /
+/// <c>GetLabelTextConstLanguageSymbolId</c>.</item>
+/// </list>
+///
+/// This helper lives in ALCops.Common so all SDK-version-compat reflection is centralized; future
+/// SDK bumps only need changes here rather than in the analyzer. On netstandard2.1 the underlying
+/// SDK methods do not exist, so this helper is compiled out entirely (the LC0091 analyzer is an inert
+/// stub there).
+/// </summary>
+public static class TranslationIdHelper
+{
+    // GetTranslationFileId(string name, SymbolKind kind, Symbol containingSymbol, bool isMissingCaption,
+    //                      IRootTypeSymbol? rootSymbolOverride, bool useNamespaces) — internal, new SDK only.
+    private static readonly Lazy<MethodInfo?> _getTranslationFileIdMethod = new(() =>
+        typeof(LanguageFileUtilities)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "GetTranslationFileId" && m.GetParameters().Length == 6));
+
+    // UseTranslationsWithNamespaces(ISymbol) — public, new SDK only.
+    private static readonly Lazy<MethodInfo?> _useTranslationsWithNamespacesMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "UseTranslationsWithNamespaces",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol)],
+            null));
+
+    // Old-SDK fallbacks: public 2-param methods, present only on SDKs without the namespace feature.
+    private static readonly Lazy<MethodInfo?> _getLanguageSymbolIdMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "GetLanguageSymbolId",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol), typeof(IRootTypeSymbol)],
+            null));
+
+    private static readonly Lazy<MethodInfo?> _getLabelTextConstLanguageSymbolIdMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "GetLabelTextConstLanguageSymbolId",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol), typeof(IRootTypeSymbol)],
+            null));
+
+    /// <summary>
+    /// Computes the XLIFF trans-unit ID for the given translatable symbol, matching the ID the AL
+    /// compiler generates. Returns <see langword="null"/> when no compatible SDK method can be resolved
+    /// (in which case callers should skip the symbol rather than report a false positive).
+    /// </summary>
+    /// <param name="symbol">The translatable symbol (property, label variable, or report label).</param>
+    /// <param name="rootSymbol">The translation root symbol override, or <see langword="null"/>.</param>
+    /// <param name="isLabelConst">
+    /// <see langword="true"/> for label text constants (uses the NamedType symbol kind and the
+    /// label-const fallback); <see langword="false"/> for properties and report labels.
+    /// </param>
+    public static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst)
+    {
+        MethodInfo? translationFileId = _getTranslationFileIdMethod.Value;
+        if (translationFileId is not null)
+        {
+            SymbolKind kind = isLabelConst ? EnumProvider.SymbolKind.NamedType : symbol.Kind;
+            bool useNamespaces = GetUseTranslationsWithNamespaces(symbol);
+
+            return translationFileId.Invoke(null,
+                [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string;
+        }
+
+        MethodInfo? fallback = isLabelConst
+            ? _getLabelTextConstLanguageSymbolIdMethod.Value
+            : _getLanguageSymbolIdMethod.Value;
+
+        return fallback?.Invoke(null, [symbol, rootSymbol]) as string;
+    }
+
+    private static bool GetUseTranslationsWithNamespaces(ISymbol symbol)
+    {
+        MethodInfo? method = _useTranslationsWithNamespacesMethod.Value;
+        if (method is null)
+            return false;
+
+        return method.Invoke(null, [symbol]) is true;
+    }
+}
+#endif

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/NamespaceTableCaption.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/NamespaceTableCaption.al
@@ -1,0 +1,11 @@
+namespace MyCompany.App;
+
+table 50100 MyTable
+{
+    [|Caption = 'My Table'|];
+
+    fields
+    {
+        field(1; MyField; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/NamespaceTableCaptionTranslated.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/NamespaceTableCaptionTranslated.al
@@ -1,0 +1,11 @@
+namespace MyCompany.App;
+
+table 50100 MyTable
+{
+    [|Caption = 'My Table'|];
+
+    fields
+    {
+        field(1; MyField; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -38,6 +38,26 @@ namespace ALCops.LinterCop.Test
             </xliff>
             """);
 
+        // Trans-unit id for a table Caption in namespace "MyCompany.App" when the compiler feature
+        // TranslationsWithNamespaces is enabled: namespace-prefixed, unhashed segments joined by " - ".
+        private static readonly byte[] NamespaceTranslatedTableCaptionXliffContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file datatype="xml" source-language="en-US" target-language="da-DK" original="TestApp">
+                <body>
+                  <group id="body">
+                    <trans-unit id="Namespace MyCompany.App - Table MyTable - Property Caption" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>My Table</source>
+                      <target>Min tabel</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - Property Caption</note>
+                    </trans-unit>
+                  </group>
+                </body>
+              </file>
+            </xliff>
+            """);
+
         private static readonly byte[] SettingsWithDaDK = System.Text.Encoding.UTF8.GetBytes(
             """{"LanguagesToTranslate": ["da-DK"]}""");
 
@@ -134,6 +154,35 @@ namespace ALCops.LinterCop.Test
                 new AnalyzerTestFixtureConfig
                 {
                     FileSystem = fileSystem
+                });
+        }
+
+        // COMPAT: CompilerFeatures.TranslationsWithNamespaces and CompilationOptions.WithCompilerFeatures are
+        // resolved reflectively so this test project still compiles against older SDKs where the enum member is
+        // absent. The namespace tests are version-gated (RequireMinimumVersion) so this only runs where present.
+        private static Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions CreateNamespaceCompilationOptions()
+        {
+            var options = new Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions();
+            var optionsType = typeof(Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions);
+            var featuresType = optionsType.Assembly.GetType("Microsoft.Dynamics.Nav.CodeAnalysis.CompilerFeatures")!;
+            var feature = Enum.Parse(featuresType, "TranslationsWithNamespaces");
+            var withFeatures = optionsType.GetMethod("WithCompilerFeatures", new[] { featuresType })!;
+            return (Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions)withFeatures.Invoke(options, new[] { feature })!;
+        }
+
+        private static AnalyzerTestFixture CreateFixtureWithNamespaceFeature(byte[] xliffContent)
+        {
+            var files = new Dictionary<string, byte[]>
+            {
+                { "Translations/TestApp.da-DK.xlf", xliffContent }
+            };
+            var fileSystem = new MemoryFileSystem(files);
+
+            return RoslynFixtureFactory.Create<Analyzers.TranslatableTextShouldBeTranslated>(
+                new AnalyzerTestFixtureConfig
+                {
+                    FileSystem = fileSystem,
+                    CompilationOptions = CreateNamespaceCompilationOptions()
                 });
         }
 
@@ -247,6 +296,36 @@ namespace ALCops.LinterCop.Test
 
             var fixture = CreateFixtureWithXliffAndSettings(SettingsWithDaDKAndDeDE);
             fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("NamespaceTableCaption")]
+        public async Task HasDiagnosticWithNamespaces(string testCase)
+        {
+            RequireMinimumVersion("18.0.38.52553",
+                "Translations with namespaces (CompilerFeatures.TranslationsWithNamespaces) requires the 18.0.38.52553 SDK.");
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithNamespaceFeature(EmptyXliffContent);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("NamespaceTableCaptionTranslated")]
+        public async Task NoDiagnosticWithNamespaces(string testCase)
+        {
+            RequireMinimumVersion("18.0.38.52553",
+                "Translations with namespaces (CompilerFeatures.TranslationsWithNamespaces) requires the 18.0.38.52553 SDK.");
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithNamespaceFeature(NamespaceTranslatedTableCaptionXliffContent);
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
         }
     }
 }

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -138,7 +138,9 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(symbol);
-        string translationId = LanguageFileUtilities.GetLabelTextConstLanguageSymbolId(symbol, rootSymbol);
+        string? translationId = ComputeTranslationId(symbol, rootSymbol, isLabelConst: true);
+        if (translationId is null)
+            return;
 
         ReportMissingTranslation(ctx, symbol, translationId, translationIndex);
     }
@@ -152,7 +154,9 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(symbol);
-        string translationId = LanguageFileUtilities.GetLanguageSymbolId(symbol, rootSymbol);
+        string? translationId = ComputeTranslationId(symbol, rootSymbol, isLabelConst: false);
+        if (translationId is null)
+            return;
 
         ReportMissingTranslation(ctx, symbol, translationId, translationIndex);
     }
@@ -215,7 +219,9 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(property);
-        string translationId = LanguageFileUtilities.GetLanguageSymbolId(property, rootSymbol);
+        string? translationId = ComputeTranslationId(property, rootSymbol, isLabelConst: false);
+        if (translationId is null)
+            return;
 
         ReportMissingTranslation(ctx, property, translationId, translationIndex);
     }
@@ -350,6 +356,81 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         }
 
         return new TranslationIndex(availableLanguages, index);
+    }
+
+    #endregion
+
+    #region Translation ID computation (SDK version compat)
+
+    // COMPAT: In AL SDK 18.0.38.52553 the public LanguageFileUtilities translation-ID methods gained an
+    // optional `bool useNamespaces = false` parameter. C# bakes optional-parameter defaults into the call
+    // site, so a direct call compiled against an older SDK (2-param) throws MissingMethodException when the
+    // analyzer runs against the newer SDK (3-param). All ID computation therefore goes through reflection so
+    // no arity is baked into the call site.
+    //
+    // - New SDK: use internal GetTranslationFileId(...) + public UseTranslationsWithNamespaces(ISymbol) so the
+    //   computed ID matches the compiler-generated trans-unit ID (including namespace-aware IDs).
+    // - Old SDK: fall back to the public 2-param GetLanguageSymbolId / GetLabelTextConstLanguageSymbolId.
+
+    // GetTranslationFileId(string name, SymbolKind kind, Symbol containingSymbol, bool isMissingCaption,
+    //                      IRootTypeSymbol? rootSymbolOverride, bool useNamespaces) — internal, new SDK only.
+    private static readonly Lazy<MethodInfo?> _getTranslationFileIdMethod = new(() =>
+        typeof(LanguageFileUtilities)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "GetTranslationFileId" && m.GetParameters().Length == 6));
+
+    // UseTranslationsWithNamespaces(ISymbol) — public, new SDK only.
+    private static readonly Lazy<MethodInfo?> _useTranslationsWithNamespacesMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "UseTranslationsWithNamespaces",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol)],
+            null));
+
+    // Old-SDK fallbacks: public 2-param methods, present only on SDKs without the namespace feature.
+    private static readonly Lazy<MethodInfo?> _getLanguageSymbolIdMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "GetLanguageSymbolId",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol), typeof(IRootTypeSymbol)],
+            null));
+
+    private static readonly Lazy<MethodInfo?> _getLabelTextConstLanguageSymbolIdMethod = new(() =>
+        typeof(LanguageFileUtilities).GetMethod(
+            "GetLabelTextConstLanguageSymbolId",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            [typeof(ISymbol), typeof(IRootTypeSymbol)],
+            null));
+
+    private static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst)
+    {
+        MethodInfo? translationFileId = _getTranslationFileIdMethod.Value;
+        if (translationFileId is not null)
+        {
+            SymbolKind kind = isLabelConst ? EnumProvider.SymbolKind.NamedType : symbol.Kind;
+            bool useNamespaces = GetUseTranslationsWithNamespaces(symbol);
+
+            return translationFileId.Invoke(null,
+                [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string;
+        }
+
+        MethodInfo? fallback = isLabelConst
+            ? _getLabelTextConstLanguageSymbolIdMethod.Value
+            : _getLanguageSymbolIdMethod.Value;
+
+        return fallback?.Invoke(null, [symbol, rootSymbol]) as string;
+    }
+
+    private static bool GetUseTranslationsWithNamespaces(ISymbol symbol)
+    {
+        MethodInfo? method = _useTranslationsWithNamespacesMethod.Value;
+        if (method is null)
+            return false;
+
+        return method.Invoke(null, [symbol]) is true;
     }
 
     #endregion

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -138,7 +138,7 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(symbol);
-        string? translationId = ComputeTranslationId(symbol, rootSymbol, isLabelConst: true);
+        string? translationId = TranslationIdHelper.ComputeTranslationId(symbol, rootSymbol, isLabelConst: true);
         if (translationId is null)
             return;
 
@@ -154,7 +154,7 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(symbol);
-        string? translationId = ComputeTranslationId(symbol, rootSymbol, isLabelConst: false);
+        string? translationId = TranslationIdHelper.ComputeTranslationId(symbol, rootSymbol, isLabelConst: false);
         if (translationId is null)
             return;
 
@@ -219,7 +219,7 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             return;
 
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(property);
-        string? translationId = ComputeTranslationId(property, rootSymbol, isLabelConst: false);
+        string? translationId = TranslationIdHelper.ComputeTranslationId(property, rootSymbol, isLabelConst: false);
         if (translationId is null)
             return;
 
@@ -356,81 +356,6 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         }
 
         return new TranslationIndex(availableLanguages, index);
-    }
-
-    #endregion
-
-    #region Translation ID computation (SDK version compat)
-
-    // COMPAT: In AL SDK 18.0.38.52553 the public LanguageFileUtilities translation-ID methods gained an
-    // optional `bool useNamespaces = false` parameter. C# bakes optional-parameter defaults into the call
-    // site, so a direct call compiled against an older SDK (2-param) throws MissingMethodException when the
-    // analyzer runs against the newer SDK (3-param). All ID computation therefore goes through reflection so
-    // no arity is baked into the call site.
-    //
-    // - New SDK: use internal GetTranslationFileId(...) + public UseTranslationsWithNamespaces(ISymbol) so the
-    //   computed ID matches the compiler-generated trans-unit ID (including namespace-aware IDs).
-    // - Old SDK: fall back to the public 2-param GetLanguageSymbolId / GetLabelTextConstLanguageSymbolId.
-
-    // GetTranslationFileId(string name, SymbolKind kind, Symbol containingSymbol, bool isMissingCaption,
-    //                      IRootTypeSymbol? rootSymbolOverride, bool useNamespaces) — internal, new SDK only.
-    private static readonly Lazy<MethodInfo?> _getTranslationFileIdMethod = new(() =>
-        typeof(LanguageFileUtilities)
-            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-            .FirstOrDefault(m => m.Name == "GetTranslationFileId" && m.GetParameters().Length == 6));
-
-    // UseTranslationsWithNamespaces(ISymbol) — public, new SDK only.
-    private static readonly Lazy<MethodInfo?> _useTranslationsWithNamespacesMethod = new(() =>
-        typeof(LanguageFileUtilities).GetMethod(
-            "UseTranslationsWithNamespaces",
-            BindingFlags.Public | BindingFlags.Static,
-            null,
-            [typeof(ISymbol)],
-            null));
-
-    // Old-SDK fallbacks: public 2-param methods, present only on SDKs without the namespace feature.
-    private static readonly Lazy<MethodInfo?> _getLanguageSymbolIdMethod = new(() =>
-        typeof(LanguageFileUtilities).GetMethod(
-            "GetLanguageSymbolId",
-            BindingFlags.Public | BindingFlags.Static,
-            null,
-            [typeof(ISymbol), typeof(IRootTypeSymbol)],
-            null));
-
-    private static readonly Lazy<MethodInfo?> _getLabelTextConstLanguageSymbolIdMethod = new(() =>
-        typeof(LanguageFileUtilities).GetMethod(
-            "GetLabelTextConstLanguageSymbolId",
-            BindingFlags.Public | BindingFlags.Static,
-            null,
-            [typeof(ISymbol), typeof(IRootTypeSymbol)],
-            null));
-
-    private static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst)
-    {
-        MethodInfo? translationFileId = _getTranslationFileIdMethod.Value;
-        if (translationFileId is not null)
-        {
-            SymbolKind kind = isLabelConst ? EnumProvider.SymbolKind.NamedType : symbol.Kind;
-            bool useNamespaces = GetUseTranslationsWithNamespaces(symbol);
-
-            return translationFileId.Invoke(null,
-                [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string;
-        }
-
-        MethodInfo? fallback = isLabelConst
-            ? _getLabelTextConstLanguageSymbolIdMethod.Value
-            : _getLanguageSymbolIdMethod.Value;
-
-        return fallback?.Invoke(null, [symbol, rootSymbol]) as string;
-    }
-
-    private static bool GetUseTranslationsWithNamespaces(ISymbol symbol)
-    {
-        MethodInfo? method = _useTranslationsWithNamespacesMethod.Value;
-        if (method is null)
-            return false;
-
-        return method.Invoke(null, [symbol]) is true;
     }
 
     #endregion


### PR DESCRIPTION
## Problem

With AL SDK `18.0.38.52553`, 9 `LC0091` (`TranslatableTextShouldBeTranslated`) tests fail — all `HasDiagnostic*` cases. The analyzer emits no `LC0091` where it should.

### Root cause (version drift)

`LanguageFileUtilities.GetLanguageSymbolId(ISymbol, IRootTypeSymbol?)` and `GetLabelTextConstLanguageSymbolId(ISymbol, IRootTypeSymbol?)` gained an optional `bool useNamespaces = false` parameter in `18.0.38.52553` (part of the `TranslationsWithNamespaces` compiler feature). C# bakes optional-parameter defaults into the **call site** at compile time. The analyzer is built once against the lowest net10.0 SDK (`18.0.36.x`, 2-param) and, in CI, runs against `18.0.38.52553` (binary reference) — so the baked 2-param overload no longer exists at runtime → `MissingMethodException` → no `LC0091`. `NoDiagnostic` cases pass trivially. A local `ProjectReference` build compiles+runs against the same SDK and does **not** reproduce it.

## Fix

Translation IDs are now computed through **runtime reflection** so no arity is baked into the call site, and that reflection lives in a dedicated `ALCops.Common.Reflection.TranslationIdHelper` (public `ComputeTranslationId(ISymbol, IRootTypeSymbol?, bool isLabelConst)`):

- **New SDKs** (feature present): internal `GetTranslationFileId(...)` + public `UseTranslationsWithNamespaces(ISymbol)`. Produces namespace-aware trans-unit IDs (namespace-prefixed, unhashed segments joined by `" - "`, hashed only when > 400 chars) that match the compiler — avoiding **false positives** on namespace-enabled projects.
- **Older SDKs** (methods absent): fall back to the public 2-param methods.

Design split:

- **Mechanism → `ALCops.Common`:** the `Lazy<MethodInfo?>` probes, `GetTranslationFileId`/fallback branching and `useNamespaces` detection sit in `TranslationIdHelper`, alongside `SymbolHelper` / `EnumProvider` — matching the project convention that all SDK-version-compat reflection is centralized in Common, so future SDK bumps only touch one place. Guarded with `#if !NETSTANDARD2_1` (the underlying SDK methods don't exist there; LC0091 is an inert stub on netstandard2.1).
- **Policy → analyzer:** the analyzer keeps translation concerns only — which symbols to inspect, `isLabelConst` decisions, null-guarding and reporting — and calls `TranslationIdHelper.ComputeTranslationId(...)`.
- Added `EnumProvider.SymbolKind.NamedType` for the label-const path (mirrors `GetLabelTextConstLanguageSymbolId`, which forces `NamedType`).

## Tests

Added version-gated (`RequireMinimumVersion("18.0.38.52553")`) namespace regression tests that enable the feature via `CompilationOptions.WithCompilerFeatures(TranslationsWithNamespaces)` (resolved reflectively so the test project still compiles on older SDKs):

- **HasDiagnosticWithNamespaces** — empty XLIFF, feature on → namespace-mode path reports.
- **NoDiagnosticWithNamespaces** — translated XLIFF with the namespace-aware id `Namespace MyCompany.App - Table MyTable - Property Caption` → no false positive.

### Local validation

- `18.0.36.33307` (pinned): 262 passed, 2 namespace tests correctly skipped.
- `18.0.38.52553` (temporarily installed, then reverted): 264 passed — including both namespace tests (new `GetTranslationFileId` reflection path).

Cross-version coverage is handled by the CI matrix.

## Docs

Updated `.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md` (design decisions, known issues, test coverage).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
