### PR TITLE
feat: add PC0038 and LC0097 return-flow diagnostics

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -107,3 +107,5 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `pc0035-use-set-auto-calc-fields-for-loops` | rule-scoped | PC0035 rule |
 | `lc0095-parameter-not-referenced` | rule-scoped | LC0095 rule |
 | `ac0006-run-page-implement-page-management` | rule-scoped | AC0006 rule |
+| `pc0038-not-all-code-paths-return-value` | rule-scoped | PC0038 rule |
+| `lc0097-mixed-exit-and-named-return-assignment` | rule-scoped | LC0097 rule |

--- a/.github/instructions/lc0097-mixed-exit-and-named-return-assignment.instructions.md
+++ b/.github/instructions/lc0097-mixed-exit-and-named-return-assignment.instructions.md
@@ -46,9 +46,9 @@ Detects methods with a named return variable that mix both styles:
 ## Test coverage
 
 **HasDiagnostic (6 cases):** NamedAssignmentAndExitValue, NamedAssignmentAndExitWithoutValue, NamedAssignmentInIfAndExitInElse, NamedCaseAssignmentAndExit, NamedIfElseIfElseAssignmentAndExit, NamedNestedIfElseIfAssignmentAndExit.
-**NoDiagnostic (10 cases):** NamedOnlyAssignment, NamedOnlyExit, UnnamedExitAndLocalAssignment, TryFunctionExcluded, NamedCaseOnlyAssignments, NamedIfElseIfElseOnlyExit, NamedNestedIfElseIfOnlyAssignments, TriggerBooleanOnlyExit, TriggerBooleanCaseOnlyExit, TriggerBooleanNestedIfElseIfOnlyExit.
+**NoDiagnostic (11 cases):** NamedOnlyAssignment, NamedOnlyExit, UnnamedExitAndLocalAssignment, TryFunctionExcluded, NamedCaseOnlyAssignments, NamedIfElseIfElseOnlyExit, NamedNestedIfElseIfOnlyAssignments, TriggerBooleanOnlyExit, TriggerBooleanCaseOnlyExit, TriggerBooleanNestedIfElseIfOnlyExit, NamedFieldSameNameOnlyExit.
 
 ## Known issues
 
-- Assignment target detection prefers `ReturnValueReferenceExpression` but keeps symbol-name fallback for SDK representation differences.
+- Assignment target detection prefers `ReturnValueReferenceExpression` and falls back to symbol identity — the fallback requires the symbol's `Kind` to be `ReturnValue` so that field members whose names happen to match the return variable (e.g. `Buf.Result := 5;` when `Result` is also the return name) are not misidentified as return-variable assignments. See `IsNamedReturnTarget` in `ALCops.Common/Extensions/OperationExtensions.cs`.
 - Methods that only use `exit` (without return-variable assignments) are intentionally not flagged.

--- a/.github/instructions/lc0097-mixed-exit-and-named-return-assignment.instructions.md
+++ b/.github/instructions/lc0097-mixed-exit-and-named-return-assignment.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: 'src/ALCops.LinterCop/**/MixedExitAndNamedReturnAssignment*'
+---
+
+# LC0097: MixedExitAndNamedReturnAssignment
+
+## Purpose
+
+Detects methods with a named return variable that mix both styles:
+- assignment to the named return variable, and
+- usage of `exit(...)` or `exit`.
+
+## Diagnostic properties
+
+| Property | Value |
+|----------|-------|
+| ID | LC0097 |
+| Category | Usage |
+| Severity | Warning |
+| Enabled | No (disabled by default) |
+| CodeFix | No |
+| Message | `{0} '{1}' mixes exit() with assignments to the named return variable. Use one return style consistently.` |
+
+## Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Scope: method and trigger declarations with return values | Ensures all return-capable declarations are evaluated for mixed return style |
+| Check only named return methods | The rule is about mixing named return assignments with `exit(...)` |
+| Triggers are analyzed but currently contribute only NoDiagnostic scenarios | Page triggers like `OnQueryClosePage` return unnamed values and cannot satisfy the mixed-style condition |
+| Exclude TryFunction | TryFunction has platform-defined return semantics |
+| Single `exit` is sufficient when named-return assignment exists | One mixed path is enough to make the declaration inconsistent |
+| Assignment position is irrelevant (any nesting depth) | The readability problem exists regardless of control-flow depth |
+| Report location is each exit statement | Points directly at the conflicting return style |
+
+## Architecture
+
+- Registers `CodeBlockAction`.
+- Filters to `MethodOrTriggerDeclarationSyntax` with body and named return symbol (`ReturnValueSymbol.IsNamed`).
+- Excludes TryFunction methods via `MethodDeclarationSyntaxExtensions.IsTryFunction` in `ALCops.Common`.
+- Walks operation tree with `OperationWalker`:
+  - collects all `exit` statement locations,
+  - detects assignments targeting the named return variable via `OperationSafeExtensions.IsNamedReturnTarget` in `ALCops.Common`.
+- Emits LC0097 for each collected `exit` location if both conditions are true.
+
+## Test coverage
+
+**HasDiagnostic (6 cases):** NamedAssignmentAndExitValue, NamedAssignmentAndExitWithoutValue, NamedAssignmentInIfAndExitInElse, NamedCaseAssignmentAndExit, NamedIfElseIfElseAssignmentAndExit, NamedNestedIfElseIfAssignmentAndExit.
+**NoDiagnostic (10 cases):** NamedOnlyAssignment, NamedOnlyExit, UnnamedExitAndLocalAssignment, TryFunctionExcluded, NamedCaseOnlyAssignments, NamedIfElseIfElseOnlyExit, NamedNestedIfElseIfOnlyAssignments, TriggerBooleanOnlyExit, TriggerBooleanCaseOnlyExit, TriggerBooleanNestedIfElseIfOnlyExit.
+
+## Known issues
+
+- Assignment target detection prefers `ReturnValueReferenceExpression` but keeps symbol-name fallback for SDK representation differences.
+- Methods that only use `exit` (without return-variable assignments) are intentionally not flagged.

--- a/.github/instructions/pc0038-not-all-code-paths-return-value.instructions.md
+++ b/.github/instructions/pc0038-not-all-code-paths-return-value.instructions.md
@@ -30,6 +30,10 @@ The rule excludes TryFunction methods.
 | Flow analysis based on IOperation tree | Works consistently for nested blocks and AL control-flow constructs |
 | Named return variable counts as return value when definitely assigned on fallthrough paths | Matches AL named-return pattern without forcing exit() usage |
 | `exit` without explicit expression is treated as missing value unless named return was already assigned on that path | Prevents silent default-value returns on early exits |
+| Built-in `Error(...)` and `ThrowError` invocations terminate the path (return empty state set) | Guard clauses like `if Cond then exit(x) else Error('...');` are pervasive in AL; without this, PC0038 would fire on every such branch |
+| Named return is treated as assigned when passed to a `var` (by-reference) parameter or used as the receiver of an invocation (e.g. `Rec.Get(No)`) | Covers common AL idioms: out-parameter initialization and `Record.Get`/`FindFirst`/etc. into the return record. Intentionally conservative to avoid noise |
+| Case-else clauses are traversed through both `IBlockStatement` and `IStatementList` | The AL SDK wraps a case's else clause in `IStatementList` (`BoundStatementList`), so an additional case was added alongside the block handler |
+| `IsNamedReturnTarget` fallback requires symbol kind `ReturnValue` | Comparing by name only would misclassify member accesses that share the return variable's name (e.g. `Buf.Result := 5;` when the record has a field named `Result`). Fix lives in `ALCops.Common/Extensions/OperationExtensions.cs` |
 | Report location is method name | User requirement |
 
 ## Architecture
@@ -51,8 +55,8 @@ The rule excludes TryFunction methods.
 
 ## Test coverage
 
-**HasDiagnostic (7 cases):** UnnamedNoExit, UnnamedIfWithoutElse, NamedAssignedOnlyInIf, NamedLoopMayNotAssign, UnnamedCaseWithoutElse, UnnamedIfElseIfElseMissingReturn, NamedNestedIfElseIfMissingAssignment.
-**NoDiagnostic (15 cases):** UnnamedImmediateExit, UnnamedIfElseBothExit, NamedDirectAssignment, NamedAssignmentInBothBranches, NamedAssignedBeforeConditional, TryFunctionExcluded, NamedCaseAllBranchesAssigned, UnnamedIfElseIfElseAllReturn, NamedNestedIfElseIfAssigned, TriggerBooleanMissingReturn, TriggerBooleanCaseWithoutElse, TriggerBooleanNestedIfElseIfMissingReturn, TriggerBooleanAllPathsReturn, TriggerBooleanCaseAllBranchesReturn, TriggerBooleanNestedIfElseIfAllReturn.
+**HasDiagnostic (9 cases):** UnnamedNoExit, UnnamedIfWithoutElse, NamedAssignedOnlyInIf, NamedLoopMayNotAssign, UnnamedCaseWithoutElse, UnnamedIfElseIfElseMissingReturn, NamedNestedIfElseIfMissingAssignment, NamedPassedAsByValueArgument, NamedNotAssignedFieldSameName.
+**NoDiagnostic (17 cases):** UnnamedImmediateExit, UnnamedIfElseBothExit, NamedDirectAssignment, NamedAssignmentInBothBranches, NamedAssignedBeforeConditional, TryFunctionExcluded, NamedCaseAllBranchesAssigned, UnnamedIfElseIfElseAllReturn, NamedNestedIfElseIfAssigned, TriggerCases, UnnamedIfElseErrorTerminates, NamedIfElseErrorTerminates, UnnamedCaseElseErrorTerminates, UnnamedCaseElseExitTerminates, UnnamedGuardClauseErrorFirst, NamedInitializedByVarArgument, NamedInitializedByReceiverCall.
 
 ## Test notes
 

--- a/.github/instructions/pc0038-not-all-code-paths-return-value.instructions.md
+++ b/.github/instructions/pc0038-not-all-code-paths-return-value.instructions.md
@@ -1,0 +1,64 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/NotAllCodePathsReturnValue*'
+---
+
+# PC0038: NotAllCodePathsReturnValue
+
+## Purpose
+
+Detects procedure declarations with an explicit return type where at least one reachable path does not return a value.
+The rule excludes TryFunction methods.
+
+## Diagnostic properties
+
+| Property | Value |
+|----------|-------|
+| ID | PC0038 |
+| Category | Usage |
+| Severity | Warning |
+| Enabled | Yes |
+| CodeFix | No |
+| Message | `'{0}': not all code paths return a value` |
+
+## Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Scope: procedure declarations with return values | The rule intentionally excludes triggers even when they declare a return type |
+| Require explicit return syntax (`method.ReturnValue`) | Targets only methods that declare a return contract |
+| Exclude TryFunction | TryFunction has implicit platform semantics and is intentionally out of scope |
+| Flow analysis based on IOperation tree | Works consistently for nested blocks and AL control-flow constructs |
+| Named return variable counts as return value when definitely assigned on fallthrough paths | Matches AL named-return pattern without forcing exit() usage |
+| `exit` without explicit expression is treated as missing value unless named return was already assigned on that path | Prevents silent default-value returns on early exits |
+| Report location is method name | User requirement |
+
+## Architecture
+
+- Registers `SyntaxNodeAction` on `SyntaxKind.MethodDeclaration`.
+- Resolves `IMethodSymbol` and validates:
+  - explicit return syntax is present,
+  - procedure is not a TryFunction method (via `MethodDeclarationSyntaxExtensions.IsTryFunction` in `ALCops.Common`),
+  - body exists.
+- Formats the diagnostic subject through `MethodSymbolInterfaceExtensions.GetDiagnosticDisplayText(...)` in `ALCops.Common` using the object name, procedure name, and parameter type list.
+- Obtains operation tree via `SemanticModel.GetOperation(method.Body)`.
+- Runs path-state analysis with state set `{assignedNamedReturn: true|false}`.
+  - Assignment to named return target marks state as `true` (via `OperationSafeExtensions.IsNamedReturnTarget` in `ALCops.Common`).
+  - `exit(<expr>)` terminates path with value.
+  - `exit` without expression terminates path and marks missing-value path if required.
+  - Branches (`if`, `case`) union successor states.
+  - Loops conservatively include non-executed path for optional loops.
+- Reports diagnostic when at least one reachable path can end without value.
+
+## Test coverage
+
+**HasDiagnostic (7 cases):** UnnamedNoExit, UnnamedIfWithoutElse, NamedAssignedOnlyInIf, NamedLoopMayNotAssign, UnnamedCaseWithoutElse, UnnamedIfElseIfElseMissingReturn, NamedNestedIfElseIfMissingAssignment.
+**NoDiagnostic (15 cases):** UnnamedImmediateExit, UnnamedIfElseBothExit, NamedDirectAssignment, NamedAssignmentInBothBranches, NamedAssignedBeforeConditional, TryFunctionExcluded, NamedCaseAllBranchesAssigned, UnnamedIfElseIfElseAllReturn, NamedNestedIfElseIfAssigned, TriggerBooleanMissingReturn, TriggerBooleanCaseWithoutElse, TriggerBooleanNestedIfElseIfMissingReturn, TriggerBooleanAllPathsReturn, TriggerBooleanCaseAllBranchesReturn, TriggerBooleanNestedIfElseIfAllReturn.
+
+## Test notes
+
+- The test suite contains a hard-coded `AnalyzeTriggers = false` toggle so the existing trigger fixtures remain reusable while triggers stay intentionally excluded from the analyzer.
+
+## Known issues
+
+- `LoopKind.Repeat` handling depends on SDK loop metadata availability across versions; behavior is conservative for optional-loop execution.
+- `case` line body extraction uses reflective fallback to remain compatible across SDK versions.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Setup BC DevTools Dependencies",
+            "label": "ALCops: Setup BC DevTools Dependencies",
             "type": "shell",
             "command": "pwsh",
             "args": [
@@ -17,7 +17,7 @@
             "problemMatcher": []
         },
         {
-            "label": "Copy Bin to AL Analyzers",
+            "label": "ALCops: Copy Bin to AL Analyzers",
             "type": "shell",
             "command": "pwsh",
             "args": [

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
@@ -23,7 +23,7 @@
             <StronglyTypedClassName>ApplicationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
@@ -22,6 +22,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>ApplicationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.ApplicationCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.ApplicationCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.Common/Extensions/MethodDeclarationSyntaxExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodDeclarationSyntaxExtensions.cs
@@ -7,13 +7,23 @@ public static class MethodDeclarationSyntaxExtensions
 {
     private const string TryFunctionAttributeName = "TryFunction";
 
+    /// <summary>
+    /// Syntax-based TryFunction detection.
+    /// The SDK exposes <c>IMethodSymbol.IsTryFunction</c> on <c>net8.0</c> and <c>net10.0</c>,
+    /// but that property is <em>not</em> present on the <c>netstandard2.1</c> reference DLL
+    /// pinned in this repository, so analyzers targeting all three CI TFMs must use this
+    /// syntax-based check to remain portable.
+    /// </summary>
     public static bool IsTryFunction(this MethodDeclarationSyntax method)
     {
         foreach (var attribute in method.Attributes)
         {
             var attributeName = attribute.GetIdentifierOrLiteralValue();
+
             if (attributeName is not null && SemanticFacts.IsSameName(attributeName, TryFunctionAttributeName))
+			{
                 return true;
+			}
         }
 
         return false;

--- a/src/ALCops.Common/Extensions/MethodDeclarationSyntaxExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodDeclarationSyntaxExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.Common.Extensions;
+
+public static class MethodDeclarationSyntaxExtensions
+{
+    private const string TryFunctionAttributeName = "TryFunction";
+
+    public static bool IsTryFunction(this MethodDeclarationSyntax method)
+    {
+        foreach (var attribute in method.Attributes)
+        {
+            var attributeName = attribute.GetIdentifierOrLiteralValue();
+            if (attributeName is not null && SemanticFacts.IsSameName(attributeName, TryFunctionAttributeName))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
+++ b/src/ALCops.Common/Extensions/MethodSymbolInterfaceExtensions.cs
@@ -3,8 +3,31 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 
 namespace ALCops.Common.Extensions;
 
+public enum MethodSymbolDisplayFormat
+{
+    MethodOnly,
+    MethodSignature,
+    ObjectNameWithMethod,
+    ObjectNameWithMethodSignature
+}
+
 public static class MethodSymbolInterfaceExtensions
 {
+    public static string GetDiagnosticDisplayText(this IMethodSymbol methodSymbol, MethodSymbolDisplayFormat format)
+    {
+        var methodName = methodSymbol.Name.QuoteIdentifierIfNeededWithReflection();
+
+        return format switch
+        {
+            MethodSymbolDisplayFormat.MethodOnly => $"{methodName}()",
+            MethodSymbolDisplayFormat.MethodSignature => $"{methodName}({GetParameterTypeList(methodSymbol)})",
+            MethodSymbolDisplayFormat.ObjectNameWithMethod => $"{GetObjectPrefix(methodSymbol)}{methodName}()",
+            MethodSymbolDisplayFormat.ObjectNameWithMethodSignature =>
+                $"{GetObjectPrefix(methodSymbol)}{methodName}({GetParameterTypeList(methodSymbol)})",
+            _ => $"{GetObjectPrefix(methodSymbol)}{methodName}({GetParameterTypeList(methodSymbol)})"
+        };
+    }
+
     public static bool MethodImplementsInterfaceMethod(this IMethodSymbol methodSymbol)
     {
         if (methodSymbol is null)
@@ -22,15 +45,15 @@ public static class MethodSymbolInterfaceExtensions
     public static bool IsHandler(this IMethodSymbol method)
         => method.GetPropertyIfExists<bool>("IsHandler");
 
-	/// <summary>
-	/// Checks whether the method is an IntegrationEvent or BusinessEvent.
-	/// </summary>
+    /// <summary>
+    /// Checks whether the method is an IntegrationEvent or BusinessEvent.
+    /// </summary>
     public static bool IsIntegrationOrBusinessEvent(this IMethodSymbol methodSymbol) =>
         methodSymbol.Attributes.Any(attr => (attr.AttributeKind == EnumProvider.AttributeKind.IntegrationEvent) || (attr.AttributeKind == EnumProvider.AttributeKind.BusinessEvent));
 
-	/// <summary>
-	/// Checks whether the method is an InternalEvent.
-	/// </summary>
+    /// <summary>
+    /// Checks whether the method is an InternalEvent.
+    /// </summary>
     public static bool IsInternalEvent(this IMethodSymbol methodSymbol) =>
         methodSymbol.Attributes.Any(attr => attr.AttributeKind == EnumProvider.AttributeKind.InternalEvent);
 
@@ -65,4 +88,27 @@ public static class MethodSymbolInterfaceExtensions
 
         return true;
     }
+
+    private static string GetObjectPrefix(IMethodSymbol methodSymbol)
+    {
+        var containingObject = methodSymbol.GetContainingApplicationObjectTypeSymbol();
+
+        if (containingObject is null)
+        {
+            return string.Empty;
+        }
+
+        return $"{containingObject.Name.QuoteIdentifierIfNeededWithReflection()}.";
+    }
+
+    private static string GetParameterTypeList(IMethodSymbol methodSymbol) =>
+        string.Join(", ",
+            methodSymbol.Parameters.Select(parameter => GetParameterTypeDisplay(parameter.ParameterType)));
+
+    private static string GetParameterTypeDisplay(ITypeSymbol typeSymbol)
+#if NETSTANDARD2_1
+        => typeSymbol.ToDisplayStringWithReflection();
+#else
+        => typeSymbol.ToDisplayString();
+#endif
 }

--- a/src/ALCops.Common/Extensions/OperationExtensions.cs
+++ b/src/ALCops.Common/Extensions/OperationExtensions.cs
@@ -51,7 +51,14 @@ public static class OperationSafeExtensions
         if (target.Kind == EnumProvider.OperationKind.ReturnValueReferenceExpression)
             return true;
 
+        // Fall back to symbol identity, but only accept symbols whose kind is `ReturnValue`.
+        // Comparing by name alone would incorrectly match unrelated members that happen to
+        // share the return variable's name (e.g. `Buf.Result := 5;` where `Buf` is a record
+        // with a field named `Result`).
         var symbol = target.GetSymbolSafe();
-        return symbol is not null && symbol.Name.IsSameName(returnVariableName);
+
+        return symbol is not null
+            && symbol.Kind == EnumProvider.SymbolKind.ReturnValue
+            && symbol.Name.IsSameName(returnVariableName);
     }
 }

--- a/src/ALCops.Common/Extensions/OperationExtensions.cs
+++ b/src/ALCops.Common/Extensions/OperationExtensions.cs
@@ -42,4 +42,16 @@ public static class OperationSafeExtensions
 
         return operation.GetSymbol();
     }
+
+    public static bool IsNamedReturnTarget(this IOperation? target, string returnVariableName)
+    {
+        if (target is null)
+            return false;
+
+        if (target.Kind == EnumProvider.OperationKind.ReturnValueReferenceExpression)
+            return true;
+
+        var symbol = target.GetSymbolSafe();
+        return symbol is not null && symbol.Name.IsSameName(returnVariableName);
+    }
 }

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -853,6 +853,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.RequestPage)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _requestPageExtension =
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.RequestPageExtension)));
+        private static readonly Lazy<NavCodeAnalysis.SymbolKind> _returnValue =
+            new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.ReturnValue)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _table =
             new(() => ParseEnum<NavCodeAnalysis.SymbolKind>(nameof(NavCodeAnalysis.SymbolKind.Table)));
         private static readonly Lazy<NavCodeAnalysis.SymbolKind> _tableExtension =
@@ -901,6 +903,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.SymbolKind ReportLabel => _reportLabel.Value;
         public static NavCodeAnalysis.SymbolKind RequestPage => _requestPage.Value;
         public static NavCodeAnalysis.SymbolKind RequestPageExtension => _requestPageExtension.Value;
+        public static NavCodeAnalysis.SymbolKind ReturnValue => _returnValue.Value;
         public static NavCodeAnalysis.SymbolKind Table => _table.Value;
         public static NavCodeAnalysis.SymbolKind TableExtension => _tableExtension.Value;
         public static NavCodeAnalysis.SymbolKind Undefined => _undefined.Value;

--- a/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
+++ b/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
@@ -23,7 +23,7 @@
             <StronglyTypedClassName>DocumentationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>

--- a/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
+++ b/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
@@ -22,6 +22,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>DocumentationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.DocumentationCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.DocumentationCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
@@ -40,12 +40,14 @@ public sealed class ProcedureRequiresDocumentation : DiagnosticAnalyzer
 
 		if (ctx.ContainingSymbol is IMethodSymbol methodSymbol && (methodSymbol is not null))
 		{
+			var methodDisplayText = methodSymbol.GetDiagnosticDisplayText(MethodSymbolDisplayFormat.MethodSignature);
+
 			if (methodSymbol.IsIntegrationOrBusinessEvent())
 			{
 				ctx.ReportDiagnostic(Diagnostic.Create(
 					DiagnosticDescriptors.EventRequiresDocumentation,
 					method.Name.GetLocation(),
-					method.Name.Identifier.ToString()));
+					methodDisplayText));
 			}
 
 			else if (methodSymbol.IsInternalEvent())
@@ -53,7 +55,7 @@ public sealed class ProcedureRequiresDocumentation : DiagnosticAnalyzer
 				ctx.ReportDiagnostic(Diagnostic.Create(
 					DiagnosticDescriptors.InternalEventRequiresDocumentation,
 					method.Name.GetLocation(),
-					method.Name.Identifier.ToString()));
+					methodDisplayText));
 			}
 
 			else
@@ -69,14 +71,14 @@ public sealed class ProcedureRequiresDocumentation : DiagnosticAnalyzer
 					ctx.ReportDiagnostic(Diagnostic.Create(
 						DiagnosticDescriptors.InternalProcedureRequiresDocumentation,
 						method.Name.GetLocation(),
-						method.Name.Identifier.ToString()));
+						methodDisplayText));
 				}
 				else
 				{
 					ctx.ReportDiagnostic(Diagnostic.Create(
 						DiagnosticDescriptors.PublicProcedureRequiresDocumentation,
 						method.Name.GetLocation(),
-						method.Name.Identifier.ToString()));
+						methodDisplayText));
 				}
 			}
 		}

--- a/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
@@ -22,6 +22,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>FormattingCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.FormattingCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
@@ -23,7 +23,7 @@
             <StronglyTypedClassName>FormattingCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.FormattingCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/HasDiagnostic/NamedBranchAssignmentAndExitCases.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/HasDiagnostic/NamedBranchAssignmentAndExitCases.al
@@ -1,0 +1,47 @@
+codeunit 50100 NmdBranchAssignExit
+{
+    procedure NamedAssignmentInIfAndExitInElse(UseExit: Boolean) Result: Integer
+    begin
+        if UseExit then
+            [|exit(2)|]
+        else
+            Result := 1;
+    end;
+
+    procedure NamedCaseAssignmentAndExit(Input: Integer) Result: Integer
+    begin
+        case Input of
+            1:
+                Result := 10;
+
+            2:
+                [|exit(20);|]
+
+            else
+                Result := 30;
+        end;
+    end;
+
+    procedure NamedIfElseIfElseAssignmentAndExit(Input: Integer) Result: Integer
+    begin
+        if Input = 1 then
+            Result := 10
+        else if Input = 2 then
+            [|exit(20)|]
+        else
+            Result := 30;
+    end;
+
+    procedure NamedNestedIfElseIfAssignmentAndExit(Outer: Boolean; Inner: Integer) Result: Integer
+    begin
+        if Outer then begin
+            if Inner = 1 then
+                Result := 10
+            else if Inner = 2 then
+                [|exit(20)|]
+            else
+                Result := 40;
+        end else
+            Result := 30;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/HasDiagnostic/NamedSimpleAssignmentAndExitCases.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/HasDiagnostic/NamedSimpleAssignmentAndExitCases.al
@@ -1,0 +1,16 @@
+codeunit 50101 NmdSimpleAssignExit
+{
+    procedure NamedAssignmentAndExitValue() Result: Integer
+    begin
+        Result := 1;
+
+        [|exit(2);|]
+    end;
+
+    procedure NamedAssignmentAndExitWithoutValue() Result: Integer
+    begin
+        Result := 1;
+
+        [|exit;|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.cs
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.cs
@@ -42,6 +42,7 @@ public class MixedExitAndNamedReturnAssignment : NavCodeAnalysisBase
     [TestCase("NamedIfElseIfElseOnlyExit")]
     [TestCase("NamedNestedIfElseIfOnlyAssignments")]
     [TestCase("TriggerOnlyExitCases")]
+    [TestCase("NamedFieldSameNameOnlyExit")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.cs
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.cs
@@ -1,0 +1,52 @@
+using RoslynTestKit;
+
+namespace ALCops.LinterCop.Test;
+
+public class MixedExitAndNamedReturnAssignment : NavCodeAnalysisBase
+{
+    private AnalyzerTestFixture _fixture;
+    private string _testCasePath;
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCasePath = Path.Combine(
+            Directory.GetParent(
+                Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            Path.Combine("Rules", nameof(MixedExitAndNamedReturnAssignment)));
+
+        _fixture = RoslynFixtureFactory.Create<Analyzers.MixedExitAndNamedReturnAssignment>(
+            new AnalyzerTestFixtureConfig
+            {
+                RuleSetPath = Path.Combine(_testCasePath, $"{nameof(MixedExitAndNamedReturnAssignment)}.ruleset.json")
+            });
+    }
+
+    [Test]
+    [TestCase("NamedSimpleAssignmentAndExitCases")]
+    [TestCase("NamedBranchAssignmentAndExitCases")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.MixedExitAndNamedReturnAssignment);
+    }
+
+    [Test]
+    [TestCase("NamedOnlyAssignment")]
+    [TestCase("NamedOnlyExit")]
+    [TestCase("UnnamedExitAndLocalAssignment")]
+    [TestCase("TryFunctionExcluded")]
+    [TestCase("NamedCaseOnlyAssignments")]
+    [TestCase("NamedIfElseIfElseOnlyExit")]
+    [TestCase("NamedNestedIfElseIfOnlyAssignments")]
+    [TestCase("TriggerOnlyExitCases")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.MixedExitAndNamedReturnAssignment);
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.ruleset.json
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/MixedExitAndNamedReturnAssignment.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable LC0097",
+    "description": "Enables the default-disabled LC0097 rule so it can be tested.",
+    "rules": [
+        {
+            "id": "LC0097",
+            "action": "Warning"
+        }
+    ]
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedCaseOnlyAssignments.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedCaseOnlyAssignments.al
@@ -1,0 +1,14 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute(Input: Integer) Result: Integer
+    begin
+        [|case Input of
+            1:
+                Result := 10;
+            2:
+                Result := 20;
+            else
+                Result := 30;
+        end;|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedFieldSameNameOnlyExit.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedFieldSameNameOnlyExit.al
@@ -1,0 +1,22 @@
+table 50100 ProbeBuffer
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Result; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}
+
+codeunit 50101 MyCodeunit
+{
+    procedure [|Compute|](var Buf: Record ProbeBuffer) Result: Integer
+    begin
+        Buf.Result := 5;
+        exit(1);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedIfElseIfElseOnlyExit.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedIfElseIfElseOnlyExit.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute(Input: Integer): Integer
+    begin
+        [|if Input = 1 then
+            exit(10)
+        else if Input = 2 then
+            exit(20)
+        else
+            exit(30);|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedNestedIfElseIfOnlyAssignments.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedNestedIfElseIfOnlyAssignments.al
@@ -1,0 +1,15 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute(Outer: Boolean; Inner: Integer) Result: Integer
+    begin
+        [|if Outer then begin
+        if Inner = 1 then
+            Result := 10
+        else if Inner = 2 then
+            Result := 20
+        else
+            Result := 40;
+    end else
+            Result := 30;|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedOnlyAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedOnlyAssignment.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute() Result: Integer
+    begin
+        [|Result := 1;|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedOnlyExit.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/NamedOnlyExit.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute(): Integer
+    begin
+        [|exit(1);|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/TriggerOnlyExitCases.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/TriggerOnlyExitCases.al
@@ -1,0 +1,65 @@
+page 50110 TrigBoolOnlyExitPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            exit(true)
+        else
+            exit(false);
+    end;
+}
+
+page 50111 TrigBoolCaseExitPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        case CloseAction of
+            Action::LookupOK:
+                exit(true);
+
+            Action::OK:
+                exit(false);
+
+            else
+                exit(false);
+        end;
+    end;
+}
+
+page 50112 TrigBoolNestExitPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            if true then
+                exit(true)
+            else if false then
+                exit(false)
+            else
+                exit(true)
+        else
+            exit(false);
+    end;
+}
+
+table 50150 MyBuffer
+{
+    fields
+    {
+        field(1; "No."; Integer)
+        {
+        }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/TryFunctionExcluded.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/TryFunctionExcluded.al
@@ -1,0 +1,8 @@
+codeunit 50100 MyCodeunit
+{
+    [TryFunction]
+    procedure MyTryFunction()
+    begin
+        [|exit;|]
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/UnnamedExitAndLocalAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/MixedExitAndNamedReturnAssignment/NoDiagnostic/UnnamedExitAndLocalAssignment.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure Compute(): Integer
+    var
+        LocalResult: Integer;
+    begin
+        [|LocalResult := 1;|]
+        [|exit(LocalResult);|]
+    end;
+}

--- a/src/ALCops.LinterCop/ALCops.LinterCop.csproj
+++ b/src/ALCops.LinterCop/ALCops.LinterCop.csproj
@@ -26,7 +26,7 @@
             <StronglyTypedClassName>LinterCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>

--- a/src/ALCops.LinterCop/ALCops.LinterCop.csproj
+++ b/src/ALCops.LinterCop/ALCops.LinterCop.csproj
@@ -25,6 +25,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>LinterCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.LinterCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.LinterCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -411,6 +411,15 @@
   <data name="ParameterNotReferencedCodeAction" xml:space="preserve">
     <value>ALCops: Remove unreferenced parameter</value>
   </data>
+  <data name="MixedExitAndNamedReturnAssignmentTitle" xml:space="preserve">
+    <value>Avoid mixing exit() and named return variable assignments</value>
+  </data>
+  <data name="MixedExitAndNamedReturnAssignmentMessageFormat" xml:space="preserve">
+    <value>{0} '{1}' mixes exit() with assignments to the named return variable. Use one return style consistently.</value>
+  </data>
+  <data name="MixedExitAndNamedReturnAssignmentDescription" xml:space="preserve">
+    <value>In procedures and triggers with a named return variable, mixing exit() statements with return-variable assignments makes control flow harder to reason about and increases the risk of accidental default returns. Prefer one return style per procedure or trigger.</value>
+  </data>
   <data name="AnalyzerExceptionTitle" xml:space="preserve">
     <value>Analyzer threw an unhandled exception</value>
   </data>

--- a/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
+++ b/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
@@ -81,7 +81,7 @@ public sealed class MixedExitAndNamedReturnAssignment : DiagnosticAnalyzer
 
         public bool HasNamedReturnAssignment { get; private set; }
 
-        public ImmutableArray<Location> ExitLocations => [.. _exitLocations];
+        public ImmutableArray<Location> ExitLocations => _exitLocations.ToImmutableArray();
 
         public override void VisitExitStatement(IExitStatement operation)
         {

--- a/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
+++ b/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
@@ -67,7 +67,7 @@ public sealed class MixedExitAndNamedReturnAssignment : DiagnosticAnalyzer
                 DiagnosticDescriptors.MixedExitAndNamedReturnAssignment,
                 location,
                 GetDeclarationKind(declarationSyntax),
-                methodSymbol.Name));
+                methodSymbol.GetDiagnosticDisplayText(MethodSymbolDisplayFormat.MethodSignature)));
         }
     }
 

--- a/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
+++ b/src/ALCops.LinterCop/Analyzers/MixedExitAndNamedReturnAssignment.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+
+namespace ALCops.LinterCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class MixedExitAndNamedReturnAssignment : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MixedExitAndNamedReturnAssignment);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterCodeBlockAction(AnalyzeCodeBlock);
+
+    private static void AnalyzeCodeBlock(CodeBlockAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() ||
+            ctx.CodeBlock is not MethodOrTriggerDeclarationSyntax declarationSyntax ||
+            declarationSyntax.Body is null)
+        {
+            return;
+        }
+
+        if (declarationSyntax.ReturnValue is null)
+        {
+            return;
+        }
+
+        if (declarationSyntax is MethodDeclarationSyntax methodSyntax && methodSyntax.IsTryFunction())
+        {
+            return;
+        }
+
+        if (ctx.OwningSymbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (methodSymbol.ReturnValueSymbol is not { IsNamed: true } returnValue)
+        {
+            return;
+        }
+
+        var operation = ctx.SemanticModel.GetOperation(declarationSyntax.Body, ctx.CancellationToken);
+
+        if (operation is null)
+        {
+            return;
+        }
+
+        var walker = new ReturnUsageWalker(returnValue.Name);
+        walker.Visit(operation);
+
+        if (!walker.HasNamedReturnAssignment || walker.ExitLocations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var location in walker.ExitLocations)
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.MixedExitAndNamedReturnAssignment,
+                location,
+                GetDeclarationKind(declarationSyntax),
+                methodSymbol.Name));
+        }
+    }
+
+    private static string GetDeclarationKind(MethodOrTriggerDeclarationSyntax declarationSyntax) =>
+        declarationSyntax is TriggerDeclarationSyntax ? "Trigger" : "Procedure";
+
+    private sealed class ReturnUsageWalker(string returnVariableName) : OperationWalker
+    {
+        private readonly string _returnVariableName = returnVariableName;
+        private readonly List<Location> _exitLocations = [];
+
+        public bool HasNamedReturnAssignment { get; private set; }
+
+        public ImmutableArray<Location> ExitLocations => [.. _exitLocations];
+
+        public override void VisitExitStatement(IExitStatement operation)
+        {
+            _exitLocations.Add(operation.Syntax.GetLocation());
+            base.VisitExitStatement(operation);
+        }
+
+        public override void VisitAssignmentStatement(IAssignmentStatement operation)
+        {
+            if (operation.Target.IsNamedReturnTarget(_returnVariableName))
+            {
+                HasNamedReturnAssignment = true;
+            }
+
+            base.VisitAssignmentStatement(operation);
+        }
+    }
+}

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -304,6 +304,16 @@ public static class DiagnosticDescriptors
         description: LinterCopAnalyzers.ParameterNotReferencedDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.ParameterNotReferenced));
 
+    public static readonly DiagnosticDescriptor MixedExitAndNamedReturnAssignment = new(
+        id: DiagnosticIds.MixedExitAndNamedReturnAssignment,
+        title: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentTitle,
+        messageFormat: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentMessageFormat,
+        category: Category.Usage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.MixedExitAndNamedReturnAssignment));
+
     public static readonly DiagnosticDescriptor UseSecretTextForSensitiveText = new(
         id: DiagnosticIds.UseSecretTextForSensitiveText,
         title: LinterCopAnalyzers.UseSecretTextForSensitiveTextTitle,

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -309,7 +309,7 @@ public static class DiagnosticDescriptors
         title: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentTitle,
         messageFormat: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentMessageFormat,
         category: Category.Usage,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: false,
         description: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.MixedExitAndNamedReturnAssignment));

--- a/src/ALCops.LinterCop/DiagnosticIds.cs
+++ b/src/ALCops.LinterCop/DiagnosticIds.cs
@@ -33,4 +33,5 @@ public static class DiagnosticIds
     public static readonly string AllowInCustomizationsRedundancy = "LC0094";
     public static readonly string ParameterNotReferenced = "LC0095";
     public static readonly string UnnecessaryRecordParameterInMethodCall = "LC0096";
+    public static readonly string MixedExitAndNamedReturnAssignment = "LC0097";
 }

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedAssignedOnlyInIf.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedAssignedOnlyInIf.al
@@ -1,0 +1,8 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](SetResult: Boolean) Result: Integer
+    begin
+        if SetResult then
+            Result := 1;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedLoopMayNotAssign.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedLoopMayNotAssign.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Count: Integer) Result: Integer
+    begin
+        while Count > 10 do begin
+            Result := Count;
+            Count := Count - 1;
+        end;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedNestedIfElseIfMissingAssignment.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedNestedIfElseIfMissingAssignment.al
@@ -1,0 +1,15 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Outer: Boolean; Inner: Integer) Result: Integer
+    begin
+        if Outer then begin
+            if Inner = 1 then
+                Result := 10
+            else if Inner = 2 then
+                Result := 20
+            else
+                ;
+        end else
+            Result := 30;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedNotAssignedFieldSameName.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedNotAssignedFieldSameName.al
@@ -1,0 +1,21 @@
+table 50100 ProbeBuffer
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Result; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}
+
+codeunit 50101 MyCodeunit
+{
+    procedure [|Compute|](var Buf: Record ProbeBuffer) Result: Integer
+    begin
+        Buf.Result := 5;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedPassedAsByValueArgument.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/NamedPassedAsByValueArgument.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|]() Result: Integer
+    begin
+        ReadOnly(Result);
+    end;
+
+    local procedure ReadOnly(Value: Integer)
+    begin
+        Message('%1', Value);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedCaseWithoutElse.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedCaseWithoutElse.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        case Input of
+            1:
+                exit(10);
+            2:
+                exit(20);
+        end;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedIfElseIfElseMissingReturn.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedIfElseIfElseMissingReturn.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        if Input = 1 then
+            exit(10)
+        else if Input = 2 then
+            exit(20)
+        else
+            ;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedIfWithoutElse.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedIfWithoutElse.al
@@ -1,0 +1,8 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|GetValue|](IsPositive: Boolean): Integer
+    begin
+        if IsPositive then
+            exit(1);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedNoExit.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/HasDiagnostic/UnnamedNoExit.al
@@ -1,0 +1,6 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|GetValue|](): Integer
+    begin
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedAssignedBeforeConditional.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedAssignedBeforeConditional.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](UseFallback: Boolean) Result: Integer
+    begin
+        Result := 10;
+
+        if UseFallback then
+            Result := 20;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedAssignmentInBothBranches.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedAssignmentInBothBranches.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](UseFirst: Boolean) Result: Integer
+    begin
+        if UseFirst then
+            Result := 1
+        else
+            Result := 2;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedCaseAllBranchesAssigned.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedCaseAllBranchesAssigned.al
@@ -1,0 +1,16 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer) Result: Integer
+    begin
+        Result := 0;
+
+        case Input of
+            1:
+                Result := 10;
+            2:
+                Result := 20;
+            else
+                Result := 30;
+        end;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedDirectAssignment.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedDirectAssignment.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|]() Result: Integer
+    begin
+        Result := 100;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedIfElseErrorTerminates.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedIfElseErrorTerminates.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer) Result: Integer
+    begin
+        if Input = 1 then
+            Result := 10
+        else
+            Error('unsupported');
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedInitializedByReceiverCall.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedInitializedByReceiverCall.al
@@ -1,0 +1,20 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 50101 MyCodeunit
+{
+    procedure [|GetRecord|](No: Code[20]) MyRec: Record MyTable
+    begin
+        MyRec.Get(No);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedInitializedByVarArgument.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedInitializedByVarArgument.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|]() Result: Integer
+    begin
+        ComputeInto(Result);
+    end;
+
+    local procedure ComputeInto(var Value: Integer)
+    begin
+        Value := 42;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedNestedIfElseIfAssigned.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/NamedNestedIfElseIfAssigned.al
@@ -1,0 +1,15 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Outer: Boolean; Inner: Integer) Result: Integer
+    begin
+        if Outer then begin
+            if Inner = 1 then
+                Result := 10
+            else if Inner = 2 then
+                Result := 20
+            else
+                Result := 40;
+        end else
+            Result := 30;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/TriggerCases.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/TriggerCases.al
@@ -1,0 +1,112 @@
+page 50110 TrigBoolMissRetPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            exit(true);
+    end;
+}
+
+page 50111 TrigBoolCaseNoElsePg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        case CloseAction of
+            Action::LookupOK:
+                exit(true);
+
+            Action::OK:
+                exit(false);
+        end;
+    end;
+}
+
+page 50112 TrigBoolNestMissingPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            if true then
+                exit(true)
+            else if false then
+                exit(false);
+    end;
+}
+
+page 50113 TrigBoolAllPathsPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            exit(true)
+        else
+            exit(false);
+    end;
+}
+
+page 50114 TrigBoolCaseAllPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        case CloseAction of
+            Action::LookupOK:
+                exit(true);
+
+            Action::OK:
+                exit(false);
+
+            else
+                exit(false);
+        end;
+    end;
+}
+
+page 50115 TrigBoolNestAllPg
+{
+    PageType = Card;
+    SourceTable = MyBuffer;
+    ApplicationArea = All;
+
+    trigger [|OnQueryClosePage|](CloseAction: Action): Boolean
+    begin
+        if CloseAction = Action::LookupOK then
+            if true then
+                exit(true)
+            else if false then
+                exit(false)
+            else
+                exit(false)
+        else
+            exit(false);
+    end;
+}
+
+table 50150 MyBuffer
+{
+    fields
+    {
+        field(1; "No."; Integer)
+        {
+        }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/TryFunctionExcluded.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/TryFunctionExcluded.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    [TryFunction]
+    procedure [|MyTryFunction|]()
+    begin
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedCaseElseErrorTerminates.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedCaseElseErrorTerminates.al
@@ -1,0 +1,14 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        case Input of
+            1:
+                exit(10);
+            2:
+                exit(20);
+            else
+                Error('unsupported');
+        end;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedCaseElseExitTerminates.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedCaseElseExitTerminates.al
@@ -1,0 +1,14 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        case Input of
+            1:
+                exit(10);
+            2:
+                exit(20);
+            else
+                exit(30);
+        end;
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedGuardClauseErrorFirst.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedGuardClauseErrorFirst.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        if Input < 0 then
+            Error('negative not supported');
+
+        exit(Input * 2);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseBothExit.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseBothExit.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|GetValue|](IsPositive: Boolean): Integer
+    begin
+        if IsPositive then
+            exit(1)
+        else
+            exit(-1);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseErrorTerminates.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseErrorTerminates.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        if Input = 1 then
+            exit(10)
+        else
+            Error('unsupported');
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseIfElseAllReturn.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedIfElseIfElseAllReturn.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|Compute|](Input: Integer): Integer
+    begin
+        if Input = 1 then
+            exit(10)
+        else if Input = 2 then
+            exit(20)
+        else
+            exit(30);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedImmediateExit.al
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NoDiagnostic/UnnamedImmediateExit.al
@@ -1,0 +1,7 @@
+codeunit 50100 MyCodeunit
+{
+    procedure [|GetValue|](): Integer
+    begin
+        exit(42);
+    end;
+}

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NotAllCodePathsReturnValue.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NotAllCodePathsReturnValue.cs
@@ -26,6 +26,8 @@ public class NotAllCodePathsReturnValue : NavCodeAnalysisBase
     [TestCase("UnnamedCaseWithoutElse")]
     [TestCase("UnnamedIfElseIfElseMissingReturn")]
     [TestCase("NamedNestedIfElseIfMissingAssignment")]
+    [TestCase("NamedPassedAsByValueArgument")]
+    [TestCase("NamedNotAssignedFieldSameName")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -45,6 +47,13 @@ public class NotAllCodePathsReturnValue : NavCodeAnalysisBase
     [TestCase("UnnamedIfElseIfElseAllReturn")]
     [TestCase("NamedNestedIfElseIfAssigned")]
     [TestCase("TriggerCases")]
+    [TestCase("UnnamedIfElseErrorTerminates")]
+    [TestCase("NamedIfElseErrorTerminates")]
+    [TestCase("UnnamedCaseElseErrorTerminates")]
+    [TestCase("UnnamedCaseElseExitTerminates")]
+    [TestCase("UnnamedGuardClauseErrorFirst")]
+    [TestCase("NamedInitializedByVarArgument")]
+    [TestCase("NamedInitializedByReceiverCall")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NotAllCodePathsReturnValue.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/NotAllCodePathsReturnValue/NotAllCodePathsReturnValue.cs
@@ -1,0 +1,55 @@
+using RoslynTestKit;
+
+namespace ALCops.PlatformCop.Test;
+
+public class NotAllCodePathsReturnValue : NavCodeAnalysisBase
+{
+    private AnalyzerTestFixture _fixture;
+    private string _testCasePath;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fixture = RoslynFixtureFactory.Create<Analyzers.NotAllCodePathsReturnValue>();
+
+        _testCasePath = Path.Combine(
+            Directory.GetParent(
+                Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            Path.Combine("Rules", nameof(NotAllCodePathsReturnValue)));
+    }
+
+    [Test]
+    [TestCase("UnnamedNoExit")]
+    [TestCase("UnnamedIfWithoutElse")]
+    [TestCase("NamedAssignedOnlyInIf")]
+    [TestCase("NamedLoopMayNotAssign")]
+    [TestCase("UnnamedCaseWithoutElse")]
+    [TestCase("UnnamedIfElseIfElseMissingReturn")]
+    [TestCase("NamedNestedIfElseIfMissingAssignment")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.NotAllCodePathsReturnValue);
+    }
+
+    [Test]
+    [TestCase("UnnamedImmediateExit")]
+    [TestCase("UnnamedIfElseBothExit")]
+    [TestCase("NamedDirectAssignment")]
+    [TestCase("NamedAssignmentInBothBranches")]
+    [TestCase("NamedAssignedBeforeConditional")]
+    [TestCase("TryFunctionExcluded")]
+    [TestCase("NamedCaseAllBranchesAssigned")]
+    [TestCase("UnnamedIfElseIfElseAllReturn")]
+    [TestCase("NamedNestedIfElseIfAssigned")]
+    [TestCase("TriggerCases")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.NotAllCodePathsReturnValue);
+    }
+}

--- a/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
@@ -22,6 +22,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>PlatformCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.PlatformCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
@@ -23,7 +23,7 @@
             <StronglyTypedClassName>PlatformCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.PlatformCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -495,6 +495,15 @@
   <data name="UseValidateForFieldAssignmentCodeAction" xml:space="preserve">
     <value>ALCops: Use Validate() for field assignment</value>
   </data>
+  <data name="NotAllCodePathsReturnValueTitle" xml:space="preserve">
+    <value>Not all code paths return a value</value>
+  </data>
+  <data name="NotAllCodePathsReturnValueMessageFormat" xml:space="preserve">
+    <value>'{0}': not all code paths return a value</value>
+  </data>
+  <data name="NotAllCodePathsReturnValueDescription" xml:space="preserve">
+    <value>Procedures and triggers with an explicit return type should return a value on every reachable path. Falling through the end of a procedure or trigger without an explicit return value can hide logic bugs and produce unintended default values.</value>
+  </data>
   <data name="AnalyzerExceptionTitle" xml:space="preserve">
     <value>Analyzer threw an unhandled exception</value>
   </data>

--- a/src/ALCops.PlatformCop/Analyzers/NotAllCodePathsReturnValue.cs
+++ b/src/ALCops.PlatformCop/Analyzers/NotAllCodePathsReturnValue.cs
@@ -105,6 +105,9 @@ public sealed class NotAllCodePathsReturnValue : DiagnosticAnalyzer
             case IBlockStatement block:
                 return AnalyzeStatements(block.Statements, states, hasNamedReturn, returnVariableName, out hasPathWithoutValue);
 
+            case IStatementList statementList:
+                return AnalyzeStatements(statementList.Statements, states, hasNamedReturn, returnVariableName, out hasPathWithoutValue);
+
             case IAssignmentStatement assignment:
                 if (hasNamedReturn && assignment.Target.IsNamedReturnTarget(returnVariableName))
                 {
@@ -239,9 +242,78 @@ public sealed class NotAllCodePathsReturnValue : DiagnosticAnalyzer
 
                 return states.Union(forEachBodyStates);
 
+            case IInvocationExpression invocation:
+                return AnalyzeInvocation(invocation, states, hasNamedReturn, returnVariableName);
+
+            case IExpressionStatement expressionStatement
+                when expressionStatement.Expression is IInvocationExpression wrappedInvocation:
+                return AnalyzeInvocation(wrappedInvocation, states, hasNamedReturn, returnVariableName);
+
             default:
                 return states;
         }
+    }
+
+    private static ImmutableHashSet<bool> AnalyzeInvocation(
+        IInvocationExpression invocation,
+        ImmutableHashSet<bool> states,
+        bool hasNamedReturn,
+        string returnVariableName)
+    {
+        if (IsFlowTerminatingCall(invocation))
+        {
+            return ImmutableHashSet<bool>.Empty;
+        }
+
+        if (hasNamedReturn && InvocationAssignsNamedReturn(invocation, returnVariableName))
+        {
+            return ImmutableHashSet.Create(true);
+        }
+
+        return states;
+    }
+
+    // Named return is considered "assigned" when it is either the receiver of an invocation
+    // (e.g. `Customer.Get(No)` where `Customer` is the return variable, populating the record)
+    // or is passed as a by-reference (`var`) argument (e.g. `ComputeInto(Result)`).
+    // This is intentionally conservative to avoid false positives on common AL idioms.
+    private static bool InvocationAssignsNamedReturn(IInvocationExpression invocation, string returnVariableName)
+    {
+        if (invocation.Instance.IsNamedReturnTarget(returnVariableName))
+        {
+            return true;
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter is IParameterSymbol parameter
+                && parameter.IsVar
+                && argument.Value.IsNamedReturnTarget(returnVariableName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Built-in AL methods that never return control to the caller (they throw).
+    // Treating them as path terminators prevents PC0038 false positives on guard clauses
+    // such as `if Cond then exit(x) else Error('...');`.
+    private static bool IsFlowTerminatingCall(IInvocationExpression invocation)
+    {
+        if (invocation.TargetMethod is not IMethodSymbol targetMethod)
+        {
+            return false;
+        }
+
+        if (targetMethod.MethodKind != EnumProvider.MethodKind.BuiltInMethod)
+        {
+            return false;
+        }
+
+        return string.Equals(targetMethod.Name, "Error", StringComparison.Ordinal)
+            || string.Equals(targetMethod.Name, "ThrowError", StringComparison.Ordinal);
     }
 
     private static ImmutableHashSet<bool> AnalyzeStatements(

--- a/src/ALCops.PlatformCop/Analyzers/NotAllCodePathsReturnValue.cs
+++ b/src/ALCops.PlatformCop/Analyzers/NotAllCodePathsReturnValue.cs
@@ -1,0 +1,339 @@
+using System.Collections;
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.PlatformCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class NotAllCodePathsReturnValue : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.NotAllCodePathsReturnValue);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSyntaxNodeAction(
+            AnalyzeDeclaration,
+            EnumProvider.SyntaxKind.MethodDeclaration);
+        // Can be extended to triggers in the future: EnumProvider.SyntaxKind.TriggerDeclaration
+
+    private static void AnalyzeDeclaration(SyntaxNodeAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Node is not MethodDeclarationSyntax declarationSyntax)
+        {
+            return;
+        }
+
+        if (declarationSyntax.ReturnValue is null)
+        {
+            return;
+        }
+
+        if (declarationSyntax is MethodDeclarationSyntax methodSyntax && methodSyntax.IsTryFunction())
+        {
+            return;
+        }
+
+        if (ctx.ContainingSymbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        var returnValue = methodSymbol.ReturnValueSymbol;
+
+        if (returnValue is null)
+        {
+            return;
+        }
+
+        if (declarationSyntax.Body is null)
+        {
+            return;
+        }
+
+        var bodyOperation = ctx.SemanticModel.GetOperation(declarationSyntax.Body, ctx.CancellationToken);
+
+        if (bodyOperation is null)
+        {
+            return;
+        }
+
+        var hasNamedReturn = returnValue.IsNamed;
+
+        var finalStates = AnalyzeOperation(
+            bodyOperation,
+            ImmutableHashSet.Create(false),
+            hasNamedReturn,
+            returnValue.Name,
+            out var hasPathWithoutValue);
+
+        var hasFallthroughWithoutValue = hasNamedReturn
+            ? finalStates.Contains(false)
+            : finalStates.Count > 0;
+
+        if (!hasPathWithoutValue && !hasFallthroughWithoutValue)
+        {
+            return;
+        }
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.NotAllCodePathsReturnValue,
+            declarationSyntax.Name.GetLocation(),
+            methodSymbol.GetDiagnosticDisplayText(MethodSymbolDisplayFormat.MethodSignature)));
+    }
+
+    private static ImmutableHashSet<bool> AnalyzeOperation(
+        IOperation? operation,
+        ImmutableHashSet<bool> states,
+        bool hasNamedReturn,
+        string returnVariableName,
+        out bool hasPathWithoutValue)
+    {
+        hasPathWithoutValue = false;
+
+        if (operation is null || states.Count == 0)
+        {
+            return states;
+        }
+
+        switch (operation)
+        {
+            case IBlockStatement block:
+                return AnalyzeStatements(block.Statements, states, hasNamedReturn, returnVariableName, out hasPathWithoutValue);
+
+            case IAssignmentStatement assignment:
+                if (hasNamedReturn && assignment.Target.IsNamedReturnTarget(returnVariableName))
+                {
+                    return ImmutableHashSet.Create(true);
+                }
+
+                return states;
+
+            case IExitStatement exitStatement:
+                var returnsValue = exitStatement.ReturnedValue is not null;
+
+                if (!returnsValue)
+                {
+                    if (!hasNamedReturn)
+                    {
+                        hasPathWithoutValue = true;
+                    }
+                    else
+                    {
+                        foreach (var assigned in states)
+                        {
+                            if (!assigned)
+                            {
+                                hasPathWithoutValue = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                return ImmutableHashSet<bool>.Empty;
+
+            case IIfStatement ifStatement:
+                var trueStates = AnalyzeOperation(
+                    ifStatement.IfTrueStatement,
+                    states,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out var truePathWithoutValue);
+
+                var falsePathWithoutValue = false;
+
+                var falseStates = ifStatement.IfFalseStatement is null
+                    ? states
+                    : AnalyzeOperation(
+                        ifStatement.IfFalseStatement,
+                        states,
+                        hasNamedReturn,
+                        returnVariableName,
+                        out falsePathWithoutValue);
+
+                hasPathWithoutValue = truePathWithoutValue || falsePathWithoutValue;
+
+                return trueStates.Union(falseStates);
+
+            case ICaseStatement caseStatement:
+                var mergedStates = ImmutableHashSet<bool>.Empty;
+                var caseHasPathWithoutValue = false;
+
+                foreach (var caseLine in caseStatement.CaseLines)
+                {
+                    var caseLineStates = AnalyzeCaseLine(
+                        caseLine,
+                        states,
+                        hasNamedReturn,
+                        returnVariableName,
+                        out var caseLineHasPathWithoutValue);
+
+                    caseHasPathWithoutValue |= caseLineHasPathWithoutValue;
+                    mergedStates = mergedStates.Union(caseLineStates);
+                }
+
+                if (caseStatement.ElseStatement is not null)
+                {
+                    var elseStates = AnalyzeOperation(
+                        caseStatement.ElseStatement,
+                        states,
+                        hasNamedReturn,
+                        returnVariableName,
+                        out var elseHasPathWithoutValue);
+
+                    caseHasPathWithoutValue |= elseHasPathWithoutValue;
+                    mergedStates = mergedStates.Union(elseStates);
+                }
+                else
+                {
+                    mergedStates = mergedStates.Union(states);
+                }
+
+                hasPathWithoutValue = caseHasPathWithoutValue;
+
+                return mergedStates;
+
+            case IWhileRepeatLoopStatement loopStatement:
+                var bodyStates = AnalyzeOperation(
+                    loopStatement.Body,
+                    states,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out var loopHasPathWithoutValue);
+
+                hasPathWithoutValue = loopHasPathWithoutValue;
+
+                if (loopStatement.LoopKind == EnumProvider.LoopKind.Repeat)
+                {
+                    return bodyStates;
+                }
+
+                return states.Union(bodyStates);
+
+            case IForLoopStatement forLoop:
+                var forBodyStates = AnalyzeOperation(
+                    forLoop.Body,
+                    states,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out var forHasPathWithoutValue);
+
+                hasPathWithoutValue = forHasPathWithoutValue;
+
+                return states.Union(forBodyStates);
+
+            case IForEachLoopStatement forEachLoop:
+                var forEachBodyStates = AnalyzeOperation(
+                    forEachLoop.Body,
+                    states,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out var forEachHasPathWithoutValue);
+
+                hasPathWithoutValue = forEachHasPathWithoutValue;
+
+                return states.Union(forEachBodyStates);
+
+            default:
+                return states;
+        }
+    }
+
+    private static ImmutableHashSet<bool> AnalyzeStatements(
+        IEnumerable<IOperation> statements,
+        ImmutableHashSet<bool> initialStates,
+        bool hasNamedReturn,
+        string returnVariableName,
+        out bool hasPathWithoutValue)
+    {
+        var states = initialStates;
+        var anyPathWithoutValue = false;
+
+        foreach (var statement in statements)
+        {
+            states = AnalyzeOperation(
+                statement,
+                states,
+                hasNamedReturn,
+                returnVariableName,
+                out var statementHasPathWithoutValue);
+
+            anyPathWithoutValue |= statementHasPathWithoutValue;
+
+            if (states.Count == 0)
+            {
+                break;
+            }
+        }
+
+        hasPathWithoutValue = anyPathWithoutValue;
+
+        return states;
+    }
+
+    private static ImmutableHashSet<bool> AnalyzeCaseLine(
+        object caseLine,
+        ImmutableHashSet<bool> states,
+        bool hasNamedReturn,
+        string returnVariableName,
+        out bool hasPathWithoutValue)
+    {
+        hasPathWithoutValue = false;
+
+        if (caseLine is IOperation caseOperation)
+        {
+            var bodyOperation = caseOperation.GetPropertyIfExists<IOperation>("Body")
+                ?? caseOperation.GetPropertyIfExists<IOperation>("Statement");
+
+            if (bodyOperation is not null)
+            {
+                return AnalyzeOperation(
+                    bodyOperation,
+                    states,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out hasPathWithoutValue);
+            }
+
+            var statements = caseOperation.GetPropertyIfExists<IEnumerable>("Statements");
+
+            if (statements is null)
+            {
+                return states;
+            }
+
+            var result = states;
+
+            foreach (var statement in statements)
+            {
+                if (statement is not IOperation statementOperation)
+                {
+                    continue;
+                }
+
+                result = AnalyzeOperation(
+                    statementOperation,
+                    result,
+                    hasNamedReturn,
+                    returnVariableName,
+                    out var statementHasPathWithoutValue);
+
+                hasPathWithoutValue |= statementHasPathWithoutValue;
+
+                if (result.Count == 0)
+                {
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        return states;
+    }
+}

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -365,6 +365,16 @@ public static class DiagnosticDescriptors
         description: PlatformCopAnalyzers.UseValidateForFieldAssignmentDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseValidateForFieldAssignment));
 
+    public static readonly DiagnosticDescriptor NotAllCodePathsReturnValue = new(
+        id: DiagnosticIds.NotAllCodePathsReturnValue,
+        title: PlatformCopAnalyzers.NotAllCodePathsReturnValueTitle,
+        messageFormat: PlatformCopAnalyzers.NotAllCodePathsReturnValueMessageFormat,
+        category: Category.Usage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: PlatformCopAnalyzers.NotAllCodePathsReturnValueDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.NotAllCodePathsReturnValue));
+
     public static readonly DiagnosticDescriptor AnalyzerException = new(
         id: DiagnosticIds.AnalyzerException,
         title: PlatformCopAnalyzers.AnalyzerExceptionTitle,

--- a/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.PlatformCop/DiagnosticDescriptors.cs
@@ -370,7 +370,7 @@ public static class DiagnosticDescriptors
         title: PlatformCopAnalyzers.NotAllCodePathsReturnValueTitle,
         messageFormat: PlatformCopAnalyzers.NotAllCodePathsReturnValueMessageFormat,
         category: Category.Usage,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         description: PlatformCopAnalyzers.NotAllCodePathsReturnValueDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.NotAllCodePathsReturnValue));

--- a/src/ALCops.PlatformCop/DiagnosticIds.cs
+++ b/src/ALCops.PlatformCop/DiagnosticIds.cs
@@ -39,4 +39,5 @@ public static class DiagnosticIds
     public static readonly string UseSetAutoCalcFieldsForLoops = "PC0035";
     public static readonly string PageVariableSetRecordTemporaryRecord = "PC0036";
     public static readonly string UseValidateForFieldAssignment = "PC0037";
+    public static readonly string NotAllCodePathsReturnValue = "PC0038";
 }

--- a/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
+++ b/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
@@ -22,6 +22,13 @@
             <StronglyTypedFileName>$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs</StronglyTypedFileName>
             <StronglyTypedClassName>TestAutomationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
+        <Compile Include="$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs"
+                 Condition="Exists('$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs')"
+                 Visible="false">
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <DependentUpon>ALCops.TestAutomationCopAnalyzers.resx</DependentUpon>
+        </Compile>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
+++ b/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
@@ -23,7 +23,7 @@
             <StronglyTypedClassName>TestAutomationCopAnalyzers</StronglyTypedClassName>
         </EmbeddedResource>
         <Compile Include="$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs"
-                 Condition="Exists('$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs')"
+                 Condition="'$(DesignTimeBuild)' == 'true' and Exists('$(IntermediateOutputPath)ALCops.TestAutomationCopAnalyzers.cs')"
                  Visible="false">
             <AutoGen>true</AutoGen>
             <DesignTime>true</DesignTime>


### PR DESCRIPTION
# Feat: add PC0038 and LC0097 return-flow diagnostics

This PR introduces two new analyzer features for return-flow quality:

- PC0038 NotAllCodePathsReturnValue
- LC0097 MixedExitAndNamedReturnAssignment (disabled by default)

## What is new

- Added a new PlatformCop rule PC0038 to detect methods where not all code paths return a value.
- Added a new LinterCop rule LC0097 to detect methods that mix exit style and named-return assignment style.

## Test coverage

- Added comprehensive rule-specific test suites for PC0038 and LC0097.

## Additional updates

- **Resource generation fix**: updated cop project files to ensure reliable analyzer `.resx` strongly-typed resource generation/design-time inclusion.
- **Task naming cleanup**: renamed VS Code tasks with a consistent `ALCops:` prefix.
- **Diagnostic display consistency**: adopted shared method display formatting in:
- Updated method display (signature) in **ProcedureRequiresDocumentation** analyzer diagnostics

## Outcome

This feature set strengthens return-flow correctness and consistency, reduces ambiguous control-flow patterns, and provides clearer guidance during development.

Implements #392 
See discussion [Warning/error if procedure with return value doesn't contain exit() and doesn't assign to the named return value](https://github.com/ALCops/Analyzers/discussions/362#discussion-10311249).