### PR TITLE
fix: PC0037 CodeFix no longer fabricates semicolon before else

### DIFF
--- a/.github/instructions/pc0037-use-validate-for-field-assignment.instructions.md
+++ b/.github/instructions/pc0037-use-validate-for-field-assignment.instructions.md
@@ -42,13 +42,13 @@ Detects direct field assignments on non-temporary record variables and recommend
 - **Current-record detection** (`IsCurrentRecordInstance`): true when the instance is a `this`/self reference — detected via `instance.Kind == EnumProvider.OperationKind.ThisReference` (guarded `!= default`), **not** the `IInstanceReferenceOperation` type — or when its symbol is named `Rec` (covers explicit `Rec.` and a page's implicit-with bare reference). `Rec`/`xRec` are reserved AL keywords, so the name is the only public discriminator between the current record and the `xRec` before-image. See the this/self note in `analyzer-development.instructions.md`.
 - **Owner field resolution** (`ResolveTriggerOwnerField`): the trigger symbol's `ContainingSymbol` is the owner — an `IFieldSymbol` (table field), an `IControlSymbol` (page control, resolved via `RelatedFieldSymbol`), or a change-modify symbol for `modify(...)` extensions whose modified base field/control is read via the internal `Target` property (`PropertyAccessor.GetPropertyIfExists`), then resolved recursively
 - **Location**: Reports on `fieldAccess.Syntax.GetIdentifierNameSyntax()` (the field identifier token)
-- **CodeFix**: Navigates from diagnostic span to parent `AssignmentStatementSyntax`, rewrites to `ExpressionStatement(InvocationExpression(MemberAccess(Rec, "Validate"), ArgumentList(FieldName, Value)))`
+- **CodeFix**: Navigates from diagnostic span to parent `AssignmentStatementSyntax`, rewrites to `ExpressionStatement(InvocationExpression(MemberAccess(Rec, "Validate"), ArgumentList(FieldName, Value)))`. Reuses the original `assignment.SemicolonToken` (a missing token when absent) instead of fabricating one, so then-branch assignments directly before `else` stay compilable (issue #395)
 
 ## Test coverage
 
 **HasDiagnostic (8 cases):** SimpleAssignment, CompoundAssignment, AfterInit, PrimaryKeyField, OnValidateDifferentFieldOnRec, OnValidateXRecSameField, OnValidateOtherRecordSameField, InherentlyTemporaryTable.
 **NoDiagnostic (14 cases):** TemporaryVariable, ValidateCall, NonRecordVariable, InsideOnValidateTrigger, TableFieldOnValidateSameField, TableExtensionFieldOnBeforeValidateSameField, TableExtensionFieldOnAfterValidateSameField, PageControlOnValidateSameField, PageExtensionControlOnBeforeValidateSameField, PageExtensionControlOnAfterValidateSameField, OnValidateSameFieldThisReference, PageControlOnValidateSameFieldBareReference, CRMTableType, CDSTableType.
-**HasFix (1 case):** SimpleAssignment.
+**HasFix (3 cases):** SimpleAssignment, IfElseNoSemicolon, NestedIfElseInRepeatUntil.
 
 ## Known issues
 

--- a/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/IfElseNoSemicolon/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/IfElseNoSemicolon/current.al
@@ -1,0 +1,21 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(NewPrice: Decimal)
+    var
+        SalesLine: Record "Sales Line";
+    begin
+        if NewPrice > 0 then
+            SalesLine.[|"Unit Price"|] := NewPrice
+        else begin
+        end;
+    end;
+}
+
+table 50100 "Sales Line"
+{
+    fields
+    {
+        field(1; "Document No."; Code[20]) { }
+        field(2; "Unit Price"; Decimal) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/IfElseNoSemicolon/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/IfElseNoSemicolon/expected.al
@@ -1,0 +1,21 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(NewPrice: Decimal)
+    var
+        SalesLine: Record "Sales Line";
+    begin
+        if NewPrice > 0 then
+            SalesLine.Validate("Unit Price", NewPrice)
+        else begin
+        end;
+    end;
+}
+
+table 50100 "Sales Line"
+{
+    fields
+    {
+        field(1; "Document No."; Code[20]) { }
+        field(2; "Unit Price"; Decimal) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/NestedIfElseInRepeatUntil/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/NestedIfElseInRepeatUntil/current.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(NewPrice: Decimal)
+    var
+        SalesLine: Record "Sales Line";
+    begin
+        repeat
+            if NewPrice > 0 then
+                SalesLine.[|"Unit Price"|] := NewPrice
+            else
+                NewPrice += 1;
+        until NewPrice > 10;
+    end;
+}
+
+table 50100 "Sales Line"
+{
+    fields
+    {
+        field(1; "Document No."; Code[20]) { }
+        field(2; "Unit Price"; Decimal) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/NestedIfElseInRepeatUntil/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/HasFix/NestedIfElseInRepeatUntil/expected.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(NewPrice: Decimal)
+    var
+        SalesLine: Record "Sales Line";
+    begin
+        repeat
+            if NewPrice > 0 then
+                SalesLine.Validate("Unit Price", NewPrice)
+            else
+                NewPrice += 1;
+        until NewPrice > 10;
+    end;
+}
+
+table 50100 "Sales Line"
+{
+    fields
+    {
+        field(1; "Document No."; Code[20]) { }
+        field(2; "Unit Price"; Decimal) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/UseValidateForFieldAssignment.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseValidateForFieldAssignment/UseValidateForFieldAssignment.cs
@@ -79,6 +79,8 @@ namespace ALCops.PlatformCop.Test
 
         [Test]
         [TestCase("SimpleAssignment")]
+        [TestCase("IfElseNoSemicolon")]
+        [TestCase("NestedIfElseInRepeatUntil")]
         public async Task HasFix(string testCase)
         {
             var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.PlatformCop/CodeFixes/UseValidateForFieldAssignment.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseValidateForFieldAssignment.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
@@ -88,8 +87,9 @@ public sealed class UseValidateForFieldAssignmentCodeFixProvider : CodeFixProvid
         var argumentList = SyntaxFactory.ArgumentList(arguments);
 
         var validateInvocation = SyntaxFactory.InvocationExpression(validateMemberAccess, argumentList);
-        var expressionStatement = SyntaxFactory.ExpressionStatement(validateInvocation,
-            SyntaxFactory.Token(EnumProvider.SyntaxKind.SemicolonToken))
+        // Reuse the original semicolon token: statements directly before 'else' have none,
+        // and fabricating one would produce non-compiling code (issue #395).
+        var expressionStatement = SyntaxFactory.ExpressionStatement(validateInvocation, assignment.SemicolonToken)
             .WithTriviaFrom(assignment);
 
         var root = await syntaxRootTask.ConfigureAwait(false);


### PR DESCRIPTION
## Problem

The PC0037 (`UseValidateForFieldAssignment`) CodeFix always fabricated a `SemicolonToken` when rewriting `Rec.Field := Value` into `Rec.Validate(Field, Value)`. AL forbids a semicolon on a statement directly before `else`, so applying the fix to a then-branch assignment produced non-compiling code:

```al
if BankImpExpMgtSAK.IsIBAN(IBANOrDesription) then
    Bankstatementline.Validate(IBAN, ...);  // <- illegal semicolon
else begin
end;
```

Although #395 was reported against the workspace Fix All, the semicolon was fabricated unconditionally, so single-instance fixes broke too.

## Fix

Reuse the original `assignment.SemicolonToken` (a missing token when the assignment has none) instead of constructing a fresh one. Same pattern already used in `GlobalLanguageImplementTranslationHelper.cs`.

## Tests

Two new HasFix regression cases (verified to fail against the unfixed CodeFix):
- `IfElseNoSemicolon` — issue repro: assignment as then-branch of `if ... then ... else begin end;`
- `NestedIfElseInRepeatUntil` — then-branch assignment before `else` inside `repeat ... until`

Full PlatformCop suite: 476/476 passing.

## Follow-up

#398 tracks auditing the other CodeFixes that fabricate semicolon tokens.

Fixes #395