### PR TITLE
fix: PC0035 CodeFix no longer crashes on unblocked then-branch targets

### DIFF
--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -68,11 +68,14 @@ This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (
 4. Insert `SetAutoCalcFields(fields)` before the insertion target
 5. Arguments are passed through directly from CalcFields (unqualified field names)
 
+The insertion target must be an element of a statement list (`BlockSyntax` or `RepeatStatementSyntax` body). When the target is a single-statement branch (e.g. the `if X.FindSet() then repeat...` is itself an unblocked then-branch of an outer `if`), `InsertNodesBefore` would throw `InvalidOperationException` in the SDK's `SyntaxReplacer`. The `InsertableOrNull` guard returns null in that case, so no CodeFix is offered (issue #398); the diagnostic still appears.
+
 ## Test coverage
 
 **HasDiagnostic (7 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop, NestedLoopInConditional.
 **NoDiagnostic (10 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord, CalcFieldsInIfBlock, CalcFieldsInCaseBlock, CalcFieldsInIfElseBlock, TemporaryVariable, TemporaryTableType, ReportTemporaryTableType.
-**HasFix (2 cases):** FindSetRepeatUntil, MultipleFields.
+**HasFix (4 cases):** FindSetRepeatUntil, MultipleFields, IfFindSetRepeatUntil, IfFindSetBeginRepeatUntil.
+**NoFix (2 cases):** UnblockedThenBranch, UnblockedThenBranchBeforeElse.
 
 ## Known limitations
 
@@ -80,3 +83,4 @@ This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (
 - Multiple CalcFields in the same loop are reported individually (not merged by the analyzer)
 - The CodeFix handles one CalcFields at a time; use Fix All for multiple occurrences
 - CalcFields inside conditional branches (if/case) within loops are intentionally not flagged, even if all branches call CalcFields (accepted false negative for zero false positives)
+- No CodeFix is offered when the insertion target is not in a statement list (unblocked then-branch scenario, issue #398); wrapping the branch in begin..end was considered and rejected as over-engineering (pattern does not occur in the BaseApp)

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoFix/UnblockedThenBranch.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoFix/UnblockedThenBranch.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(Process: Boolean)
+    var
+        MyTable: Record MyTable;
+    begin
+        if Process then
+            if MyTable.FindSet() then
+                repeat
+                    [|MyTable.CalcFields(MyFlowField)|];
+                until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoFix/UnblockedThenBranchBeforeElse.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/NoFix/UnblockedThenBranchBeforeElse.al
@@ -1,0 +1,33 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(Process: Boolean)
+    var
+        MyTable: Record MyTable;
+    begin
+        if Process then
+            if MyTable.FindSet() then
+                repeat
+                    [|MyTable.CalcFields(MyFlowField)|];
+                until MyTable.Next() = 0
+        else
+            exit;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -76,4 +76,23 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
 
         fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops);
     }
+
+    [Test]
+    [TestCase("UnblockedThenBranch")]
+    [TestCase("UnblockedThenBranchBeforeElse")]
+    public async Task NoFix(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoFix), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<UseSetAutoCalcFieldsForLoopsCodeFixProvider>(
+            new CodeFixTestFixtureConfig
+            {
+                AdditionalAnalyzers = [_analyzer]
+            });
+
+        // The insertion target is an unblocked then-branch: no statement list to
+        // insert into, so no CodeFix must be offered (issue #398).
+        fixture.NoCodeFix(code, DiagnosticDescriptors.UseSetAutoCalcFieldsForLoops);
+    }
 }

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -172,20 +172,20 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
                     // Check if an ancestor if-statement contains the FindSet condition
                     var enclosingIf = FindEnclosingIfWithFind(repeatStatement);
                     if (enclosingIf is not null)
-                        return enclosingIf;
+                        return InsertableOrNull(enclosingIf);
 
                     // Otherwise look for a standalone FindSet statement before the repeat
                     var precedingFind = FindPrecedingFindStatement(repeatStatement);
                     if (precedingFind is not null)
                         return precedingFind;
 
-                    return repeatStatement;
+                    return InsertableOrNull(repeatStatement);
 
                 case WhileStatementSyntax whileStatement:
-                    return whileStatement;
+                    return InsertableOrNull(whileStatement);
 
                 case ForEachStatementSyntax forEachStatement:
-                    return forEachStatement;
+                    return InsertableOrNull(forEachStatement);
 
                 case MethodOrTriggerDeclarationSyntax:
                     // We've reached the method body without finding a loop.
@@ -197,6 +197,15 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
         }
         return null;
     }
+
+    /// <summary>
+    /// Returns the statement only when it is an element of a statement list
+    /// (begin..end block or repeat..until body). Inserting before a statement that is
+    /// a single-statement branch (e.g. an unblocked then-branch of an outer if) would
+    /// throw InvalidOperationException in the SDK's SyntaxReplacer (issue #398).
+    /// </summary>
+    private static StatementSyntax? InsertableOrNull(StatementSyntax statement) =>
+        statement.Parent is BlockSyntax or RepeatStatementSyntax ? statement : null;
 
     /// <summary>
     /// Walks up from the repeat statement to find an enclosing if-statement whose condition


### PR DESCRIPTION
## Background

Part of the #398 audit of CodeFixes that fabricate `SemicolonToken` (follow-up to #395/#399).

## Audit result

All sites listed in #398 were classified; the fabricated-semicolon sites are safe (full audit table posted on #398). However, the audit surfaced an adjacent bug in the PC0035 CodeFix.

## The bug

`UseSetAutoCalcFieldsForLoopsCodeFixProvider` inserts the `SetAutoCalcFields` statement via `InsertNodesBefore` without checking that the insertion target is an element of a statement list. When `if Rec.FindSet() then repeat..until` is itself the **unblocked then-branch** of an outer `if`, the SDK's `SyntaxReplacer` throws `InvalidOperationException: The item specified is not the element of a list`, crashing the CodeFix and any FixAll batch containing such an occurrence:

```al
if Process then
    if MyTable.FindSet() then
        repeat
            MyTable.CalcFields(MyFlowField);  // PC0035 — CodeFix crashed here
        until MyTable.Next() = 0;
```

Verified for both the plain nested case and the variant with a trailing `else`.

## The fix

Add an `InsertableOrNull` guard: the insertion target must sit in a `begin..end` block or `repeat..until` body. Otherwise no CodeFix is offered and the diagnostic remains. Wrapping the branch in `begin..end` was considered and rejected as over-engineering — the pattern does not occur anywhere in the BaseApp.

## Tests

- New `NoFix` test method with fixtures: `UnblockedThenBranch`, `UnblockedThenBranchBeforeElse` (uses `NoCodeFix` from RoslynTestKit)
- Full PlatformCop suite: 478/478 passing
- Instruction file updated (CodeFix strategy, test coverage incl. stale HasFix count 2→4, known limitations)

Closes #398