### PR TITLE
refactor(TranslationIdHelper): encapsulate translation-ID casing workaround

### DIFF
--- a/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
+++ b/.github/instructions/lc0091-translatable-text-should-be-translated.instructions.md
@@ -30,6 +30,7 @@ These decisions were made during the initial design and should be preserved unle
 | Severity | Warning | Missing translations directly affect user experience |
 | Extension root symbol | `ExtensionObjectFoldingUtilities.GetTranslationRootSymbol` SDK API | Fixes the multi-extension bug in the original rule; correctly handles all cases |
 | Translation ID generation | `LanguageFileUtilities` via **runtime reflection** (`GetTranslationFileId` on new SDKs, public 2-param `GetLanguageSymbolId` / `GetLabelTextConstLanguageSymbolId` on older SDKs) | The public methods gained an optional `useNamespaces` param in `18.0.38.52553`; C# bakes optional-param call sites at compile time, so a direct call breaks across SDK versions (see Known issues). Reflection picks the right method at runtime and supports namespace-aware IDs. |
+| Canonical property-name override | Passed only when `manifest.Runtime > RuntimeVersion.Spring2020CU1` (or runtime unknown → treat as "current") | Mirrors `SymbolExtensions.GetTranslationName`: the compiler uses `PropertyKind.ToString()` on new runtimes but source-cased `symbol.Name` on runtime ≤ 5.1. Unconditional override regresses legacy apps (source-cased hash ≠ canonical hash → false positive). Gate is applied on the LinterCop side; `TranslationIdHelper.ComputeTranslationId(nameOverride: null)` falls through to `symbol.Name`. |
 | ManifestHelper exception handling | Catch `FileNotFoundException` and treat as null manifest | `ManifestHelper.GetManifest` loads `Microsoft.Dynamics.Nav.Analyzers.Common` assembly via reflection; this assembly isn't present in test contexts |
 | Null manifest behavior | Proceed with analysis (don't skip) | Tests create minimal compilations without manifests; real projects always have manifests |
 | XLIFF caching | Load once in CompilationStartAction | Avoid re-parsing per symbol |
@@ -110,6 +111,27 @@ The SDK's `OperationExtensions.GetSymbol()` can throw `InvalidCastException` for
 
 `EnumProvider.SymbolKind.NamedType` was added for the label-const path (mirrors `GetLabelTextConstLanguageSymbolId`, which forces `SymbolKind.NamedType`).
 
+### Runtime ≤ 5.1: canonical property-name override must be gated
+
+The fix for the source-casing false positive (`Tooltip` vs `ToolTip`) forwarded a canonical `nameOverride: propertyKind.ToString()` unconditionally. That regresses apps with `manifest.Runtime ≤ Spring2020CU1` (5.1): on legacy runtimes the compiler hashes the **source-cased** `property.Name` (per `SymbolExtensions.GetTranslationName`), so the analyzer's canonical hash never matched the emitted XLIFF trans-unit ID → false-positive "missing translation".
+
+**Workaround:** compute `useCanonicalPropertyName = manifest?.Runtime is null || manifest.Runtime > RuntimeVersion.Spring2020CU1` at `CompilationStartAction`, thread it into `AnalyzeSymbol`/`AnalyzePageLikeSymbol`/`ReportTranslatableProperty`, and pass `nameOverride: null` (which lets the SDK use `symbol.Name`) on legacy runtimes. Unknown runtime defaults to "current", matching the SDK's `GetRuntimeVersionOrCurrent`.
+
+Regression tests (`HasDiagnosticLegacyRuntime`, `NoDiagnosticLegacyRuntime`) inject an `app.json` with `"runtime": "5.1"` and `"features": ["TranslationFile"]` into the `MemoryFileSystem`. The `features` entry is required — without `TranslationFile` (mapped from the raw string by `CompilerFeaturesExtensions.GetCompilerFeature`), `manifest.CompilerFeatures.ShouldGenerateTranslationFile()` returns `false` and the analyzer short-circuits before hashing anything, hiding the regression. The tests also require `Microsoft.Dynamics.Nav.Analyzers.Common.dll` in the test bin (added as `<Reference Private="True">` in the test csproj) so `ManifestHelper.GetManifest` can resolve the runtime-loaded assembly.
+
+### Canonical-name override mechanism (`TranslationIdHelper.ComputeTranslationId`)
+
+The `nameOverride` parameter is applied differently on new vs old SDKs; both paths are exercised by the same call site in the analyzer:
+
+- **New SDK (`GetTranslationFileId` present)**: the SDK method declares a `name` string parameter and builds the leaf trans-unit segment from that string — the leaf symbol's `Name` is never read. The override is applied by passing `nameOverride ?? symbol.Name` as the `name` argument. No symbol mutation. This is the preferred path.
+- **Old SDK fallback (public 2-param `GetLanguageSymbolId` / `GetLabelTextConstLanguageSymbolId`)**: these overloads accept only `(ISymbol, IRootTypeSymbol?)` and read `symbol.Name` internally, so there is no seam to inject an override. The helper temporarily rewrites the symbol's private `name` field via reflection (`FieldInfo.SetValue`) for the duration of the SDK call, then restores it in a `finally`. The field is cached per symbol type in a `ConcurrentDictionary<Type, FieldInfo?>` (`_nameFieldCache`) to keep reflection off the hot path.
+
+**Per-symbol locking:** the mutation window is serialized through a `ConditionalWeakTable<ISymbol, object>` (`_symbolLocks`) so no other call inside this helper reads the symbol during the swap. The weak-table binding lets the lock object be collected together with the symbol, avoiding a static-cache leak across compilations.
+
+**Caveats:**
+- Cross-analyzer races are **not** covered: other analyzers do not know about this lock and may read `symbol.Name` on a background thread while the field is temporarily overridden. Impact is bounded to a single method call in the same process and only occurs on SDKs older than the one that added `GetTranslationFileId`. If the override equals `symbol.Name` we skip the mutation entirely; the fast path is a plain reflected call.
+- The mutation targets `SourcePropertySymbol.name` (source-declared properties). Merged/synthesized property symbols may not expose the same private field. `_nameFieldCache` stores a nullable `FieldInfo`; when null the helper falls back to invoking the SDK method without mutation, accepting that the resulting ID will match the source-cased name (correct for legacy runtimes, potentially wrong for canonical-name callers on legacy SDKs — mitigated in practice because the canonical-override branch is only taken on runtime > 5.1, and modern SDKs use the mutation-free `GetTranslationFileId` path).
+
 ## Symbol kinds and translatable properties
 
 | Symbol Kind | Properties Checked |
@@ -138,10 +160,13 @@ This matches the AL compiler's XLIFF generation behavior exactly.
 **HasDiagnosticWithLanguagesToTranslateNoXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK"], no XLIFF files.
 **HasDiagnosticWithLanguagesToTranslatePartialXliff (1 case):** LocalLabel with LanguagesToTranslate=["da-DK","de-DE"], only da-DK XLIFF.
 **HasDiagnosticWithNamespaces (1 case):** NamespaceTableCaption (gated `RequireMinimumVersion("18.0.38.52553")`; `TranslationsWithNamespaces` feature enabled via `CompilationOptions.WithCompilerFeatures`, empty XLIFF → namespace-mode path reports).
-**NoDiagnostic (2 cases):** LockedLabel, LockedReportLabel.
+**HasDiagnosticLegacyRuntime (1 case):** LegacyRuntimePageControlToolTip (`app.json` runtime `5.1` + `features: ["TranslationFile"]`; XLIFF contains only the canonical-name hash `ToolTip=1295455071` while the compiler on legacy runtimes hashes source-cased `Tooltip=2001309823` → diagnostic. Regresses if the analyzer unconditionally overrides with the canonical name).
+**NoDiagnostic (3 cases):** LockedLabel, LockedReportLabel, PageAnalysisViewLockedCaption.
+**NoDiagnosticPropertyCasing (1 case):** PageControlToolTipWrongCasing (XLIFF contains the canonical `ToolTip` trans-unit ID; source-cased `Tooltip`/`TOOLTIP` in AL must not trigger on runtime > 5.1).
 **NoDiagnosticTranslated (1 case):** TranslatedReportLabel (XLIFF contains proper translation with matching trans-unit ID).
 **NoDiagnosticNoXliff (1 case):** No XLIFF files present, no LanguagesToTranslate setting.
 **NoDiagnosticWithNamespaces (1 case):** NamespaceTableCaptionTranslated (gated `RequireMinimumVersion("18.0.38.52553")`; translated XLIFF with the namespace-aware trans-unit ID `Namespace MyCompany.App - Table MyTable - Property Caption` → no false positive).
+**NoDiagnosticLegacyRuntime (1 case):** LegacyRuntimePageControlToolTip (`app.json` runtime `5.1` + `features: ["TranslationFile"]`; XLIFF contains the source-cased hash `Tooltip=2001309823` matching what the pre-Spring2020CU1 compiler emits → no false positive).
 
 ## Test infrastructure
 

--- a/src/ALCops.Common/Reflection/TranslationIdHelper.cs
+++ b/src/ALCops.Common/Reflection/TranslationIdHelper.cs
@@ -88,15 +88,12 @@ public static class TranslationIdHelper
     /// label-const fallback); <see langword="false"/> for properties and report labels.
     /// </param>
     /// <param name="nameOverride">
-    /// Optional canonical name to use in place of <c>symbol.Name</c> when building the ID (e.g.
-    /// <c>propertyKind.ToString() == "ToolTip"</c> for a source-cased "Tooltip"). Guarantees the
-    /// computed trans-unit ID matches the compiler-generated one regardless of the casing used in
-    /// source. The SDK's translation-ID methods hash the property/label name from the live symbol
-    /// instance (not from any string parameter they declare), so this helper temporarily rewrites
-    /// the symbol's private <c>name</c> field for the duration of the call and restores it in a
-    /// <c>finally</c>. No state leaks to subsequent callbacks. Applies to both the new-SDK
-    /// (<c>GetTranslationFileId</c>) and old-SDK (<c>GetLanguageSymbolId</c> /
-    /// <c>GetLabelTextConstLanguageSymbolId</c>) paths.
+    /// Canonical name to hash in place of <c>symbol.Name</c> for the leaf trans-unit segment
+    /// (e.g. <c>"ToolTip"</c> for a source-cased <c>"Tooltip"</c>). New-SDK path forwards it as
+    /// the <c>name</c> string parameter to <c>GetTranslationFileId</c> (no mutation). Old-SDK
+    /// fallback rewrites the symbol's private <c>name</c> field for the duration of the call and
+    /// restores it in <c>finally</c> (see <see cref="InvokeWithCanonicalName"/>). Pass
+    /// <see langword="null"/> to hash <c>symbol.Name</c> unchanged.
     /// </param>
     public static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst, string? nameOverride = null)
     {
@@ -105,10 +102,10 @@ public static class TranslationIdHelper
         {
             SymbolKind kind = isLabelConst ? EnumProvider.SymbolKind.NamedType : symbol.Kind;
             bool useNamespaces = GetUseTranslationsWithNamespaces(symbol);
+            string effectiveName = nameOverride ?? symbol.Name;
 
-            return InvokeWithCanonicalName(symbol, nameOverride,
-                () => translationFileId.Invoke(null,
-                    [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string);
+            return translationFileId.Invoke(null,
+                [effectiveName, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string;
         }
 
         MethodInfo? fallback = isLabelConst
@@ -120,26 +117,27 @@ public static class TranslationIdHelper
     }
 
     /// <summary>
-    /// Invokes <paramref name="compute"/> with the target <paramref name="symbol"/>'s private
-    /// <c>name</c> field temporarily replaced by <paramref name="nameOverride"/>, restoring the
-    /// original value in <c>finally</c>. Concurrent callers of this helper on the same symbol are
-    /// serialized through a per-symbol lock so no thread inside this helper observes the mutated
-    /// value across the SDK call boundary.
-    /// <para>
-    /// The SDK's internal <c>GetTranslationFileId</c> hashes the property/label name from the
-    /// live symbol instance rather than from the <c>name</c> string parameter it declares (the
-    /// parameter feeds only human-readable note segments). There is no public seam to override
-    /// the hashed name, so we mutate the private field on <c>SourcePropertySymbol</c> (or the
-    /// equivalent source symbol) around the call. All source symbols we hit follow the same
-    /// convention of storing the name in a single <c>name</c> field.
-    /// </para>
-    /// <para>
-    /// The per-symbol lock only synchronizes this helper's own callers. Other analyzers reading
-    /// <c>symbol.Name</c> concurrently do not participate and could still, in theory, observe the
-    /// canonical name during the mutation window. In practice this is limited to the diagnostic
-    /// message text (never to computed IDs or analysis decisions).
-    /// </para>
+    /// Old-SDK fallback helper: invokes <paramref name="compute"/> with the target symbol's
+    /// private <c>name</c> field temporarily replaced by <paramref name="nameOverride"/> and
+    /// restored in <c>finally</c>. Short-circuits to <paramref name="compute"/> when the override
+    /// is <see langword="null"/> or already matches <c>symbol.Name</c>.
     /// </summary>
+    /// <remarks>
+    /// Needed because the public 2-param <c>GetLanguageSymbolId(ISymbol, IRootTypeSymbol?)</c> and
+    /// <c>GetLabelTextConstLanguageSymbolId(ISymbol, IRootTypeSymbol?)</c> overloads read
+    /// <c>symbol.Name</c> internally and expose no name parameter. The new-SDK
+    /// <c>GetTranslationFileId</c> path takes the name as a string parameter and bypasses this
+    /// helper entirely. The mutation targets the private <c>name</c> field on
+    /// <c>SourcePropertySymbol</c> (or equivalent source symbol); all source symbols we hit store
+    /// the name in that single field.
+    /// <para>
+    /// Mutations on the same symbol are serialized via <see cref="_symbolLocks"/> (a
+    /// <see cref="ConditionalWeakTable{TKey, TValue}"/> so lock objects are collected with the
+    /// symbol). Other analyzers reading <c>symbol.Name</c> concurrently do not participate and may
+    /// briefly observe the canonical name during the SDK call; scope is limited to the fallback
+    /// path on SDKs predating <c>GetTranslationFileId</c>.
+    /// </para>
+    /// </remarks>
     private static string? InvokeWithCanonicalName(ISymbol symbol, string? nameOverride, Func<string?> compute)
     {
         if (nameOverride is null || string.Equals(nameOverride, symbol.Name, StringComparison.Ordinal))

--- a/src/ALCops.Common/Reflection/TranslationIdHelper.cs
+++ b/src/ALCops.Common/Reflection/TranslationIdHelper.cs
@@ -1,5 +1,7 @@
 #if !NETSTANDARD2_1
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Translation;
 
@@ -25,8 +27,8 @@ namespace ALCops.Common.Reflection;
 ///
 /// This helper lives in ALCops.Common so all SDK-version-compat reflection is centralized; future
 /// SDK bumps only need changes here rather than in the analyzer. On netstandard2.1 the underlying
-/// SDK methods do not exist, so this helper is compiled out entirely (the LC0091 analyzer is an inert
-/// stub there).
+/// SDK methods do not exist, so this helper is compiled out entirely (callers are expected to
+/// provide an inert stub there).
 /// </summary>
 public static class TranslationIdHelper
 {
@@ -63,6 +65,17 @@ public static class TranslationIdHelper
             [typeof(ISymbol), typeof(IRootTypeSymbol)],
             null));
 
+    // Per-symbol-type cache for the private `name` field looked up on source symbol types.
+    // Never call reflection lookups on a hot path without caching — see common-library instructions.
+    private static readonly ConcurrentDictionary<Type, FieldInfo?> _nameFieldCache = new();
+
+    // Per-symbol lock table used to serialize the temporary `name`-field mutation across concurrent
+    // analyzer callbacks touching the same symbol instance. `ConditionalWeakTable` holds the symbol
+    // by weak reference so the lock object is collected together with the symbol. Cross-analyzer
+    // races are not covered (other analyzers do not know about this lock) but same-helper races on
+    // the same symbol are eliminated.
+    private static readonly ConditionalWeakTable<ISymbol, object> _symbolLocks = new();
+
     /// <summary>
     /// Computes the XLIFF trans-unit ID for the given translatable symbol, matching the ID the AL
     /// compiler generates. Returns <see langword="null"/> when no compatible SDK method can be resolved
@@ -74,7 +87,18 @@ public static class TranslationIdHelper
     /// <see langword="true"/> for label text constants (uses the NamedType symbol kind and the
     /// label-const fallback); <see langword="false"/> for properties and report labels.
     /// </param>
-    public static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst)
+    /// <param name="nameOverride">
+    /// Optional canonical name to use in place of <c>symbol.Name</c> when building the ID (e.g.
+    /// <c>propertyKind.ToString() == "ToolTip"</c> for a source-cased "Tooltip"). Guarantees the
+    /// computed trans-unit ID matches the compiler-generated one regardless of the casing used in
+    /// source. The SDK's translation-ID methods hash the property/label name from the live symbol
+    /// instance (not from any string parameter they declare), so this helper temporarily rewrites
+    /// the symbol's private <c>name</c> field for the duration of the call and restores it in a
+    /// <c>finally</c>. No state leaks to subsequent callbacks. Applies to both the new-SDK
+    /// (<c>GetTranslationFileId</c>) and old-SDK (<c>GetLanguageSymbolId</c> /
+    /// <c>GetLabelTextConstLanguageSymbolId</c>) paths.
+    /// </param>
+    public static string? ComputeTranslationId(ISymbol symbol, IRootTypeSymbol? rootSymbol, bool isLabelConst, string? nameOverride = null)
     {
         MethodInfo? translationFileId = _getTranslationFileIdMethod.Value;
         if (translationFileId is not null)
@@ -82,15 +106,71 @@ public static class TranslationIdHelper
             SymbolKind kind = isLabelConst ? EnumProvider.SymbolKind.NamedType : symbol.Kind;
             bool useNamespaces = GetUseTranslationsWithNamespaces(symbol);
 
-            return translationFileId.Invoke(null,
-                [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string;
+            return InvokeWithCanonicalName(symbol, nameOverride,
+                () => translationFileId.Invoke(null,
+                    [symbol.Name, kind, symbol.ContainingSymbol, false, rootSymbol, useNamespaces]) as string);
         }
 
         MethodInfo? fallback = isLabelConst
             ? _getLabelTextConstLanguageSymbolIdMethod.Value
             : _getLanguageSymbolIdMethod.Value;
 
-        return fallback?.Invoke(null, [symbol, rootSymbol]) as string;
+        return InvokeWithCanonicalName(symbol, nameOverride,
+            () => fallback?.Invoke(null, [symbol, rootSymbol]) as string);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="compute"/> with the target <paramref name="symbol"/>'s private
+    /// <c>name</c> field temporarily replaced by <paramref name="nameOverride"/>, restoring the
+    /// original value in <c>finally</c>. Concurrent callers of this helper on the same symbol are
+    /// serialized through a per-symbol lock so no thread inside this helper observes the mutated
+    /// value across the SDK call boundary.
+    /// <para>
+    /// The SDK's internal <c>GetTranslationFileId</c> hashes the property/label name from the
+    /// live symbol instance rather than from the <c>name</c> string parameter it declares (the
+    /// parameter feeds only human-readable note segments). There is no public seam to override
+    /// the hashed name, so we mutate the private field on <c>SourcePropertySymbol</c> (or the
+    /// equivalent source symbol) around the call. All source symbols we hit follow the same
+    /// convention of storing the name in a single <c>name</c> field.
+    /// </para>
+    /// <para>
+    /// The per-symbol lock only synchronizes this helper's own callers. Other analyzers reading
+    /// <c>symbol.Name</c> concurrently do not participate and could still, in theory, observe the
+    /// canonical name during the mutation window. In practice this is limited to the diagnostic
+    /// message text (never to computed IDs or analysis decisions).
+    /// </para>
+    /// </summary>
+    private static string? InvokeWithCanonicalName(ISymbol symbol, string? nameOverride, Func<string?> compute)
+    {
+        if (nameOverride is null || string.Equals(nameOverride, symbol.Name, StringComparison.Ordinal))
+            return compute();
+
+        FieldInfo? nameField = _nameFieldCache.GetOrAdd(symbol.GetType(), static t =>
+        {
+            FieldInfo? field = t.GetField("name", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            return field is not null && field.FieldType == typeof(string) ? field : null;
+        });
+
+        if (nameField is null)
+            return compute();
+
+        object symbolLock = _symbolLocks.GetValue(symbol, static _ => new object());
+
+        lock (symbolLock)
+        {
+            string? original = (string?)nameField.GetValue(symbol);
+            nameField.SetValue(symbol, nameOverride);
+
+            try
+            {
+                return compute();
+            }
+            finally
+            {
+                nameField.SetValue(symbol, original);
+            }
+        }
     }
 
     private static bool GetUseTranslationsWithNamespaces(ISymbol symbol)

--- a/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
+++ b/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
@@ -84,5 +84,12 @@
             <HintPath>$(BcDevToolsDir)/$(TargetFramework)/Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
             <Private>True</Private>
         </Reference>
+        <!-- Required at test runtime so ManifestHelper.GetManifest(compilation) can load app.json -->
+        <!-- from the MemoryFileSystem (used by LC0091 runtime-version-gated legacy-runtime tests). -->
+        <!-- ALCops.Common references this DLL with Private=False, so tests must supply it. -->
+        <Reference Include="Microsoft.Dynamics.Nav.Analyzers.Common">
+            <HintPath>$(BcDevToolsDir)/$(TargetFramework)/Microsoft.Dynamics.Nav.Analyzers.Common.dll</HintPath>
+            <Private>True</Private>
+        </Reference>
     </ItemGroup>
 </Project>

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/LegacyRuntimePageControlToolTip.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/HasDiagnostic/LegacyRuntimePageControlToolTip.al
@@ -1,0 +1,23 @@
+page 50100 MyPage
+{
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            field(MyField; MyField)
+            {
+                [|Tooltip = 'This is a tooltip.'|];
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/LegacyRuntimePageControlToolTip.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/LegacyRuntimePageControlToolTip.al
@@ -1,0 +1,23 @@
+page 50100 MyPage
+{
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            field(MyField; MyField)
+            {
+                [|Tooltip = 'This is a tooltip.'|];
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/PageControlToolTipWrongCasing.al
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/NoDiagnostic/PageControlToolTipWrongCasing.al
@@ -1,0 +1,29 @@
+page 50100 MyPage
+{
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            field(MyField; MyField)
+            {
+                [|Tooltip = 'This is a tooltip.'|];
+            }
+
+            field(SecondField; SecondField)
+            {
+                [|ToolTip = 'This is also a tooltip.'|];
+            }
+        }
+    }
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Text[100]) { }
+        field(2; SecondField; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -58,6 +58,31 @@ namespace ALCops.LinterCop.Test
             </xliff>
             """);
 
+		// "Page 2931038265 - Control 1296262074 - Property 1295455071"
+		// "Page 2931038265 - Control 2674903734 - Property 1295455071"
+        private static readonly byte[] TranslatedPageControlToolTipXliffContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file datatype="xml" source-language="en-US" target-language="de-DE" original="TestApp">
+                <body>
+                  <group id="body">
+                    <trans-unit id="Page 2931038265 - Control 1296262074 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>This is a tooltip.</source>
+                      <target>Dies ist ein ToolTip.</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control MyField - Property ToolTip</note>
+                    </trans-unit>
+                    <trans-unit id="Page 2931038265 - Control 2674903734 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>This is also a tooltip.</source>
+                      <target>Dies ist ebenfalls ein ToolTip.</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control SecondField - Property ToolTip</note>
+                    </trans-unit>
+                  </group>
+                </body>
+              </file>
+            </xliff>
+            """);
+
         private static readonly byte[] SettingsWithDaDK = System.Text.Encoding.UTF8.GetBytes(
             """{"LanguagesToTranslate": ["da-DK"]}""");
 
@@ -157,6 +182,21 @@ namespace ALCops.LinterCop.Test
                 });
         }
 
+        private static AnalyzerTestFixture CreateFixtureWithTranslatedPageControlToolTipXliff()
+        {
+            var files = new Dictionary<string, byte[]>
+            {
+                { "Translations/TestApp.de-DE.xlf", TranslatedPageControlToolTipXliffContent }
+            };
+            var fileSystem = new MemoryFileSystem(files);
+
+            return RoslynFixtureFactory.Create<Analyzers.TranslatableTextShouldBeTranslated>(
+                new AnalyzerTestFixtureConfig
+                {
+                    FileSystem = fileSystem
+                });
+        }
+
         // COMPAT: CompilerFeatures.TranslationsWithNamespaces and CompilationOptions.WithCompilerFeatures are
         // resolved reflectively so this test project still compiles against older SDKs where the enum member is
         // absent. The namespace tests are version-gated (RequireMinimumVersion) so this only runs where present.
@@ -235,6 +275,28 @@ namespace ALCops.LinterCop.Test
                 .ConfigureAwait(false);
 
             var fixture = CreateFixtureWithEmptyXliff();
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("PageControlToolTipWrongCasing")]
+        public async Task NoDiagnosticPropertyCasing(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            SkipTestIfVersionIsTooLow(
+                ["PageAnalysisViewLockedCaption"],
+                testCase,
+                "18.0.36",
+                "PageAnalysisView requires net10.0 SDK."
+            );
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            var fixture = CreateFixtureWithTranslatedPageControlToolTipXliff();
             fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
         }
 

--- a/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop.Test/Rules/TranslatableTextShouldBeTranslated/TranslatableTextShouldBeTranslated.cs
@@ -83,6 +83,72 @@ namespace ALCops.LinterCop.Test
             </xliff>
             """);
 
+        // Legacy runtime (<= Spring2020CU1 / 5.1) hashes the source-cased property name, not the
+        // canonical PropertyKind name. For source "Tooltip" the compiler emits hash 2001309823
+        // (FNV-1a of UTF-16 "Tooltip") instead of 1295455071 (FNV-1a of "ToolTip"). This XLIFF is
+        // what the compiler generates for LegacyRuntimePageControlToolTip.al on runtime <= 5.1;
+        // used to verify the analyzer does NOT report a false positive when the runtime-version
+        // gate correctly disables the canonical override. If the analyzer applied the canonical
+        // override unconditionally, it would hash to 1295455071 and miss this trans-unit, raising
+        // a false-positive diagnostic on the fully-translated property.
+        private static readonly byte[] LegacySourceCasedTooltipXliffContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file datatype="xml" source-language="en-US" target-language="de-DE" original="TestApp">
+                <body>
+                  <group id="body">
+                    <trans-unit id="Page 2931038265 - Control 1296262074 - Property 2001309823" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>This is a tooltip.</source>
+                      <target>Dies ist ein ToolTip.</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control MyField - Property Tooltip</note>
+                    </trans-unit>
+                  </group>
+                </body>
+              </file>
+            </xliff>
+            """);
+
+        // Same fixture as LegacySourceCasedTooltipXliffContent but using the canonical property
+        // name hash (1295455071 for "ToolTip") instead of the source-cased hash. Used together
+        // with the source-cased AL fixture on a legacy-runtime app.json to prove the analyzer
+        // correctly reports a missing translation when the runtime is <= 5.1 (fix scenario:
+        // source-cased hash 2001309823 not in XLIFF -> diagnostic). Under the buggy unconditional
+        // canonical override, the analyzer would hash to 1295455071 and match this trans-unit,
+        // silently missing the diagnostic (false negative).
+        private static readonly byte[] LegacyCanonicalTooltipXliffContent = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file datatype="xml" source-language="en-US" target-language="de-DE" original="TestApp">
+                <body>
+                  <group id="body">
+                    <trans-unit id="Page 2931038265 - Control 1296262074 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+                      <source>This is a tooltip.</source>
+                      <target>Dies ist ein ToolTip.</target>
+                      <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control MyField - Property ToolTip</note>
+                    </trans-unit>
+                  </group>
+                </body>
+              </file>
+            </xliff>
+            """);
+
+        // Minimal app.json declaring runtime 5.1 (Spring2020CU1). Used to force the analyzer down
+        // the pre-canonical-override compiler path in LC0091's runtime-version gate.
+        private static readonly byte[] AppJsonRuntime51Content = System.Text.Encoding.UTF8.GetBytes(
+            """
+            {
+                "id": "00000000-0000-0000-0000-000000000042",
+                "name": "TestApp",
+                "publisher": "TestPublisher",
+                "version": "1.0.0.0",
+                "runtime": "5.1",
+                "idRanges": [ { "from": 50000, "to": 99999 } ],
+                "features": [ "TranslationFile" ]
+            }
+            """);
+
         private static readonly byte[] SettingsWithDaDK = System.Text.Encoding.UTF8.GetBytes(
             """{"LanguagesToTranslate": ["da-DK"]}""");
 
@@ -223,6 +289,26 @@ namespace ALCops.LinterCop.Test
                 {
                     FileSystem = fileSystem,
                     CompilationOptions = CreateNamespaceCompilationOptions()
+                });
+        }
+
+        // Fixture used to exercise LC0091's runtime-version gate. The app.json declares runtime 5.1
+        // (Spring2020CU1), which causes the analyzer to hash the source-cased property name instead
+        // of the canonical PropertyKind name — matching the compiler's SymbolExtensions.GetTranslationName
+        // behavior on legacy runtimes.
+        private static AnalyzerTestFixture CreateFixtureWithLegacyRuntime(byte[] xliffContent)
+        {
+            var files = new Dictionary<string, byte[]>
+            {
+                { "app.json", AppJsonRuntime51Content },
+                { "Translations/TestApp.de-DE.xlf", xliffContent }
+            };
+            var fileSystem = new MemoryFileSystem(files);
+
+            return RoslynFixtureFactory.Create<Analyzers.TranslatableTextShouldBeTranslated>(
+                new AnalyzerTestFixtureConfig
+                {
+                    FileSystem = fileSystem
                 });
         }
 
@@ -387,6 +473,54 @@ namespace ALCops.LinterCop.Test
                 .ConfigureAwait(false);
 
             var fixture = CreateFixtureWithNamespaceFeature(NamespaceTranslatedTableCaptionXliffContent);
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        // Regression tests for the runtime-version gate around the canonical property-name override.
+        // On runtime <= Spring2020CU1 (5.1) the compiler hashes the source-cased property name
+        // (SymbolExtensions.GetTranslationName returns property.Name); on newer runtimes it uses the
+        // canonical PropertyKind name. LC0091 must mirror this gate — an unconditional canonical
+        // override would produce false positives (or false negatives) on legacy apps whose XLIFF
+        // uses source-cased hashes. Both tests use a single-field page with source-cased "Tooltip"
+        // and an app.json declaring runtime 5.1, and paired XLIFFs designed to fail under the buggy
+        // unconditional-override behavior.
+        [Test]
+        [TestCase("LegacyRuntimePageControlToolTip")]
+        public async Task HasDiagnosticLegacyRuntime(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            // XLIFF contains only the canonical hash (1295455071). With the runtime gate correctly
+            // disabling the canonical override on runtime 5.1, the analyzer hashes source-cased
+            // "Tooltip" to 2001309823, which is NOT in the XLIFF -> diagnostic fires as expected.
+            // Under the buggy unconditional-override path, the analyzer would match the canonical
+            // trans-unit and silently miss the diagnostic (false negative regression).
+            var fixture = CreateFixtureWithLegacyRuntime(LegacyCanonicalTooltipXliffContent);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
+        }
+
+        [Test]
+        [TestCase("LegacyRuntimePageControlToolTip")]
+        public async Task NoDiagnosticLegacyRuntime(string testCase)
+        {
+            RequireMinimumVersion("16.0",
+                "LC0091 requires net8.0 SDK APIs (ExtensionObjectFoldingUtilities, GetLabelTextConstLanguageSymbolId)");
+
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            // XLIFF contains only the source-cased hash (2001309823). With the runtime gate
+            // correctly disabling the canonical override on runtime 5.1, the analyzer hashes to
+            // the same source-cased hash and matches the trans-unit -> no diagnostic. Under the
+            // buggy unconditional-override path, the analyzer would hash to 1295455071 and NOT
+            // match, raising a false-positive diagnostic on a fully-translated property.
+            var fixture = CreateFixtureWithLegacyRuntime(LegacySourceCasedTooltipXliffContent);
             fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.TranslatableTextShouldBeTranslated);
         }
     }

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -218,8 +218,12 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         if (IsPropertyLocked(property))
             return;
 
+        // Pass the canonical property name (e.g. "ToolTip") as the trans-unit name override so the
+        // computed ID matches the compiler-generated XLIFF ID regardless of the source-text casing
+        // used by the developer (e.g. "Tooltip" or "TOOLTIP").
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(property);
-        string? translationId = TranslationIdHelper.ComputeTranslationId(property, rootSymbol, isLabelConst: false);
+        string? translationId = TranslationIdHelper.ComputeTranslationId(property, rootSymbol, isLabelConst: false, nameOverride: propertyKind.ToString());
+
         if (translationId is null)
             return;
 

--- a/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
+++ b/src/ALCops.LinterCop/Analyzers/TranslatableTextShouldBeTranslated.cs
@@ -63,8 +63,14 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         if (translationIndex is null || translationIndex.AvailableLanguages.Count == 0)
             return;
 
+        // Mirror the compiler's runtime-version gate in SymbolExtensions.GetTranslationName:
+        //   runtime <= Spring2020CU1 (5.1) => use source-cased symbol.Name for the XLIFF trans-unit ID
+        //   runtime  > Spring2020CU1        => use canonical PropertyKind.ToString() (e.g. "ToolTip")
+        // Unknown runtime defaults to "current" (matches SDK's GetRuntimeVersionOrCurrent).
+        bool useCanonicalPropertyName = manifest?.Runtime is null || manifest.Runtime > RuntimeVersion.Spring2020CU1;
+
         context.RegisterSymbolAction(
-            ctx => AnalyzeSymbol(ctx, translationIndex),
+            ctx => AnalyzeSymbol(ctx, translationIndex, useCanonicalPropertyName),
             EnumProvider.SymbolKind.Table,
             EnumProvider.SymbolKind.TableExtension,
             EnumProvider.SymbolKind.Page,
@@ -85,7 +91,7 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         );
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext ctx, TranslationIndex translationIndex)
+    private static void AnalyzeSymbol(SymbolAnalysisContext ctx, TranslationIndex translationIndex, bool useCanonicalPropertyName)
     {
         if (ctx.IsObsolete())
             return;
@@ -107,8 +113,8 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
 
         if (kind == EnumProvider.SymbolKind.Field)
         {
-            ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex);
-            ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.ToolTip, translationIndex);
+            ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
+            ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.ToolTip, translationIndex, useCanonicalPropertyName);
             return;
         }
 
@@ -118,12 +124,12 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
             || kind == EnumProvider.SymbolKind.RequestPageExtension
             || kind == EnumProvider.SymbolKind.Query)
         {
-            AnalyzePageLikeSymbol(ctx, symbol, translationIndex);
+            AnalyzePageLikeSymbol(ctx, symbol, translationIndex, useCanonicalPropertyName);
             return;
         }
 
         // Table, TableExtension, XmlPort, Enum, EnumValue, Report, Profile, PermissionSet
-        ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex);
+        ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
     }
 
     private static void AnalyzeLabelVariable(SymbolAnalysisContext ctx, ISymbol symbol, TranslationIndex translationIndex)
@@ -161,9 +167,9 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         ReportMissingTranslation(ctx, symbol, translationId, translationIndex);
     }
 
-    private static void AnalyzePageLikeSymbol(SymbolAnalysisContext ctx, ISymbol symbol, TranslationIndex translationIndex)
+    private static void AnalyzePageLikeSymbol(SymbolAnalysisContext ctx, ISymbol symbol, TranslationIndex translationIndex, bool useCanonicalPropertyName)
     {
-        ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex);
+        ReportTranslatableProperty(ctx, symbol, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
 
         IEnumerable<IControlSymbol>? controls = GetFlattenedControls(symbol);
         if (controls is not null)
@@ -173,9 +179,9 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
                 if (control.IsObsolete())
                     continue;
 
-                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.Caption, translationIndex);
-                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.ToolTip, translationIndex);
-                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.OptionCaption, translationIndex);
+                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
+                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.ToolTip, translationIndex, useCanonicalPropertyName);
+                ReportTranslatableProperty(ctx, control, EnumProvider.PropertyKind.OptionCaption, translationIndex, useCanonicalPropertyName);
             }
         }
 
@@ -187,8 +193,8 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
                 if (action.IsObsolete())
                     continue;
 
-                ReportTranslatableProperty(ctx, action, EnumProvider.PropertyKind.Caption, translationIndex);
-                ReportTranslatableProperty(ctx, action, EnumProvider.PropertyKind.ToolTip, translationIndex);
+                ReportTranslatableProperty(ctx, action, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
+                ReportTranslatableProperty(ctx, action, EnumProvider.PropertyKind.ToolTip, translationIndex, useCanonicalPropertyName);
             }
         }
 
@@ -200,13 +206,13 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
                 if (analysisView.IsObsolete())
                     continue;
 
-                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.Caption, translationIndex);
-                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.ToolTip, translationIndex);
+                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.Caption, translationIndex, useCanonicalPropertyName);
+                ReportTranslatableProperty(ctx, analysisView, EnumProvider.PropertyKind.ToolTip, translationIndex, useCanonicalPropertyName);
             }
         }
     }
 
-    private static void ReportTranslatableProperty(SymbolAnalysisContext ctx, ISymbol symbol, PropertyKind propertyKind, TranslationIndex translationIndex)
+    private static void ReportTranslatableProperty(SymbolAnalysisContext ctx, ISymbol symbol, PropertyKind propertyKind, TranslationIndex translationIndex, bool useCanonicalPropertyName)
     {
         IPropertySymbol? property = symbol.GetProperty(propertyKind);
         if (property is null)
@@ -221,8 +227,13 @@ public sealed class TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
         // Pass the canonical property name (e.g. "ToolTip") as the trans-unit name override so the
         // computed ID matches the compiler-generated XLIFF ID regardless of the source-text casing
         // used by the developer (e.g. "Tooltip" or "TOOLTIP").
+        //
+        // The compiler only applies this canonical form on runtime > Spring2020CU1 (5.1); on older
+        // runtimes it hashes the source-cased symbol.Name. When useCanonicalPropertyName is false
+        // we pass null so ComputeTranslationId falls back to symbol.Name, matching the compiler.
+        string? nameOverride = useCanonicalPropertyName ? propertyKind.ToString() : null;
         IRootTypeSymbol? rootSymbol = ExtensionObjectFoldingUtilities.GetTranslationRootSymbol(property);
-        string? translationId = TranslationIdHelper.ComputeTranslationId(property, rootSymbol, isLabelConst: false, nameOverride: propertyKind.ToString());
+        string? translationId = TranslationIdHelper.ComputeTranslationId(property, rootSymbol, isLabelConst: false, nameOverride: nameOverride);
 
         if (translationId is null)
             return;


### PR DESCRIPTION
Move the private `name`-field mutation for canonical property casing out of the LC0091 analyzer and into `TranslationIdHelper.ComputeTranslationId` via a new optional `nameOverride` parameter.

- Explicit `GetField("name")` + string-type guard (was: fragile Contains match)
- Original value restored in `finally` (was: permanent mutation)
- Applies to both new-SDK and old-SDK translation-ID paths
- Cached FieldInfo per symbol type (ConcurrentDictionary)
- Per-symbol lock via ConditionalWeakTable serializes concurrent mutations

Add regression test `NoDiagnosticPropertyCasing / PageControlToolTipWrongCasing` covering a page control with `Tooltip` (source) matched against an XLIFF trans-unit id built from `ToolTip` (canonical).

Fixes #411