### PR TITLE
fix: remove stray backtick from AC0012 message format

### DIFF
--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -253,7 +253,7 @@
     <value>Integration events must not be declared in codeunits with Access set to Internal</value>
   </data>
   <data name="IntegrationEventInInternalCodeunitMessageFormat" xml:space="preserve">
-    <value>Integration event '{0}' is declared in a codeunit with Access = Internal`, making it inaccessible to extensions. Remove the Access property or declare the event as an InternalEvent.</value>
+    <value>Integration event '{0}' is declared in a codeunit with Access = Internal, making it inaccessible to extensions. Remove the Access property or declare the event as an InternalEvent.</value>
   </data>
   <data name="IntegrationEventInInternalCodeunitDescription" xml:space="preserve">
     <value>Integration events are designed to be consumed by extensions and therefore must be accessible outside the defining app. When an IntegrationEvent is declared in a codeunit with Access = Internal, the event cannot be subscribed to by extensions, rendering it ineffective.</value>


### PR DESCRIPTION
## Summary

Removes a stray backtick in the `IntegrationEventInInternalCodeunitMessageFormat` resource string (`ALCops.ApplicationCopAnalyzers.resx`). The backtick after `Access = Internal` rendered as an extra quote character in the diagnostic message.

**Before:**
> Integration event '{0}' is declared in a codeunit with Access = Internal`, making it inaccessible to extensions. ...

**After:**
> Integration event '{0}' is declared in a codeunit with Access = Internal, making it inaccessible to extensions. ...

Fixes #396

## Verification

- `dotnet build ALCops.sln`: 0 errors
- AC0012 tests (`IntegrationEventInInternalCodeunit`): 7/7 passed
- No test/docs/instruction file changes needed: tests assert via markers and diagnostic ID, not message text