### PR TITLE
feat(FC0005): flag method calls written as assignments

### DIFF
--- a/.github/instructions/fc0005-use-parenthesis-for-method-assignment.instructions.md
+++ b/.github/instructions/fc0005-use-parenthesis-for-method-assignment.instructions.md
@@ -1,0 +1,97 @@
+---
+applyTo: 'src/ALCops.FormattingCop/**/UseParenthesisForMethodAssignment*'
+---
+
+# FC0005: Use parenthesis for method call instead of assignment syntax
+
+## Purpose
+
+Detects a method that takes a single parameter being invoked using assignment
+syntax (`target.Method := value;`) and recommends the explicit parenthesised
+call (`target.Method(value);`). The assignment form hides that a method is being
+called and is ambiguous; it would become more so if AL ever gains real object
+properties. Provides a CodeFix that rewrites the assignment into a parenthesised
+invocation.
+
+Applies to both built-in methods (e.g. `Rec.ReadIsolation := ...`,
+`currXMLport.TextEncoding := ...`) and user-defined procedures
+(e.g. `MyCodeunit.SetValue := 5`).
+
+## Diagnostic properties
+
+| Property | Value |
+|---|---|
+| ID | FC0005 |
+| Category | Design |
+| Severity | Warning |
+| Help URI | https://alcops.dev/docs/analyzers/formattingcop/fc0005/ |
+| CodeFix | Yes (rewrites `x.M := v;` to `x.M(v);`) |
+
+## How it works (SDK basis)
+
+`Binder.BindAssignmentStatement` (verified in `nav-sdk-source`): when an
+assignment's target binds to a `BoundCall` whose method has `ParameterCount == 1`,
+AL rebinds `target := source` as `target(source)` via
+`BindInvocationExpression(..., asProperty: true, ...)`. The result is a
+`BoundExpressionStatement` wrapping a `BoundCall`, which surfaces in the operation
+tree as an **`IInvocationExpression` whose `Syntax` is an `AssignmentStatementSyntax`**.
+The `BoundCall` carries the assignment statement as its syntax, so the diagnostic
+location is the whole statement (including the trailing semicolon).
+
+## Architecture
+
+```
+src/ALCops.FormattingCop/
+├── Analyzers/
+│   └── UseParenthesisForMethodAssignment.cs           # Analyzer (OperationAction)
+└── CodeFixes/
+    └── UseParenthesisForMethodAssignment.cs           # CodeFix (assignment -> invocation)
+```
+
+### Analysis flow
+
+1. `RegisterOperationAction` on `OperationKind.InvocationExpression` (same pattern
+   as the sibling rule FC0003 `UseParenthesisForFunctionCall`).
+2. `ctx.IsObsolete()` guard.
+3. Keep only invocations whose `Syntax.IsKind(AssignmentStatement)` — this is the
+   assignment-as-method-call form. Normal invocations (`x.M(v)`) have
+   `InvocationExpression` syntax and are rejected cheaply.
+4. Exclude `MethodKind.Property` (see design decision below).
+5. Report at `invocation.Syntax.GetLocation()` with `TargetMethod.Name`.
+
+### CodeFix flow
+
+`FindNode(span)` returns the `AssignmentStatementSyntax`. It is rewritten into an
+`ExpressionStatementSyntax` containing
+`InvocationExpression(Target, ArgumentList().AddArguments(Source))`. Target and
+Source are taken `WithoutTrivia()`; the new statement re-applies the original
+statement's leading trivia (indentation) and reuses the original `SemicolonToken`
+(which carries the trailing newline).
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| New rule (FC0005), not an extension of FC0003 | FC0003 covers the no-paren no-arg *call* form (`Rec.LockTable;`); the syntax shape and CodeFix differ. |
+| Cover built-in methods and user procedures | Both compile via the same single-parameter assignment binding; the discussion (#235) requests both. |
+| `MethodKind.Property` exclusion is **defensive** | Genuine properties (`SynthesizedPropertySymbol`) are getters with **0 parameters**, so they never match the single-parameter assignment binding and cannot reach this analyzer today. The guard prevents a false positive (and an invalid `prop(value)` fix, which would raise `ERR_PropertyUsedAsMethod`) if the SDK ever exposes a settable property. |
+| `RegisterOperationAction(InvocationExpression)` | Consistent with FC0003. The operation is already built; the syntax-kind filter is a cheap early reject. |
+| Report on the whole assignment statement | That is the `BoundCall`'s syntax; matches the natural fixable span. |
+
+## Known issues / limitations
+
+- Compound assignments (`+=`, `-=`, ...) do not trigger the single-parameter
+  method rewrite in the binder and are out of scope.
+- `TextEncoding` (xmlport `currXMLport`) and `ReadIsolation` (record) are built-in
+  methods, not properties — FC0005 correctly flags their assignment form. (FC0003's
+  NoDiagnostic fixtures use the assignment form of `TextEncoding` only because
+  FC0003 targets a different shape.)
+
+## Test coverage
+
+**HasDiagnostic (3 cases):** BuiltInMethod, BuiltInMethodOnXmlport, UserProcedure.
+**NoDiagnostic (2 cases):** AlreadyParenthesised, FieldAndVariableAssignment.
+**HasFix (2 cases):** BuiltInMethod, UserProcedure.
+
+The `MethodKind.Property` exclusion is intentionally not covered by a NoDiagnostic
+fixture: no settable property exists in the current SDK to exercise it.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -94,6 +94,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `sdk-analyzer-infrastructure` | `'src/ALCops.*/Analyzers/**'` | NAV SDK internals: callback ordering, incremental compilation, GetOperation perf |
 | `analyzer-exception-harness` | `'src/ALCops.Common/Diagnostics/**'` | XX0000 harness: base class + context decorators that convert analyzer exceptions into located diagnostics |
 | `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
+| `fc0005-use-parenthesis-for-method-assignment` | rule-scoped | FC0005 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -318,11 +318,14 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.Method)));
        private static readonly Lazy<NavCodeAnalysis.MethodKind> _trigger =
             new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.Trigger)));
+        private static readonly Lazy<NavCodeAnalysis.MethodKind> _property =
+            new(() => ParseEnum<NavCodeAnalysis.MethodKind>(nameof(NavCodeAnalysis.MethodKind.Property)));
 
 
         public static NavCodeAnalysis.MethodKind BuiltInMethod => _builtInMethod.Value;
         public static NavCodeAnalysis.MethodKind Method => _method.Value;
         public static NavCodeAnalysis.MethodKind Trigger => _trigger.Value;
+        public static NavCodeAnalysis.MethodKind Property => _property.Value;
     }
     /// <summary>
     /// NavTypeKind enum values

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/BuiltInMethod.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/BuiltInMethod.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.ReadIsolation := IsolationLevel::ReadCommitted;|]
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/BuiltInMethodOnXmlport.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/BuiltInMethodOnXmlport.al
@@ -1,0 +1,7 @@
+xmlport 50100 MyXmlport
+{
+    trigger OnInitXmlPort()
+    begin
+        [|currXMLport.TextEncoding := TextEncoding::Windows;|]
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/UserProcedure.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasDiagnostic/UserProcedure.al
@@ -1,0 +1,16 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyOther: Codeunit MyOther;
+    begin
+        [|MyOther.SetValue := 5;|]
+    end;
+}
+
+codeunit 50101 MyOther
+{
+    procedure SetValue(NewValue: Integer)
+    begin
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/BuiltInMethod/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/BuiltInMethod/current.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.ReadIsolation := IsolationLevel::ReadCommitted;|]
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/BuiltInMethod/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/BuiltInMethod/expected.al
@@ -1,0 +1,17 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        MyTable.ReadIsolation(IsolationLevel::ReadCommitted);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/UserProcedure/current.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/UserProcedure/current.al
@@ -1,0 +1,16 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyOther: Codeunit MyOther;
+    begin
+        [|MyOther.SetValue := 5;|]
+    end;
+}
+
+codeunit 50101 MyOther
+{
+    procedure SetValue(NewValue: Integer)
+    begin
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/UserProcedure/expected.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/HasFix/UserProcedure/expected.al
@@ -1,0 +1,16 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyOther: Codeunit MyOther;
+    begin
+        MyOther.SetValue(5);
+    end;
+}
+
+codeunit 50101 MyOther
+{
+    procedure SetValue(NewValue: Integer)
+    begin
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/NoDiagnostic/AlreadyParenthesised.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/NoDiagnostic/AlreadyParenthesised.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyOther: Codeunit MyOther;
+    begin
+        [|MyTable.ReadIsolation(IsolationLevel::ReadCommitted)|];
+        [|MyOther.SetValue(5)|];
+    end;
+}
+
+codeunit 50101 MyOther
+{
+    procedure SetValue(NewValue: Integer)
+    begin
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/NoDiagnostic/FieldAndVariableAssignment.al
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/NoDiagnostic/FieldAndVariableAssignment.al
@@ -1,0 +1,19 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        i: Integer;
+    begin
+        [|MyTable.MyField := 5|];
+        [|i := 5|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/UseParenthesisForMethodAssignment.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/UseParenthesisForMethodAssignment/UseParenthesisForMethodAssignment.cs
@@ -1,0 +1,66 @@
+using ALCops.FormattingCop.CodeFixes;
+using RoslynTestKit;
+
+namespace ALCops.FormattingCop.Test
+{
+    public class UseParenthesisForMethodAssignment : NavCodeAnalysisBase
+    {
+        private AnalyzerTestFixture _fixture;
+        private static readonly Analyzers.UseParenthesisForMethodAssignment _analyzer = new();
+        private string _testCasePath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = RoslynFixtureFactory.Create<Analyzers.UseParenthesisForMethodAssignment>();
+
+            _testCasePath = Path.Combine(
+                Directory.GetParent(
+                    Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+                    Path.Combine("Rules", nameof(UseParenthesisForMethodAssignment)));
+        }
+
+        [Test]
+        [TestCase("BuiltInMethod")]
+        [TestCase("BuiltInMethodOnXmlport")]
+        [TestCase("UserProcedure")]
+        public async Task HasDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.UseParenthesisForMethodAssignment);
+        }
+
+        [Test]
+        [TestCase("AlreadyParenthesised")]
+        [TestCase("FieldAndVariableAssignment")]
+        public async Task NoDiagnostic(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                 .ConfigureAwait(false);
+
+            _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.UseParenthesisForMethodAssignment);
+        }
+
+        [Test]
+        [TestCase("BuiltInMethod")]
+        [TestCase("UserProcedure")]
+        public async Task HasFix(string testCase)
+        {
+            var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
+                .ConfigureAwait(false);
+
+            var expectedCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "expected.al"))
+                .ConfigureAwait(false);
+
+            var fixture = RoslynFixtureFactory.Create<UseParenthesisForMethodAssignmentCodeFix>(
+                new CodeFixTestFixtureConfig
+                {
+                    AdditionalAnalyzers = [_analyzer]
+                });
+
+            fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.UseParenthesisForMethodAssignment);
+        }
+    }
+}

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -150,6 +150,18 @@
   <data name="UseParenthesisForFunctionCallCodeAction" xml:space="preserve">
     <value>Add parenthesis</value>
   </data>
+  <data name="UseParenthesisForMethodAssignmentTitle" xml:space="preserve">
+    <value>Call methods with parenthesis instead of using assignment syntax</value>
+  </data>
+  <data name="UseParenthesisForMethodAssignmentMessageFormat" xml:space="preserve">
+    <value>Call method '{0}' using parenthesis instead of assignment syntax.</value>
+  </data>
+  <data name="UseParenthesisForMethodAssignmentDescription" xml:space="preserve">
+    <value>A method that takes a single parameter can be invoked using assignment syntax, but this hides that a method is being called and is ambiguous. Call the method using parenthesis instead.</value>
+  </data>
+  <data name="UseParenthesisForMethodAssignmentCodeAction" xml:space="preserve">
+    <value>Use parenthesis for method call</value>
+  </data>
   <data name="PermissionDeclarationOrderTitle" xml:space="preserve">
     <value>Permission declarations should be ordered alphabetically</value>
   </data>

--- a/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCopAnalyzers.resx
@@ -148,7 +148,7 @@
     <value>Use parenthesis in a function call even if the function does not have any parameters.</value>
   </data>
   <data name="UseParenthesisForFunctionCallCodeAction" xml:space="preserve">
-    <value>Add parenthesis</value>
+    <value>ALCops: Add parenthesis</value>
   </data>
   <data name="UseParenthesisForMethodAssignmentTitle" xml:space="preserve">
     <value>Call methods with parenthesis instead of using assignment syntax</value>
@@ -160,7 +160,7 @@
     <value>A method that takes a single parameter can be invoked using assignment syntax, but this hides that a method is being called and is ambiguous. Call the method using parenthesis instead.</value>
   </data>
   <data name="UseParenthesisForMethodAssignmentCodeAction" xml:space="preserve">
-    <value>Use parenthesis for method call</value>
+    <value>ALCops: Use parenthesis for method call</value>
   </data>
   <data name="PermissionDeclarationOrderTitle" xml:space="preserve">
     <value>Permission declarations should be ordered alphabetically</value>

--- a/src/ALCops.FormattingCop/Analyzers/UseParenthesisForMethodAssignment.cs
+++ b/src/ALCops.FormattingCop/Analyzers/UseParenthesisForMethodAssignment.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace ALCops.FormattingCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class UseParenthesisForMethodAssignment : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UseParenthesisForMethodAssignment);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterOperationAction(
+            AnalyzeInvocationExpression,
+            EnumProvider.OperationKind.InvocationExpression);
+
+    private void AnalyzeInvocationExpression(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsolete() || ctx.Operation is not IInvocationExpression invocation)
+            return;
+
+        // A single-parameter method invoked using assignment syntax (target := source)
+        // binds to an invocation whose syntax is an assignment statement.
+        if (!invocation.Syntax.IsKind(EnumProvider.SyntaxKind.AssignmentStatement))
+            return;
+
+        // Genuine property members (MethodKind.Property) are getters with no parameters,
+        // so they cannot bind to this single-parameter assignment form in practice. This guard
+        // is defensive: it prevents a false positive (and an invalid code fix) should the SDK
+        // ever expose a settable property, which must be invoked using assignment syntax.
+        if (invocation.TargetMethod is not IMethodSymbol method ||
+            method.MethodKind == EnumProvider.MethodKind.Property)
+            return;
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.UseParenthesisForMethodAssignment,
+            invocation.Syntax.GetLocation(),
+            method.Name));
+    }
+}

--- a/src/ALCops.FormattingCop/CodeFixes/UseParenthesisForMethodAssignment.cs
+++ b/src/ALCops.FormattingCop/CodeFixes/UseParenthesisForMethodAssignment.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+
+namespace ALCops.FormattingCop.CodeFixes;
+
+[CodeFixProvider(nameof(UseParenthesisForMethodAssignmentCodeFix))]
+public sealed class UseParenthesisForMethodAssignmentCodeFix : CodeFixProvider
+{
+    private class UseParenthesisForMethodAssignmentCodeAction : CodeAction.DocumentChangeAction
+    {
+        public override CodeActionKind Kind => CodeActionKind.QuickFix;
+        public override bool SupportsFixAll { get; }
+        public override string? FixAllSingleInstanceTitle => string.Empty;
+        public override string? FixAllTitle => Title;
+
+        public UseParenthesisForMethodAssignmentCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey, bool generateFixAll)
+            : base(title, createChangedDocument, equivalenceKey)
+        {
+            SupportsFixAll = generateFixAll;
+        }
+    }
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.UseParenthesisForMethodAssignment.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext ctx)
+    {
+        Document document = ctx.Document;
+        TextSpan span = ctx.Span;
+        CancellationToken cancellationToken = ctx.CancellationToken;
+
+        SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (syntaxRoot is null)
+            return;
+
+        SyntaxNode node = syntaxRoot.FindNode(span);
+        if (node is not AssignmentStatementSyntax assignment)
+            return;
+
+        ctx.RegisterCodeFix(CreateCodeAction(assignment, document, generateFixAll: true), ctx.Diagnostics[0]);
+    }
+
+    private static UseParenthesisForMethodAssignmentCodeAction CreateCodeAction(
+        AssignmentStatementSyntax assignment, Document document, bool generateFixAll)
+    {
+        return new UseParenthesisForMethodAssignmentCodeAction(
+            FormattingCopAnalyzers.UseParenthesisForMethodAssignmentCodeAction,
+            ct => UseParenthesisForMethodCall(document, assignment, ct),
+            nameof(UseParenthesisForMethodAssignmentCodeFix),
+            generateFixAll);
+    }
+
+    private static async Task<Document> UseParenthesisForMethodCall(
+        Document document, AssignmentStatementSyntax assignment, CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        CodeExpressionSyntax target = assignment.Target.WithoutTrivia();
+        CodeExpressionSyntax argument = assignment.Source.WithoutTrivia();
+
+        InvocationExpressionSyntax invocation = SyntaxFactory.InvocationExpression(
+            target,
+            SyntaxFactory.ArgumentList().AddArguments(argument));
+
+        ExpressionStatementSyntax newStatement = SyntaxFactory
+            .ExpressionStatement(invocation, assignment.SemicolonToken)
+            .WithLeadingTrivia(assignment.GetLeadingTrivia());
+
+        SyntaxNode newRoot = root.ReplaceNode(assignment, newStatement);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.FormattingCop/DiagnosticDescriptors.cs
@@ -36,6 +36,16 @@ public static class DiagnosticDescriptors
         description: FormattingCopAnalyzers.UseParenthesisForFunctionCallDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.UseParenthesisForFunctionCall));
 
+    public static readonly DiagnosticDescriptor UseParenthesisForMethodAssignment = new(
+        id: DiagnosticIds.UseParenthesisForMethodAssignment,
+        title: FormattingCopAnalyzers.UseParenthesisForMethodAssignmentTitle,
+        messageFormat: FormattingCopAnalyzers.UseParenthesisForMethodAssignmentMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: FormattingCopAnalyzers.UseParenthesisForMethodAssignmentDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.UseParenthesisForMethodAssignment));
+
     public static readonly DiagnosticDescriptor PermissionDeclarationOrder = new(
         id: DiagnosticIds.PermissionDeclarationOrder,
         title: FormattingCopAnalyzers.PermissionDeclarationOrderTitle,

--- a/src/ALCops.FormattingCop/DiagnosticIds.cs
+++ b/src/ALCops.FormattingCop/DiagnosticIds.cs
@@ -7,4 +7,5 @@ public static class DiagnosticIds
     public static readonly string CasingMismatch = "FC0002";
     public static readonly string UseParenthesisForFunctionCall = "FC0003";
     public static readonly string PermissionDeclarationOrder = "FC0004";
+    public static readonly string UseParenthesisForMethodAssignment = "FC0005";
 }


### PR DESCRIPTION
## Summary

Adds FormattingCop rule **FC0005 UseParenthesisForMethodAssignment**: detects a single-parameter method invoked using assignment syntax (`target.Method := value`) and recommends the parenthesised call (`target.Method(value)`). Covers built-in methods and user-defined procedures; genuine `MethodKind.Property` members are excluded defensively. Includes a CodeFix (with FixAll) and tests.

Also prefixes the FC0003 and FC0005 code action titles with `ALCops: ` for consistency with the other cops.

Closes #235

## Testing

- `dotnet build ALCops.sln` – 0 errors
- `dotnet test src/ALCops.FormattingCop.Test/` – 90/90 passed (includes 3 HasDiagnostic, 2 NoDiagnostic, 2 HasFix cases for FC0005)