### PR TITLE
fix(lc0083): suppress false positive on FieldRef.Value

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -96,6 +96,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
 | `fc0005-use-parenthesis-for-method-assignment` | rule-scoped | FC0005 rule |
 | `fc0006-permission-values-should-be-lowercase` | rule-scoped | FC0006 rule |
+| `lc0083-built-in-date-time-method` | rule-scoped | LC0083 rule |
 | `lc0086-page-style-string-literal` | rule-scoped | LC0086 rule |
 | `lc0091-translatable-text-should-be-translated` | rule-scoped | LC0091 rule |
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |

--- a/.github/instructions/lc0083-built-in-date-time-method.instructions.md
+++ b/.github/instructions/lc0083-built-in-date-time-method.instructions.md
@@ -1,0 +1,57 @@
+---
+applyTo: 'src/ALCops.LinterCop/**/BuiltInDateTimeMethod*'
+---
+
+# LC0083: BuiltInDateTimeMethod
+
+## Purpose
+
+Detects calls to outdated built-in date/time functions (`Date2DMY`, `Date2DWY`, `DT2Date`, `DT2Time`, `Format(... , 0, '<HOURS24|MINUTES|SECONDS|THOUSANDS>')`) and suggests the modern extension methods on `Date`, `Time`, and `DateTime` values (`.Date()`, `.Time()`, `.Day()`, `.Month()`, `.Year()`, `.DayOfWeek()`, `.WeekNo()`, `.Hour()`, `.Minute()`, `.Second()`, `.Millisecond()`). Ships with `BuiltInDateTimeMethodCodeFixProvider`.
+
+## Diagnostic properties
+
+**LC0083** · Category: Design · Severity: Warning · Enabled: true
+Message: `Use the new method {0}.{1} to extract specific parts of date/time values.`
+Version gate: `Fall2024OrGreater` (extension methods introduced in BC25) · CodeFix: yes
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Registration | `RegisterOperationAction` on `InvocationExpression` | Analyzer works on invocation operations, not raw syntax |
+| Method filter | `MethodKind == BuiltInMethod` | Cheap early exit; user-defined methods are never candidates |
+| Replacement selection | Static `switch` in `GetReplacementMethod` keyed by method name (+ arg count where relevant) | Deterministic mapping; no reflection or metadata lookup |
+| `Date2DWY(x, 3)` no fix | Returns `null` on purpose | Year part of `Date2DWY` can disagree with `.Year()` in ISO weeks spanning two years — silent skip is safer than incorrect fix |
+| Guard order | `IsFieldRefValueAccess` → `IsVariantOrJokerArgument` → replacement | FieldRef guard is a specific case; variant/joker guard is the general fallback; both must run before replacement generation |
+| `IsVariantOrJokerArgument` | Skip when type is `Variant` **or** `Joker` | `FieldRef.Value` returns `NavTypeKind.Joker` (AL wildcard), **not** `Variant`. Without the Joker branch the analyzer would emit invalid `.Date()`/`.Time()` suggestions for dynamic values |
+| `IsFieldRefValueAccess` | Explicit `.Value`-on-FieldRef guard (belt & suspenders alongside the Joker check) | Defensive redundancy: even if a future SDK version stopped typing `.Value` as `Joker`, this guard still catches the case via the operation shape |
+| `IsFieldRefValueAccess` operation shapes | Both `IInvocationExpression` **and** `IFieldAccess` | Current SDK models `FieldRef.Value` as a getter invocation. `IFieldAccess` branch is intentionally defensive against future SDK versions remodelling it as a property/field access — must not be pruned as dead code |
+| `IsFieldRefValueAccess` member scope | Only `.Value` (via `IsSameName`) | Other FieldRef members (`.Name`, `.GetFilter()`, `.Number`, …) intentionally flow through the normal analysis path |
+| Diagnostic properties bag | `ReplacementMethodName` string only | Minimal state passed to the code fix; syntax reconstruction happens in the code fix itself |
+
+## Architecture
+
+### Analysis flow
+
+1. Skip obsolete symbols and non-invocation operations.
+2. Skip non-`BuiltInMethod` invocations and calls with zero arguments.
+3. `IsFieldRefValueAccess` — early return when the first argument is `.Value` on a `FieldRef` receiver.
+4. `IsVariantOrJokerArgument` — early return when the first argument's static type is `Variant` or `Joker`.
+5. `GetReplacementMethod` — map `(methodName, argCount, discriminator)` to a synthetic `InvocationExpressionSyntax`.
+6. Report LC0083 with the replacement carried in `ImmutableDictionary` properties for the code fix.
+
+### CodeFix
+
+`BuiltInDateTimeMethodCodeFixProvider` reads `ReplacementMethodName` from the diagnostic properties and rewrites `Outer(<arg>[, extras])` into `<arg>.Replacement()`. `arg` is preserved verbatim from the original source.
+
+## Test coverage
+
+**HasDiagnostic (9 cases):** Date2DMY, Date2DWY, DT2Date, DT2Time, DT2XOnRecordField, FormatHour, FormatMillisecond, FormatMinute, FormatSecond.
+**NoDiagnostic (8 cases):** VariantDT2Date, VariantDT2Time, VariantDate2DMY, VariantDate2DWY, VariantFormat, RecRefFieldRefDT2DateTime, FieldRefValueChained, FormatFieldRefValue.
+**HasFix (11 cases):** Date2DMY_Day, Date2DMY_Month, Date2DMY_Year, Date2DWY_DayOfWeek, Date2DWY_WeekNo, DT2Date, DT2Time, Format_Hour, Format_Minute, Format_Second, Format_Millisecond.
+
+## Known issues
+
+- **`FieldRef.Value` is not `Variant`, it is `Joker`.** The AL SDK exposes the dynamic result type of `FieldRef.Value` (and the like) as `NavTypeKind.Joker`, not `NavTypeKind.Variant`. A plain Variant check therefore misses these expressions. `IsVariantOrJokerArgument` covers both; `IsFieldRefValueAccess` is a defensive second line for the specific `.Value` case.
+- **`Date2DWY(x, 3)` intentionally unfixed.** For week-year splits (ISO week 1/52-53 straddling January), `Date2DWY`'s year output and `x.Year()` can differ. The mapping returns `null` to suppress the fix; the diagnostic is not reported for this combination either.
+- **Format reasoning is string-based.** `GetFormatReplacement` matches on the literal format string only. If someone writes `Format(TextVar, 0, '<HOURS24>')`, the analyzer would still propose `TextVar.Hour()` — nonsensical but pre-existing and unrelated to the FieldRef work. No planned change.

--- a/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/BuiltInDateTimeMethod.cs
+++ b/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/BuiltInDateTimeMethod.cs
@@ -25,6 +25,7 @@ namespace ALCops.LinterCop.Test
         [TestCase("Date2DWY")]
         [TestCase("DT2Date")]
         [TestCase("DT2Time")]
+        [TestCase("DT2XOnRecordField")]
         [TestCase("FormatHour")]
         [TestCase("FormatMillisecond")]
         [TestCase("FormatMinute")]
@@ -43,6 +44,9 @@ namespace ALCops.LinterCop.Test
         [TestCase("VariantDate2DMY")]
         [TestCase("VariantDate2DWY")]
         [TestCase("VariantFormat")]
+        [TestCase("RecRefFieldRefDT2DateTime")]
+        [TestCase("FieldRefValueChained")]
+        [TestCase("FormatFieldRefValue")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/HasDiagnostic/DT2XOnRecordField.al
+++ b/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/HasDiagnostic/DT2XOnRecordField.al
@@ -1,0 +1,22 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "My DateTime"; DateTime) { }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyDate: Date;
+        MyTime: Time;
+    begin
+        MyTable.FindFirst();
+
+        MyDate := [|DT2Date(MyTable."My DateTime")|];
+        MyTime := [|DT2Time(MyTable."My DateTime")|];
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/FieldRefValueChained.al
+++ b/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/FieldRefValueChained.al
@@ -1,0 +1,23 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "My DateTime"; DateTime) { }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyRecRef: RecordRef;
+        MyDate: Date;
+    begin
+        MyTable.FindFirst();
+
+        MyRecRef.GetTable(MyTable);
+
+        MyDate := [|DT2Date(MyRecRef.Field(1).Value)|];
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/FormatFieldRefValue.al
+++ b/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/FormatFieldRefValue.al
@@ -1,0 +1,25 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "My DateTime"; DateTime) { }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyRecRef: RecordRef;
+        MyFieldRef: FieldRef;
+        MyText: Text;
+    begin
+        MyTable.FindFirst();
+
+        MyRecRef.GetTable(MyTable);
+        MyFieldRef := MyRecRef.Field(1);
+
+        MyText := [|Format(MyFieldRef.Value, 0, '<HOURS24>')|];
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/RecRefFieldRefDT2DateTime.al
+++ b/src/ALCops.LinterCop.Test/Rules/BuiltInDateTimeMethod/NoDiagnostic/RecRefFieldRefDT2DateTime.al
@@ -1,0 +1,27 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; "My DateTime"; DateTime) { }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        MyRecRef: RecordRef;
+        MyFieldRef: FieldRef;
+        MyDate: Date;
+        MyTime: Time;
+    begin
+        MyTable.FindFirst();
+
+        MyRecRef.GetTable(MyTable);
+        MyFieldRef := MyRecRef.Field(1);
+
+        MyDate := [|DT2Date(MyFieldRef.Value)|];
+        MyTime := [|DT2Time(MyFieldRef.Value)|];
+    end;
+}

--- a/src/ALCops.LinterCop/Analyzers/BuiltInDateTimeMethod.cs
+++ b/src/ALCops.LinterCop/Analyzers/BuiltInDateTimeMethod.cs
@@ -35,7 +35,10 @@ public sealed class BuiltInDateTimeMethod : DiagnosticAnalyzer
         if (operation.Syntax is not InvocationExpressionSyntax invocationExpression)
             return;
 
-        if (IsVariantArgument(operation.Arguments[0]))
+        if (IsFieldReferenceValueAccess(operation.Arguments[0]))
+            return;
+
+        if (IsVariantOrJokerArgument(operation.Arguments[0]))
             return;
 
         InvocationExpressionSyntax? replacementMethod = GetReplacementMethod(operation.TargetMethod.Name, invocationExpression);
@@ -113,7 +116,7 @@ public sealed class BuiltInDateTimeMethod : DiagnosticAnalyzer
             SyntaxFactory.ArgumentList());
     }
 
-    private static bool IsVariantArgument(IArgument argument)
+    private static bool IsVariantOrJokerArgument(IArgument argument)
     {
         IOperation value = argument.Value;
 
@@ -125,6 +128,30 @@ public sealed class BuiltInDateTimeMethod : DiagnosticAnalyzer
             ?? value.GetSymbol()?.OriginalDefinition.GetTypeSymbol().GetNavTypeKindSafe()
             ?? EnumProvider.NavTypeKind.None;
 
-        return navTypeKind == EnumProvider.NavTypeKind.Variant;
+        return navTypeKind == EnumProvider.NavTypeKind.Variant
+            || navTypeKind == EnumProvider.NavTypeKind.Joker;
+    }
+
+    private static bool IsFieldReferenceValueAccess(IArgument argument)
+    {
+        IOperation value = argument.Value;
+
+        if (value is IConversionExpression conversion)
+            value = conversion.Operand;
+
+        // The AL SDK currently models `FieldRef.Value` as an IInvocationExpression
+        // (getter call). Guarding IFieldAccess as well defends against future SDK
+        // versions that could remodel the same construct as a field/property access.
+        var (instance, memberName) = value switch
+        {
+            IInvocationExpression invocation => (invocation.Instance, invocation.TargetMethod?.Name),
+            IFieldAccess fieldAccess => (fieldAccess.Instance, fieldAccess.FieldSymbol?.Name),
+            _ => ((IOperation?)null, (string?)null)
+        };
+
+        if (!memberName.IsSameName("Value"))
+            return false;
+
+        return instance?.Type?.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.FieldRef;
     }
 }


### PR DESCRIPTION
FieldRef.Value returns NavTypeKind.Joker (AL wildcard), not Variant, so IsVariantArgument missed it and the analyzer emitted an invalid replacement suggestion like `MyFieldRef.Value.Date()`.

- Extend the variant guard to also treat Joker as a skip (renamed to IsVariantOrJokerArgument).
- Add IsFieldRefValueAccess that matches `.Value` on a FieldRef receiver via IInvocationExpression (current SDK) or IFieldAccess (defensive).
- Restrict the FieldRef guard to the `Value` member using IsSameName so other FieldRef members are unaffected.
- Add fixtures: RecRefFieldRefDT2DateTime, FieldRefValueChained, FormatFieldRefValue (NoDiagnostic) and DT2XOnRecordField (HasDiagnostic).

Fixes #409