### PR TITLE
fix(multiple) missing MessageFormat arguments across analyzers

### DIFF
--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCopAnalyzers.resx
@@ -277,7 +277,7 @@
     <value>DrillDownPageId and LookupPageId property must be defined for tables used in list pages</value>
   </data>
   <data name="LookupPageIdAndDrillDownPageIdMessageFormat" xml:space="preserve">
-    <value>Table '{0}' is used in a list page but does not define both the DrillDownPageId and LookupPageId properties.</value>
+    <value>Table '{0}' is used in list page '{1}' but does not define both the DrillDownPageId and LookupPageId properties.</value>
   </data>
   <data name="LookupPageIdAndDrillDownPageIdDescription" xml:space="preserve">
     <value>When a table is used as the source for a list page, users expect to be able to drill down into records and open lookups in a consistent and predictable way. The DrillDownPageId and LookupPageId table properties define which pages are used for these interactions.</value>

--- a/src/ALCops.ApplicationCop/Analyzers/IntegrationEventInInternalCodeunit.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/IntegrationEventInInternalCodeunit.cs
@@ -38,8 +38,7 @@ public sealed class IntegrationEventInInternalCodeunit : DiagnosticAnalyzer
         ctx.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.IntegrationEventInInternalCodeunit,
             methodSymbol.GetLocation(),
-            methodSymbol.Name,
-            applicationObject.Name));
+            methodSymbol.Name));
     }
 
     private static bool IsIntegrationEvent(IMethodSymbol methodSymbol) =>

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -355,7 +355,7 @@
     <value>Consider using a Query object or Rec.Find('-') with Rec.Next() for checking exactly one record</value>
   </data>
   <data name="UseQueryOrFindWithNextInsteadOfCountMessageFormat" xml:space="preserve">
-    <value>Consider using a Query object or {0}.Find('-') together with {0}.Next() instead of {0}.Count() for faster and more efficient record checks.</value>
+    <value>Consider using a Query object or {0}.Find('-') together with {0}.Next() instead of {0}.Count() {1} {2} for faster and more efficient record checks.</value>
   </data>
   <data name="UseQueryOrFindWithNextInsteadOfCountDescription" xml:space="preserve">
     <value>Instead of relying on Rec.Count(), consider using a Query object or a combination of Rec.Find('-') and Rec.Next() for faster and more efficient record checks.</value>

--- a/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
+++ b/src/ALCops.LinterCop/Analyzers/AnalyzeCountMethod.cs
@@ -77,13 +77,13 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
         {
             if (IsOneComparison(binaryExpression, leftValue, rightValue))
             {
-                ReportUseFindWithNextDiagnostic(ctx, invocation, GetOperatorKind(binaryExpression.OperatorToken.Kind));
+                ReportUseFindWithNextDiagnostic(ctx, invocation, binaryExpression, leftValue, rightValue);
                 return;
             }
 
             if (IsLessThanTwoComparison(binaryExpression, rightValue) || IsGreaterThanTwoComparison(binaryExpression, leftValue))
             {
-                ReportUseFindWithNextDiagnostic(ctx, invocation, EnumProvider.SyntaxKind.EqualsToken);
+                ReportUseFindWithNextDiagnostic(ctx, invocation, binaryExpression, leftValue, rightValue);
                 return;
             }
         }
@@ -100,8 +100,25 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
         return literal.Literal.GetLiteralValue() is int value ? value : -1;
     }
 
-    private static SyntaxKind GetOperatorKind(SyntaxKind tokenKind) =>
-        tokenKind == EnumProvider.SyntaxKind.EqualsToken ? EnumProvider.SyntaxKind.EqualsToken : EnumProvider.SyntaxKind.NotEqualsToken;
+    private static SyntaxKind FlipOperator(SyntaxKind kind) => kind switch
+    {
+        _ when kind == EnumProvider.SyntaxKind.LessThanToken => EnumProvider.SyntaxKind.GreaterThanToken,
+        _ when kind == EnumProvider.SyntaxKind.GreaterThanToken => EnumProvider.SyntaxKind.LessThanToken,
+        _ when kind == EnumProvider.SyntaxKind.LessThanEqualsToken => EnumProvider.SyntaxKind.GreaterThanEqualsToken,
+        _ when kind == EnumProvider.SyntaxKind.GreaterThanEqualsToken => EnumProvider.SyntaxKind.LessThanEqualsToken,
+        _ => kind, // '=' and '<>' are symmetric
+    };
+
+    private static string GetOperatorSign(SyntaxKind kind) => kind switch
+    {
+        _ when kind == EnumProvider.SyntaxKind.EqualsToken => "=",
+        _ when kind == EnumProvider.SyntaxKind.NotEqualsToken => "<>",
+        _ when kind == EnumProvider.SyntaxKind.LessThanToken => "<",
+        _ when kind == EnumProvider.SyntaxKind.GreaterThanToken => ">",
+        _ when kind == EnumProvider.SyntaxKind.LessThanEqualsToken => "<=",
+        _ when kind == EnumProvider.SyntaxKind.GreaterThanEqualsToken => ">=",
+        _ => "=",
+    };
 
     private static bool IsZeroComparison(int left, int right)
         => left == Zero || right == Zero;
@@ -150,14 +167,22 @@ public class AnalyzeCountMethod : DiagnosticAnalyzer
             GetSymbolName(operation)));
     }
 
-    private static void ReportUseFindWithNextDiagnostic(OperationAnalysisContext ctx, IInvocationExpression operation, SyntaxKind operatorToken)
+    private static void ReportUseFindWithNextDiagnostic(OperationAnalysisContext ctx, IInvocationExpression operation, BinaryExpressionSyntax binaryExpression, int leftValue, int rightValue)
     {
-        string operatorSign = operatorToken == EnumProvider.SyntaxKind.EqualsToken ? "=" : "<>";
+        // Normalize to "Count() <op> <value>" so the message always reads left-to-right,
+        // even when the source has the literal on the left (e.g. "2 > Rec.Count()").
+        bool countIsOnRight = leftValue >= 0 && rightValue < 0;
+        int comparedValue = countIsOnRight ? leftValue : rightValue;
+        SyntaxKind operatorKind = countIsOnRight
+            ? FlipOperator(binaryExpression.OperatorToken.Kind)
+            : binaryExpression.OperatorToken.Kind;
 
         ctx.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.UseQueryOrFindWithNextInsteadOfCount,
             operation.Syntax.Parent.GetLocation(),
-            GetSymbolName(operation), operatorSign));
+            GetSymbolName(operation),
+            GetOperatorSign(operatorKind),
+            comparedValue));
     }
 
     private static string GetSymbolName(IInvocationExpression operation) =>

--- a/src/ALCops.LinterCop/Analyzers/InterfaceObjectNameGuide.cs
+++ b/src/ALCops.LinterCop/Analyzers/InterfaceObjectNameGuide.cs
@@ -42,7 +42,8 @@ public sealed class InterfaceObjectNameGuide : DiagnosticAnalyzer
         {
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.InterfaceObjectNameGuide,
-                interfaceTypeSymbol.GetLocation()));
+                interfaceTypeSymbol.GetLocation(),
+                interfaceTypeSymbol.Name));
 
             return;
         }
@@ -54,7 +55,8 @@ public sealed class InterfaceObjectNameGuide : DiagnosticAnalyzer
         {
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.InterfaceObjectNameGuide,
-                interfaceTypeSymbol.GetLocation()));
+                interfaceTypeSymbol.GetLocation(),
+                interfaceTypeSymbol.Name));
 
             return;
         }
@@ -67,7 +69,8 @@ public sealed class InterfaceObjectNameGuide : DiagnosticAnalyzer
             {
                 ctx.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.InterfaceObjectNameGuide,
-                    interfaceTypeSymbol.GetLocation()));
+                    interfaceTypeSymbol.GetLocation(),
+                    interfaceTypeSymbol.Name));
 
                 return;
             }

--- a/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCopAnalyzers.resx
@@ -331,7 +331,7 @@
     <value>Incorrect number or type of arguments in .Get() method on Record object</value>
   </data>
   <data name="RecordGetProcedureArgumentsMessageFormat" xml:space="preserve">
-    <value>Invalid arguments in .Get() method for record '{0}': {1}.</value>
+    <value>Invalid arguments in call to '{0}' for record '{1}': {2}.</value>
   </data>
   <data name="RecordGetProcedureArgumentsDescription" xml:space="preserve">
     <value>This rule ensures that calls to the built-in .Get() procedure on Record objects have the correct number and types of arguments matching the primary key (PK) of the record in question.</value>

--- a/src/ALCops.PlatformCop/Analyzers/EditableFlowField.cs
+++ b/src/ALCops.PlatformCop/Analyzers/EditableFlowField.cs
@@ -48,7 +48,8 @@ public sealed class EditableFlowField : DiagnosticAnalyzer
         ctx.ReportDiagnostic(
             Diagnostic.Create(
                 DiagnosticDescriptors.EditableFlowField,
-                field.GetLocation()));
+                field.GetLocation(),
+                field.Name));
     }
 
     private static bool HasLineComment(SyntaxTriviaList triviaList)

--- a/src/ALCops.PlatformCop/Analyzers/EventPublisherIsHandledByVar.cs
+++ b/src/ALCops.PlatformCop/Analyzers/EventPublisherIsHandledByVar.cs
@@ -36,7 +36,8 @@ public sealed class EventPublisherIsHandledByVar : DiagnosticAnalyzer
 
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.EventPublisherIsHandledByVar,
-                parameter.GetLocation()));
+                parameter.GetLocation(),
+                parameter.Name));
         }
     }
 

--- a/src/ALCops.PlatformCop/Analyzers/RecordGetProcedureArguments.cs
+++ b/src/ALCops.PlatformCop/Analyzers/RecordGetProcedureArguments.cs
@@ -87,6 +87,7 @@ public sealed class RecordGetProcedureArguments : DiagnosticAnalyzer
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.RecordGetProcedureArguments,
                 ctx.Operation.Syntax.GetLocation(),
+                GetPrimaryKeySignature(table),
                 table.Name,
                 expectedArgs));
 
@@ -117,6 +118,7 @@ public sealed class RecordGetProcedureArguments : DiagnosticAnalyzer
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.RecordGetProcedureArguments,
                 ctx.Operation.Syntax.GetLocation(),
+                GetPrimaryKeySignature(table),
                 table.Name,
                 expectedArgs));
             return;
@@ -214,5 +216,20 @@ public sealed class RecordGetProcedureArguments : DiagnosticAnalyzer
 
         return fieldType.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Code
             || SemanticFacts.IsSameName(pkField.Name, PrimaryKeyFieldName);
+    }
+
+    private static string GetPrimaryKeySignature(ITableTypeSymbol table) =>
+        $"{GetMethodName}({string.Join(", ", table.PrimaryKey.Fields.Select(GetFieldDisplay))})";
+
+    private static string GetFieldDisplay(IFieldSymbol field)
+    {
+        var name = field.Name.QuoteIdentifierIfNeededWithReflection();
+#if NETSTANDARD2_1
+        var fieldType = field.OriginalDefinition.GetTypeSymbol();
+        var type = fieldType?.ToDisplayStringWithReflection() ?? string.Empty;
+#else
+        var type = field.Type?.ToDisplayString() ?? string.Empty;
+#endif
+        return $"{name}: {type}";
     }
 }


### PR DESCRIPTION
Several diagnostics passed too few arguments to Diagnostic.Create, producing messages with literal "{0}" placeholders. Add the missing name arguments and align resx/call sites where they had drifted.

- AC0001 (LookupPageIdAndDrillDownPageId): include list page name in message
- AC0012 (IntegrationEventInInternalCodeunit): drop superfluous {1} arg
- PC0001 (EditableFlowField): pass field.Name
- PC0011 (EventPublisherIsHandledByVar): pass parameter.Name
- PC0013: diagnostic message now includes the resolved primary key fields for clarity.
- LC0054 (InterfaceObjectNameGuide): pass interfaceTypeSymbol.Name (3 sites)
- LC0082 (UseQueryOrFindWithNextInsteadOfCount): preserve real operator and compared value; add FlipOperator/GetOperatorSign switch expressions so "2 > Rec.Count()" is normalized to "Count() < 2" in the message

Fixes #414