### PR TITLE
fix(DC0005): handle <param> tag without name attribute (#417)

### DIFF
--- a/src/ALCops.DocumentationCop.Test/Rules/XmlDocumentationProcedureConsistency/HasDiagnostic/ParamWithoutNameAttribute.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/XmlDocumentationProcedureConsistency/HasDiagnostic/ParamWithoutNameAttribute.al
@@ -1,0 +1,29 @@
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Param tag without name attribute on procedure with parameters.
+    /// </summary>
+    /// [|<param></param>|]
+    procedure WithParameter([|Value: Boolean|])
+    begin
+
+    end;
+
+    /// <summary>
+    /// Param tag without name attribute on procedure without parameters.
+    /// </summary>
+    /// [|<param></param>|]
+    procedure WithoutParameter()
+    begin
+
+    end;
+
+    /// <summary>
+    /// Param tag without name attribute on procedure with parameters.
+    /// </summary>
+    /// [|<param>|]
+    procedure WithParameterAlsoInvalid([|Value: Boolean|])
+    begin
+
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/XmlDocumentationProcedureConsistency/XmlDocumentationProcedureConsistency.cs
+++ b/src/ALCops.DocumentationCop.Test/Rules/XmlDocumentationProcedureConsistency/XmlDocumentationProcedureConsistency.cs
@@ -24,6 +24,7 @@ namespace ALCops.DocumentationCop.Test
         [TestCase("DuplicateParameter")]
         [TestCase("DuplicateReturns")]
         [TestCase("TryFunction")]
+        [TestCase("ParamWithoutNameAttribute")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.DocumentationCop/Analyzers/XmlDocumentationProcedureConsistency.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/XmlDocumentationProcedureConsistency.cs
@@ -26,6 +26,7 @@ public sealed class XmlDocumentationProcedureConsistency : DiagnosticAnalyzer
             return;
 
         var docCommentTrivia = methodDeclarationSyntax.GetLeadingTrivia().FirstOrDefault(trivia => trivia.Kind == EnumProvider.SyntaxKind.SingleLineDocumentationCommentTrivia);
+
         if (docCommentTrivia.IsKind(EnumProvider.SyntaxKind.None))
             return; // no documentation comment exists
 
@@ -41,8 +42,17 @@ public sealed class XmlDocumentationProcedureConsistency : DiagnosticAnalyzer
             switch (element.StartTag.Name.LocalName.Text.ToLowerInvariant())
             {
                 case "param":
-                    var nameAttribute = (XmlNameAttributeSyntax)element.StartTag.Attributes.First(att => att.IsKind(EnumProvider.SyntaxKind.XmlNameAttribute));
+                    var nameAttributeSyntax = element.StartTag.Attributes.FirstOrDefault(att => att.IsKind(EnumProvider.SyntaxKind.XmlNameAttribute));
+
+                    if (nameAttributeSyntax is null)
+                    {
+                        ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.XmlDocumentationProcedureConsistency, element.GetLocation()));
+                        break;
+                    }
+
+                    var nameAttribute = (XmlNameAttributeSyntax)nameAttributeSyntax;
                     var parameterName = nameAttribute.Identifier.GetText().ToString();
+
                     if (!docCommentParameters.ContainsKey(parameterName))
                         docCommentParameters.Add(parameterName, element);
                     else
@@ -53,6 +63,7 @@ public sealed class XmlDocumentationProcedureConsistency : DiagnosticAnalyzer
                     if (docCommentReturns is not null)
                         // report diagnostic for duplicate returns documentation
                         ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.XmlDocumentationProcedureConsistency, element.GetLocation()));
+
                     docCommentReturns = element;
                     break;
             }


### PR DESCRIPTION
`Attributes.First(att => att.IsKind(XmlNameAttribute))` threw `InvalidOperationException` when a `<param>` element had no `name` attribute. Switch to `FirstOrDefault` and report DC0005 on the malformed element instead of crashing.

Adds `ParamWithoutNameAttribute` HasDiagnostic fixture covering `<param></param>` on procedures with and without parameters.

Fixes #417 