### PR TITLE
feat: add FC0006 - Permission values should be lowercase

### DIFF
--- a/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
+++ b/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
@@ -1,0 +1,65 @@
+---
+applyTo: 'src/ALCops.FormattingCop/**/PermissionValuesShouldBeLowercase*'
+---
+
+# FC0006: Permission Values Should Be Lowercase
+
+## Purpose
+
+Detects uppercase permission values (e.g. `RIMD`, `Rimd`) in the `Permissions` property of application objects. Casing has no runtime effect there; both cases grant the same indirect permission, but uppercase wrongly suggests direct permissions are granted (a semantic that only exists in permissionset objects and the `InherentPermissions` property). Provides a CodeFix that lowercases all permission values in the property. Origin: discussion #383.
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | FC0006 |
+| Category | Style |
+| Severity | Info |
+| Help URI | https://alcops.dev/docs/analyzers/formattingcop/fc0006/ |
+
+## Architecture
+
+```
+src/ALCops.FormattingCop/
+├── Analyzers/
+│   └── PermissionValuesShouldBeLowercase.cs           # Analyzer (SyntaxNodeAction)
+└── CodeFixes/
+    └── PermissionValuesShouldBeLowercaseCodeFixProvider.cs  # CodeFix (lowercase tokens)
+```
+
+### Analysis flow
+
+1. `RegisterSyntaxNodeAction` on `EnumProvider.SyntaxKind.PermissionPropertyValue` (rare node; cheap pre-filter, covers requestpages nested in reports/xmlports which `GetDeclaredApplicationObjectSymbols()` cannot reach)
+2. Skip obsolete symbols via `ctx.IsObsolete()`
+3. Skip when any ancestor is a `PermissionSet`/`PermissionSetExtension` object (casing is semantic there: uppercase = direct, lowercase = indirect)
+4. Flag when any `PermissionSyntax.Permissions` token text contains an uppercase char
+5. Report one diagnostic per property on the `PropertySyntax` node (parent of the value node)
+
+## SDK facts (verified against nav-sdk-source and empirically)
+
+- The `Permissions` property exists on: Codeunit, Table, Page, Report, RequestPage, XmlPort, Query, PermissionSet, PermissionSetExtension (`PropertyInfoLookup`). Extension objects do not support it.
+- **The object-level `Permissions` property only accepts `tabledata` entries.** Non-`tabledata` entries (`codeunit X = X` etc.) are rejected with `AL0104: Syntax error, 'tabledata' expected`, despite Microsoft Learn docs showing such examples. Only permissionset objects accept other object types (parsed via `ParsePermissionSetPermissionListPropertyValue`).
+- Both object-level and permissionset permission lists produce `PermissionPropertyValueSyntax` (same `SyntaxKind.PermissionPropertyValue`), hence the explicit permissionset ancestor exclusion.
+- `InherentPermissions` produces a different node kind (`InherentPermissionsPropertyValue`), so it is naturally excluded by the registration.
+- The parser uppercases permission values before validation (`GetPermissionValuesTokenWithError`), so any casing parses cleanly.
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| Syntax-node action on `PermissionPropertyValue` | Rare node, no compilation-wide iteration; reaches nested requestpage properties |
+| One diagnostic per property, not per entry | Matches FC0004; the fix lowercases the whole list |
+| Diagnostic on `PropertySyntax` node | Ensures CodeFix can find the node via `FindNode` + ancestor/descendant traversal (same as FC0004) |
+| Exclude permissionset(extension) via syntax ancestors | Deterministic, no semantic model lookup needed |
+| Skip obsolete objects | Standard convention (`ctx.IsObsolete()`) |
+| `ContainsUppercase` is `internal static` on the analyzer | Shared with the CodeFix within the assembly |
+
+## CodeFix
+
+`PermissionValuesShouldBeLowercaseCodeFixProvider` collects all `Permissions` tokens containing uppercase chars and replaces them via `root.ReplaceTokens` with `SyntaxFactory.Identifier(text.ToLowerInvariant()).WithTriviaFrom(original)`. Entry order, formatting, and trivia are preserved. Supports FixAll via BatchFixer.
+
+## Test coverage
+
+**HasDiagnostic (9 cases):** CodeunitUppercase, CodeunitMixedCase, TableUppercase, PageUppercase, ReportUppercase, XmlPortUppercase, QueryUppercase, RequestPageUppercase, MultipleEntriesOneUppercase.
+**NoDiagnostic (6 cases):** LowercaseCodeunit, PermissionSetUppercase, PermissionSetExtensionUppercase, InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
+**HasFix (3 cases):** LowercaseAllValues, MixedCaseValue, MultipleEntries.

--- a/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
+++ b/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
@@ -6,7 +6,7 @@ applyTo: 'src/ALCops.FormattingCop/**/PermissionValuesShouldBeLowercase*'
 
 ## Purpose
 
-Detects uppercase permission values (e.g. `RIMD`, `Rimd`) in the `Permissions` property of application objects. Casing has no runtime effect there; both cases grant the same indirect permission, but uppercase wrongly suggests direct permissions are granted (a semantic that only exists in permissionset objects and the `InherentPermissions` property). Provides a CodeFix that lowercases all permission values in the property. Origin: discussion #383.
+Detects uppercase permission values (e.g. `RIMD`, `Rimd`, `X`) in the `Permissions` property of application objects. Casing has no runtime effect there; both cases grant the same indirect permission, but uppercase wrongly suggests direct permissions are granted (a semantic that only exists in permissionset objects and the `InherentPermissions` property). Applies to read/insert/modify/delete (`rimd`) and execute (`x`) values alike. Provides a CodeFix that lowercases all permission values in the property. Origin: discussion #383 (execute coverage confirmed by rvanbekkum in the discussion).
 
 ## Diagnostic properties
 
@@ -42,6 +42,7 @@ src/ALCops.FormattingCop/
 - Both object-level and permissionset permission lists produce `PermissionPropertyValueSyntax` (same `SyntaxKind.PermissionPropertyValue`), hence the explicit permissionset ancestor exclusion.
 - `InherentPermissions` produces a different node kind (`InherentPermissionsPropertyValue`), so it is naturally excluded by the registration.
 - The parser uppercases permission values before validation (`GetPermissionValuesTokenWithError`), so any casing parses cleanly.
+- **Execute permission (`X`/`x`) reachability**: on object-level `Permissions`, `tabledata Foo = X` parses into the tree but carries `AL0195: Invalid permission kind. Expected: 'RIMD'` — the analyzer still sees the token and flags it. Non-`tabledata` entries (`codeunit Foo = X`) are dropped entirely by parser error recovery (`SkipBadPermissionSyntaxToken`); their `X` token never reaches a `PermissionSyntax` node, so the analyzer cannot see it (verified empirically). Since the analyzer checks every `PermissionSyntax.Permissions` token for any uppercase char, a future SDK that legalizes non-tabledata entries is covered automatically.
 
 ## Design decisions
 
@@ -53,6 +54,7 @@ src/ALCops.FormattingCop/
 | Exclude permissionset(extension) via syntax ancestors | Deterministic, no semantic model lookup needed |
 | Skip obsolete objects | Standard convention (`ctx.IsObsolete()`) |
 | `ContainsUppercase` is `internal static` on the analyzer | Shared with the CodeFix within the assembly |
+| Execute (`X`) coverage via generic uppercase check, tested with error-tolerant fixtures | `X` in scope only occurs in code with a compile error (AL0195); test methods `*InDocumentWithErrors` use `ThrowsWhenInputDocumentContainsError = false` (same pattern as `ApplicationCop.Test/TestHelper.cs`) |
 
 ## CodeFix
 
@@ -61,5 +63,8 @@ src/ALCops.FormattingCop/
 ## Test coverage
 
 **HasDiagnostic (9 cases):** CodeunitUppercase, CodeunitMixedCase, TableUppercase, PageUppercase, ReportUppercase, XmlPortUppercase, QueryUppercase, RequestPageUppercase, MultipleEntriesOneUppercase.
+**HasDiagnosticInDocumentWithErrors (1 case):** ExecuteUppercase.
 **NoDiagnostic (6 cases):** LowercaseCodeunit, PermissionSetUppercase, PermissionSetExtensionUppercase, InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
+**NoDiagnosticInDocumentWithErrors (1 case):** LowercaseExecute.
 **HasFix (3 cases):** LowercaseAllValues, MixedCaseValue, MultipleEntries.
+**HasFixInDocumentWithErrors (1 case):** ExecuteValue.

--- a/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
+++ b/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
@@ -64,8 +64,7 @@ src/ALCops.FormattingCop/
 
 **HasDiagnostic (9 cases):** CodeunitUppercase, CodeunitMixedCase, TableUppercase, PageUppercase, ReportUppercase, XmlPortUppercase, QueryUppercase, RequestPageUppercase, MultipleEntriesOneUppercase.
 **HasDiagnosticInDocumentWithErrors (1 case):** ExecuteUppercase.
-**NoDiagnostic (5 cases):** LowercaseCodeunit, PermissionSetUppercase, InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
-**NoDiagnosticOnPermissionSetExtension (1 case, requires SDK v13+):** PermissionSetExtensionUppercase. Older SDKs reject the fixture with AL0334 (extension target already declared in this module).
+**NoDiagnostic (6 cases):** LowercaseCodeunit, PermissionSetUppercase, PermissionSetExtensionUppercase (skipped below SDK v13: permissionsetextension target declared in the same module), InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
 **NoDiagnosticInDocumentWithErrors (1 case):** LowercaseExecute.
 **HasFix (3 cases):** LowercaseAllValues, MixedCaseValue, MultipleEntries.
 **HasFixInDocumentWithErrors (1 case):** ExecuteValue.

--- a/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
+++ b/.github/instructions/fc0006-permission-values-should-be-lowercase.instructions.md
@@ -64,7 +64,8 @@ src/ALCops.FormattingCop/
 
 **HasDiagnostic (9 cases):** CodeunitUppercase, CodeunitMixedCase, TableUppercase, PageUppercase, ReportUppercase, XmlPortUppercase, QueryUppercase, RequestPageUppercase, MultipleEntriesOneUppercase.
 **HasDiagnosticInDocumentWithErrors (1 case):** ExecuteUppercase.
-**NoDiagnostic (6 cases):** LowercaseCodeunit, PermissionSetUppercase, PermissionSetExtensionUppercase, InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
+**NoDiagnostic (5 cases):** LowercaseCodeunit, PermissionSetUppercase, InherentPermissionsUppercase, NoPermissionsProperty, ObsoleteCodeunit.
+**NoDiagnosticOnPermissionSetExtension (1 case, requires SDK v13+):** PermissionSetExtensionUppercase. Older SDKs reject the fixture with AL0334 (extension target already declared in this module).
 **NoDiagnosticInDocumentWithErrors (1 case):** LowercaseExecute.
 **HasFix (3 cases):** LowercaseAllValues, MixedCaseValue, MultipleEntries.
 **HasFixInDocumentWithErrors (1 case):** ExecuteValue.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -94,6 +94,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `sdk-analyzer-infrastructure` | `'src/ALCops.*/Analyzers/**'` | NAV SDK internals: callback ordering, incremental compilation, GetOperation perf |
 | `analyzer-exception-harness` | `'src/ALCops.Common/Diagnostics/**'` | XX0000 harness: base class + context decorators that convert analyzer exceptions into located diagnostics |
 | `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
+| `fc0006-permission-values-should-be-lowercase` | rule-scoped | FC0006 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -1152,6 +1152,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.Parameter)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _pragmaWarningDirectiveTrivia =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PragmaWarningDirectiveTrivia)));
+        private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _permissionPropertyValue =
+            new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PermissionPropertyValue)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _permissionSet =
             new(() => ParseEnum<NavCodeAnalysis.SyntaxKind>(nameof(NavCodeAnalysis.SyntaxKind.PermissionSet)));
         private static readonly Lazy<NavCodeAnalysis.SyntaxKind> _permissionSetExtension =
@@ -1349,6 +1351,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.SyntaxKind PageActionSeparator => _pageActionSeparator.Value;
         public static NavCodeAnalysis.SyntaxKind PageArea => _pageArea.Value;
         public static NavCodeAnalysis.SyntaxKind Parameter => _parameter.Value;
+        public static NavCodeAnalysis.SyntaxKind PermissionPropertyValue => _permissionPropertyValue.Value;
         public static NavCodeAnalysis.SyntaxKind PermissionSet => _permissionSet.Value;
         public static NavCodeAnalysis.SyntaxKind PermissionSetExtension => _permissionSetExtension.Value;
         public static NavCodeAnalysis.SyntaxKind PermissionValue => _permissionValue.Value;

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/CodeunitMixedCase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/CodeunitMixedCase.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = Rimd|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/CodeunitUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/CodeunitUppercase.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = RIMD|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/ExecuteUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/ExecuteUppercase.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = X|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/MultipleEntriesOneUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/MultipleEntriesOneUppercase.al
@@ -1,0 +1,23 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = rimd,
+                  tabledata Bravo = RIMD|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/PageUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/PageUppercase.al
@@ -1,0 +1,13 @@
+page 50100 "My Page"
+{
+    [|Permissions = tabledata Alpha = IMD|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/QueryUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/QueryUppercase.al
@@ -1,0 +1,21 @@
+query 50100 "My Query"
+{
+    [|Permissions = tabledata Alpha = RIMD|];
+
+    elements
+    {
+        dataitem(Alpha; Alpha)
+        {
+            column(MyField; MyField) { }
+        }
+    }
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/ReportUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/ReportUppercase.al
@@ -1,0 +1,13 @@
+report 50100 "My Report"
+{
+    [|Permissions = tabledata Alpha = R|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/RequestPageUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/RequestPageUppercase.al
@@ -1,0 +1,16 @@
+report 50100 "My Report"
+{
+    requestpage
+    {
+        [|Permissions = tabledata Alpha = RIMD|];
+    }
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/TableUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/TableUppercase.al
@@ -1,0 +1,18 @@
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    [|Permissions = tabledata Bravo = RM|];
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/XmlPortUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/XmlPortUppercase.al
@@ -1,0 +1,20 @@
+xmlport 50100 "My XmlPort"
+{
+    [|Permissions = tabledata Alpha = RIMD|];
+
+    schema
+    {
+        textelement(Root)
+        {
+        }
+    }
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/ExecuteValue/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/ExecuteValue/current.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = X|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/ExecuteValue/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/ExecuteValue/expected.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = x;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/LowercaseAllValues/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/LowercaseAllValues/current.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = RIMD|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/LowercaseAllValues/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/LowercaseAllValues/expected.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = rimd;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MixedCaseValue/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MixedCaseValue/current.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = Rimd|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MixedCaseValue/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MixedCaseValue/expected.al
@@ -1,0 +1,13 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = rimd;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MultipleEntries/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MultipleEntries/current.al
@@ -1,0 +1,33 @@
+codeunit 50100 "My Codeunit"
+{
+    [|Permissions = tabledata Alpha = RIMD,
+                  tabledata Bravo = rm,
+                  tabledata Charlie = Ri|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MultipleEntries/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasFix/MultipleEntries/expected.al
@@ -1,0 +1,33 @@
+codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = rimd,
+                  tabledata Bravo = rm,
+                  tabledata Charlie = ri;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50102 Charlie
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/InherentPermissionsUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/InherentPermissionsUppercase.al
@@ -1,0 +1,9 @@
+[||]table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    InherentPermissions = RIMD;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/LowercaseCodeunit.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/LowercaseCodeunit.al
@@ -1,0 +1,23 @@
+[||]codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = rimd,
+                  tabledata Bravo = r;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/LowercaseExecute.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/LowercaseExecute.al
@@ -1,0 +1,13 @@
+[||]codeunit 50100 "My Codeunit"
+{
+    Permissions = tabledata Alpha = x;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/NoPermissionsProperty.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/NoPermissionsProperty.al
@@ -1,0 +1,3 @@
+[||]codeunit 50100 "My Codeunit"
+{
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/ObsoleteCodeunit.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/ObsoleteCodeunit.al
@@ -1,0 +1,15 @@
+[||]codeunit 50100 "My Codeunit"
+{
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Deprecated';
+    Permissions = tabledata Alpha = RIMD;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/PermissionSetExtensionUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/PermissionSetExtensionUppercase.al
@@ -1,0 +1,21 @@
+[||]permissionset 50100 "Base Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    Permissions = tabledata Alpha = r;
+}
+
+permissionsetextension 50100 "My Extension" extends "Base Permission Set"
+{
+    Permissions = tabledata Alpha = RIMD;
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/PermissionSetUppercase.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/PermissionSetUppercase.al
@@ -1,0 +1,21 @@
+[||]permissionset 50100 "My Permission Set"
+{
+    Assignable = false;
+    Access = Public;
+
+    Permissions = tabledata Alpha = RIMD,
+                  codeunit "Target Codeunit" = X;
+}
+
+codeunit 50101 "Target Codeunit"
+{
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
@@ -6,6 +6,7 @@ namespace ALCops.FormattingCop.Test
     public class PermissionValuesShouldBeLowercase : NavCodeAnalysisBase
     {
         private AnalyzerTestFixture _fixture;
+        private AnalyzerTestFixture _errorTolerantFixture;
         private static readonly Analyzers.PermissionValuesShouldBeLowercase _analyzer = new();
         private string _testCasePath;
 
@@ -13,6 +14,14 @@ namespace ALCops.FormattingCop.Test
         public void Setup()
         {
             _fixture = RoslynFixtureFactory.Create<Analyzers.PermissionValuesShouldBeLowercase>();
+
+            // The compiler rejects execute permission values (X/x) in the object-level
+            // Permissions property (AL0195), so fixtures containing them cannot compile cleanly.
+            _errorTolerantFixture = RoslynFixtureFactory.Create<Analyzers.PermissionValuesShouldBeLowercase>(
+                new AnalyzerTestFixtureConfig
+                {
+                    ThrowsWhenInputDocumentContainsError = false
+                });
 
             _testCasePath = Path.Combine(
                 Directory.GetParent(
@@ -39,6 +48,16 @@ namespace ALCops.FormattingCop.Test
         }
 
         [Test]
+        [TestCase("ExecuteUppercase")]
+        public async Task HasDiagnosticInDocumentWithErrors(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _errorTolerantFixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
         [TestCase("LowercaseCodeunit")]
         [TestCase("PermissionSetUppercase")]
         [TestCase("PermissionSetExtensionUppercase")]
@@ -51,6 +70,16 @@ namespace ALCops.FormattingCop.Test
                 .ConfigureAwait(false);
 
             _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
+        [TestCase("LowercaseExecute")]
+        public async Task NoDiagnosticInDocumentWithErrors(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _errorTolerantFixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
         }
 
         [Test]
@@ -69,6 +98,26 @@ namespace ALCops.FormattingCop.Test
                 new CodeFixTestFixtureConfig
                 {
                     AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
+        [TestCase("ExecuteValue")]
+        public async Task HasFixInDocumentWithErrors(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<PermissionValuesShouldBeLowercaseCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer],
+                    ThrowsWhenInputDocumentContainsError = false
                 });
 
             fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.PermissionValuesShouldBeLowercase);

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
@@ -60,24 +60,17 @@ namespace ALCops.FormattingCop.Test
         [Test]
         [TestCase("LowercaseCodeunit")]
         [TestCase("PermissionSetUppercase")]
+        [TestCase("PermissionSetExtensionUppercase")]
         [TestCase("InherentPermissionsUppercase")]
         [TestCase("NoPermissionsProperty")]
         [TestCase("ObsoleteCodeunit")]
         public async Task NoDiagnostic(string testCase)
         {
-            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
-                .ConfigureAwait(false);
-
-            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
-        }
-
-        [Test]
-        [TestCase("PermissionSetExtensionUppercase")]
-        public async Task NoDiagnosticOnPermissionSetExtension(string testCase)
-        {
-            RequireMinimumVersion(
+            SkipTestIfVersionIsTooLow(
+                ["PermissionSetExtensionUppercase"],
+                testCase,
                 "13.0",
-                "Older SDKs reject the permission set extension fixture with AL0334 (extension target already declared in this module)");
+                "No support for permissionsetextensions when target itself is already declared in the same module");
 
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
@@ -1,0 +1,77 @@
+using ALCops.FormattingCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.FormattingCop.Test
+{
+    public class PermissionValuesShouldBeLowercase : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.PermissionValuesShouldBeLowercase _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.PermissionValuesShouldBeLowercase>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(PermissionValuesShouldBeLowercase)));
+        }
+
+        [Test]
+        [TestCase("CodeunitUppercase")]
+        [TestCase("CodeunitMixedCase")]
+        [TestCase("TableUppercase")]
+        [TestCase("PageUppercase")]
+        [TestCase("ReportUppercase")]
+        [TestCase("XmlPortUppercase")]
+        [TestCase("QueryUppercase")]
+        [TestCase("RequestPageUppercase")]
+        [TestCase("MultipleEntriesOneUppercase")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
+        [TestCase("LowercaseCodeunit")]
+        [TestCase("PermissionSetUppercase")]
+        [TestCase("PermissionSetExtensionUppercase")]
+        [TestCase("InherentPermissionsUppercase")]
+        [TestCase("NoPermissionsProperty")]
+        [TestCase("ObsoleteCodeunit")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
+        [TestCase("LowercaseAllValues")]
+        [TestCase("MixedCaseValue")]
+        [TestCase("MultipleEntries")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<PermissionValuesShouldBeLowercaseCodeFixProvider>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.PermissionValuesShouldBeLowercase);
+        }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
@@ -60,12 +60,25 @@ namespace ALCops.FormattingCop.Test
         [Test]
         [TestCase("LowercaseCodeunit")]
         [TestCase("PermissionSetUppercase")]
-        [TestCase("PermissionSetExtensionUppercase")]
         [TestCase("InherentPermissionsUppercase")]
         [TestCase("NoPermissionsProperty")]
         [TestCase("ObsoleteCodeunit")]
         public async Task NoDiagnostic(string testCase)
         {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.PermissionValuesShouldBeLowercase);
+        }
+
+        [Test]
+        [TestCase("PermissionSetExtensionUppercase")]
+        public async Task NoDiagnosticOnPermissionSetExtension(string testCase)
+        {
+            RequireMinimumVersion(
+                "13.0",
+                "Older SDKs reject the permission set extension fixture with AL0334 (extension target already declared in this module)");
+
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
                 .ConfigureAwait(false);
 

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -166,7 +166,7 @@
     <value>Permission values should be lowercase</value>
   </data>
   <data name="PermissionValuesShouldBeLowercaseMessageFormat" xml:space="preserve">
-    <value>The Permissions property contains uppercase permission values; use lowercase 'r', 'i', 'm' and 'd' instead.</value>
+    <value>The Permissions property contains uppercase permission values; use lowercase 'r', 'i', 'm', 'd' and 'x' instead.</value>
   </data>
   <data name="PermissionValuesShouldBeLowercaseDescription" xml:space="preserve">
     <value>In the Permissions property, the casing of permission values has no runtime effect; both uppercase and lowercase grant the same indirect permission. Uppercase values wrongly suggest that direct permissions are granted, a semantic that only exists in permissionset objects and the InherentPermissions property. Use lowercase values to avoid wrong expectations.</value>

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -162,6 +162,18 @@
   <data name="PermissionDeclarationOrderCodeAction" xml:space="preserve">
     <value>ALCops: Sort permission declarations alphabetically</value>
   </data>
+  <data name="PermissionValuesShouldBeLowercaseTitle" xml:space="preserve">
+    <value>Permission values should be lowercase</value>
+  </data>
+  <data name="PermissionValuesShouldBeLowercaseMessageFormat" xml:space="preserve">
+    <value>The Permissions property contains uppercase permission values; use lowercase 'r', 'i', 'm' and 'd' instead.</value>
+  </data>
+  <data name="PermissionValuesShouldBeLowercaseDescription" xml:space="preserve">
+    <value>In the Permissions property, the casing of permission values has no runtime effect; both uppercase and lowercase grant the same indirect permission. Uppercase values wrongly suggest that direct permissions are granted, a semantic that only exists in permissionset objects and the InherentPermissions property. Use lowercase values to avoid wrong expectations.</value>
+  </data>
+  <data name="PermissionValuesShouldBeLowercaseCodeAction" xml:space="preserve">
+    <value>ALCops: Convert permission values to lowercase</value>
+  </data>
   <data name="AnalyzerExceptionTitle" xml:space="preserve">
     <value>Analyzer threw an unhandled exception</value>
   </data>

--- a/src/ALCops.FormattingCop/Analyzers/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop/Analyzers/PermissionValuesShouldBeLowercase.cs
@@ -1,0 +1,79 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace ALCops.FormattingCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class PermissionValuesShouldBeLowercase : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.PermissionValuesShouldBeLowercase);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSyntaxNodeAction(
+            AnalyzePermissionPropertyValue,
+            EnumProvider.SyntaxKind.PermissionPropertyValue);
+
+    private static void AnalyzePermissionPropertyValue(SyntaxNodeAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Node is not PermissionPropertyValueSyntax permissionValue)
+            return;
+
+        // In permissionset objects the casing of permission values is semantic:
+        // uppercase grants direct permissions, lowercase grants indirect permissions.
+        if (IsInPermissionSetObject(permissionValue))
+            return;
+
+        if (!HasUppercasePermissionValue(permissionValue))
+            return;
+
+        // Report on the PropertySyntax so the CodeFix can find it
+        var location = (permissionValue.Parent ?? permissionValue).GetLocation();
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.PermissionValuesShouldBeLowercase,
+            location));
+    }
+
+    private static bool IsInPermissionSetObject(SyntaxNode node)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            var kind = ancestor.Kind;
+            if (kind == EnumProvider.SyntaxKind.PermissionSet ||
+                kind == EnumProvider.SyntaxKind.PermissionSetExtension)
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool HasUppercasePermissionValue(PermissionPropertyValueSyntax permissionValue)
+    {
+        foreach (var permission in permissionValue.PermissionProperties)
+        {
+            if (ContainsUppercase(permission.Permissions.Text))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool ContainsUppercase(string? permissionValueText)
+    {
+        if (string.IsNullOrEmpty(permissionValueText))
+            return false;
+
+        foreach (var c in permissionValueText)
+        {
+            if (char.IsUpper(c))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ALCops.FormattingCop/CodeFixes/PermissionValuesShouldBeLowercaseCodeFixProvider.cs
+++ b/src/ALCops.FormattingCop/CodeFixes/PermissionValuesShouldBeLowercaseCodeFixProvider.cs
@@ -1,0 +1,99 @@
+using System.Collections.Immutable;
+using ALCops.FormattingCop.Analyzers;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.FormattingCop.CodeFixes;
+
+[CodeFixProvider(nameof(PermissionValuesShouldBeLowercaseCodeFixProvider))]
+public sealed class PermissionValuesShouldBeLowercaseCodeFixProvider : CodeFixProvider
+{
+    private class PermissionValuesShouldBeLowercaseCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+
+        public PermissionValuesShouldBeLowercaseCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument,
+            string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.PermissionValuesShouldBeLowercase.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        RegisterInstanceCodeFix(ctx, syntaxRoot, span, document);
+    }
+
+    private static void RegisterInstanceCodeFix(CodeFixContext ctx, SyntaxNode syntaxRoot,
+        TextSpan span, Document document)
+    {
+        var node = syntaxRoot.FindNode(span);
+        var propertySyntax = node as PropertySyntax
+            ?? node.FirstAncestorOrSelf<PropertySyntax>()
+            ?? node.DescendantNodes().OfType<PropertySyntax>().FirstOrDefault();
+        if (propertySyntax is null)
+            return;
+
+        ctx.RegisterCodeFix(
+            CreateCodeAction(propertySyntax, document, generateFixAll: true),
+            ctx.Diagnostics[0]);
+    }
+
+    private static PermissionValuesShouldBeLowercaseCodeAction CreateCodeAction(
+        PropertySyntax propertySyntax, Document document, bool generateFixAll)
+    {
+        return new PermissionValuesShouldBeLowercaseCodeAction(
+            FormattingCopAnalyzers.PermissionValuesShouldBeLowercaseCodeAction,
+            ct => ApplyFix(document, propertySyntax, ct),
+            nameof(PermissionValuesShouldBeLowercaseCodeFixProvider),
+            generateFixAll);
+    }
+
+    private static async Task<Document> ApplyFix(Document document,
+        PropertySyntax propertySyntax, CancellationToken cancellationToken)
+    {
+        if (propertySyntax.Value is not PermissionPropertyValueSyntax permissionValue)
+            return document;
+
+        var tokensToFix = new List<SyntaxToken>();
+        foreach (var permission in permissionValue.PermissionProperties)
+        {
+            var token = permission.Permissions;
+            if (PermissionValuesShouldBeLowercase.ContainsUppercase(token.Text))
+                tokensToFix.Add(token);
+        }
+
+        if (tokensToFix.Count == 0)
+            return document;
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var newRoot = root.ReplaceTokens(tokensToFix, (original, _) =>
+            SyntaxFactory.Identifier(original.Text.ToLowerInvariant())
+                .WithTriviaFrom(original));
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
@@ -46,6 +46,15 @@ public static class DiagnosticDescriptors
         description: FormattingCopAnalyzers.PermissionDeclarationOrderDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.PermissionDeclarationOrder));
 
+    public static readonly DiagnosticDescriptor PermissionValuesShouldBeLowercase = new(
+        id: DiagnosticIds.PermissionValuesShouldBeLowercase,
+        title: FormattingCopAnalyzers.PermissionValuesShouldBeLowercaseTitle,
+        messageFormat: FormattingCopAnalyzers.PermissionValuesShouldBeLowercaseMessageFormat,
+        category: Category.Style,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: FormattingCopAnalyzers.PermissionValuesShouldBeLowercaseDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.PermissionValuesShouldBeLowercase));
 
     public static readonly DiagnosticDescriptor AnalyzerException = new(
         id: DiagnosticIds.AnalyzerException,

--- a/src/ALCops.FormattingCop/DiagnosticIds.cs
+++ b/src/ALCops.FormattingCop/DiagnosticIds.cs
@@ -7,4 +7,5 @@ public static class DiagnosticIds
     public static readonly string CasingMismatch = "FC0002";
     public static readonly string UseParenthesisForFunctionCall = "FC0003";
     public static readonly string PermissionDeclarationOrder = "FC0004";
+    public static readonly string PermissionValuesShouldBeLowercase = "FC0006";
 }


### PR DESCRIPTION
## Summary

Implements a new FormattingCop rule **FC0006 `PermissionValuesShouldBeLowercase`** from discussion #383.

The `Permissions` property on application objects accepts permission values in any casing, but casing has no runtime meaning there. Uppercase `RIMD` falsely suggests direct permission grants, a semantic that only exists in `permissionset`/`permissionsetextension` objects and the `InherentPermissions` property. FC0006 flags uppercase values and ships a code fix that lowercases them.

## Scope decisions

- **Covered objects**: codeunit, table, page, report, requestpage, xmlport, query (all objects supporting the `Permissions` property).
- **Excluded**: `permissionset` / `permissionsetextension` objects and the `InherentPermissions` property — casing is semantic there (direct vs. indirect).
- **Granularity**: one diagnostic per `Permissions` property (matches FC0004).
- **Severity**: Info, Category Style (matches FC0004).
- Scope was posted for feedback on the discussion: [scope comment](https://github.com/ALCops/Analyzers/discussions/383#discussioncomment-17612104).

- **Execute permission (`X`) is covered**: the uppercase check applies to every permission value, including `X`, per rvanbekkum's feedback on the discussion.

## Notable finding

The AL compiler only accepts `tabledata` entries in the object-level `Permissions` property; non-tabledata entries (`codeunit X = X`) fail with `AL0104: Syntax error, 'tabledata' expected`, despite Microsoft Learn examples suggesting otherwise. Parser evidence: `ObjectParser` parses object-level permission lists with a `TableDataKeyword`-only predicate.

Consequence for `X` coverage: in FC0006's scope, `X` only occurs in code carrying a compile error (`AL0195` on tabledata entries; non-tabledata entries are dropped by parser error recovery and never reach the analyzer). The rule still flags and fixes `tabledata Foo = X`, and the generic uppercase check automatically covers non-tabledata entries should a future compiler legalize them. The `X` test cases use error-tolerant fixtures (`ThrowsWhenInputDocumentContainsError = false`), following the existing `ApplicationCop.Test/TestHelper.cs` pattern.

## Changes

- Analyzer `PermissionValuesShouldBeLowercase` (syntax-node action on `PermissionPropertyValue`, skips obsolete objects and permissionset ancestors)
- CodeFix `PermissionValuesShouldBeLowercaseCodeFixProvider` (lowercases all permission tokens, BatchFixer)
- `EnumProvider`: added `SyntaxKind.PermissionPropertyValue`
- 21 tests (10 HasDiagnostic, 7 NoDiagnostic, 4 HasFix)
- Instruction file + maintenance table row

## Testing

- `dotnet build ALCops.sln`: clean
- `dotnet test ALCops.sln`: all pass (FormattingCop.Test: 101, incl. 21 new FC0006 tests)

Documentation page for alcops.dev prepared separately.

Closes #383
