### PR TITLE
fix(ci): support BC29 flat VSIX layout for Analyzers DLL discovery

### DIFF
--- a/.github/actions/get-bc-devtools/Get-BC-DevTools.ps1
+++ b/.github/actions/get-bc-devtools/Get-BC-DevTools.ps1
@@ -210,6 +210,15 @@ function Get-AssetInfo {
     #         (VSIX is itself a ZIP, but it is local so no nested HTTP range requests needed).
     # Step 3: Reflect on the DLL via Get-AssemblyInfo — identical to the VSIX/NuGet path,
     #         giving both the true AL Language assembly version and target framework moniker.
+    #
+    # VSIX layout changed in BC 29 (AL 17): the DLL moved from the legacy
+    # 'extension/bin/Analyzers/' folder to a flat 'extension/bin/'. Try the current
+    # layout first, then fall back to the legacy folder for older versions.
+    $vsixDllCandidates = @(
+        'extension/bin/Microsoft.Dynamics.Nav.Analyzers.Common.dll',           # BC29+ flat layout
+        'extension/bin/Analyzers/Microsoft.Dynamics.Nav.Analyzers.Common.dll'  # legacy layout (pre-BC29)
+    )
+
     if ($PackageType -eq 'BCArtifact') {
         $vsixPath = Join-Path $TempDirectory 'ALLanguage.vsix'
         $dllPath = Join-Path $TempDirectory 'Microsoft.Dynamics.Nav.Analyzers.Common.dll'
@@ -218,15 +227,19 @@ function Get-AssetInfo {
             $rangeScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'shared\Get-RemoteZipEntry.ps1'
             & $rangeScript -Uri $uri -EntryPath 'ALLanguage.vsix' -OutputPath $vsixPath
 
-            # Step 2: extract the Analyzers DLL from the now-local VSIX
+            # Step 2: extract the Analyzers DLL from the now-local VSIX (first candidate path wins)
             $vsixZip = [System.IO.Compression.ZipFile]::OpenRead($vsixPath)
             try {
-                $dllEntry = $vsixZip.Entries | Where-Object {
-                    $_.FullName -ieq 'extension/bin/Analyzers/Microsoft.Dynamics.Nav.Analyzers.Common.dll'
-                } | Select-Object -First 1
+                $dllEntry = $null
+                foreach ($candidate in $vsixDllCandidates) {
+                    $dllEntry = $vsixZip.Entries | Where-Object {
+                        ($_.FullName -replace '\\', '/') -ieq $candidate
+                    } | Select-Object -First 1
+                    if ($dllEntry) { break }
+                }
 
                 if (-not $dllEntry) {
-                    throw "Microsoft.Dynamics.Nav.Analyzers.Common.dll not found inside ALLanguage.vsix."
+                    throw "Microsoft.Dynamics.Nav.Analyzers.Common.dll not found inside ALLanguage.vsix at any known path: $($vsixDllCandidates -join ', ')."
                 }
 
                 [System.IO.Compression.ZipFileExtensions]::ExtractToFile($dllEntry, $dllPath, $true)
@@ -249,14 +262,11 @@ function Get-AssetInfo {
         }
     }
 
-    # Determine the archive-internal folder and the full entry path for the target DLL.
     # For NuGet packages that ship multiple TFMs, we want the highest.
     # Order highest-first so the first successful extraction wins.
     $nugetTfmPaths = @('tools/net10.0/any', 'tools/net8.0/any')
-    $pathInArchive = switch ($PackageType) {
-        'VSIX' { 'extension/bin/Analyzers' }
-        'NuGet' { $nugetTfmPaths[0] }
-        default { throw "Unknown asset type: $PackageType" }
+    if ($PackageType -notin 'VSIX', 'NuGet') {
+        throw "Unknown asset type: $PackageType"
     }
     $dllPath = Join-Path $TempDirectory 'Microsoft.Dynamics.Nav.Analyzers.Common.dll'
 
@@ -282,8 +292,9 @@ function Get-AssetInfo {
             }
         }
         else {
-            $entryPath = "$pathInArchive/Microsoft.Dynamics.Nav.Analyzers.Common.dll"
-            & $rangeScript -Uri $uri -EntryPath $entryPath -OutputPath $dllPath
+            # Marketplace VSIX: try current (flat bin) and legacy (Analyzers) layouts
+            # in a single Central Directory pass — first candidate match wins.
+            & $rangeScript -Uri $uri -EntryPath $vsixDllCandidates -OutputPath $dllPath
         }
 
         $assemblyInfo = Get-AssemblyInfo -AssemblyPath $dllPath

--- a/.github/actions/setup-bc-devtools/action.yml
+++ b/.github/actions/setup-bc-devtools/action.yml
@@ -152,10 +152,25 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         TFM: ${{ inputs.tfm }}
       run: |
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+
         $pathInArchive = switch ($env:ASSET_TYPE) {
-          'VSIX'       { 'extension/bin/Analyzers' }
+          { $_ -in 'VSIX', 'BCArtifact' } {
+            # VSIX layout changed in BC 29 (AL 17): DLLs moved from the legacy
+            # 'extension/bin/Analyzers' folder to a flat 'extension/bin'.
+            # Probe the archive for the current layout first; fall back to legacy.
+            $probe = [System.IO.Compression.ZipFile]::OpenRead($env:ARCHIVE_PATH)
+            try {
+              $flatLayout = $probe.Entries | Where-Object {
+                ($_.FullName -replace '\\', '/') -ieq 'extension/bin/Microsoft.Dynamics.Nav.Analyzers.Common.dll'
+              } | Select-Object -First 1
+            }
+            finally {
+              $probe.Dispose()
+            }
+            if ($flatLayout) { 'extension/bin' } else { 'extension/bin/Analyzers' }
+          }
           'NuGet'      { "tools/$($env:TFM)/any" }
-          'BCArtifact' { 'extension/bin/Analyzers' }
           default { 
             Write-Error "Invalid asset-type: $($env:ASSET_TYPE). Must be 'VSIX', 'NuGet', or 'BCArtifact'."
             exit 1

--- a/.github/actions/shared/Get-RemoteZipEntry.ps1
+++ b/.github/actions/shared/Get-RemoteZipEntry.ps1
@@ -21,7 +21,9 @@ Supports both ZIP32 and ZIP64 archives.
 The remote URL of the ZIP/VSIX/nupkg file.
 
 .PARAMETER EntryPath
-The full path of the entry to extract, using forward slashes.
+One or more candidate entry paths to extract, using forward slashes.
+Candidates are tried in order against the Central Directory (a single pass,
+no extra HTTP requests); the first match wins.
 Example: 'extension/bin/Analyzers/Microsoft.Dynamics.Nav.CodeAnalysis.dll'
 
 .PARAMETER OutputPath
@@ -32,6 +34,13 @@ Get-RemoteZipEntry.ps1 `
     -Uri 'https://example.com/package.vsix' `
     -EntryPath 'extension/bin/Analyzers/Microsoft.Dynamics.Nav.CodeAnalysis.dll' `
     -OutputPath 'C:\Temp\Microsoft.Dynamics.Nav.CodeAnalysis.dll'
+
+.EXAMPLE
+Get-RemoteZipEntry.ps1 `
+    -Uri 'https://example.com/package.vsix' `
+    -EntryPath 'extension/bin/Microsoft.Dynamics.Nav.CodeAnalysis.dll',
+               'extension/bin/Analyzers/Microsoft.Dynamics.Nav.CodeAnalysis.dll' `
+    -OutputPath 'C:\Temp\Microsoft.Dynamics.Nav.CodeAnalysis.dll'
 #>
 
 [CmdletBinding()]
@@ -40,7 +49,7 @@ param(
     [string]$Uri,
 
     [Parameter(Mandatory = $true)]
-    [string]$EntryPath,
+    [string[]]$EntryPath,
 
     [Parameter(Mandatory = $true)]
     [string]$OutputPath
@@ -258,13 +267,18 @@ else {
 $entries = Get-CentralDirectoryEntries -CdBytes $cdBytes
 Write-Verbose "  [RangeRequest] $($entries.Count) entries in Central Directory"
 
-$normalizedEntry = ($EntryPath -replace '\\', '/').TrimStart('/')
-$target = $entries | Where-Object {
-    ($_.Filename -replace '\\', '/') -ieq $normalizedEntry
-} | Select-Object -First 1
+# Try each candidate entry path in order; first match wins (single CD pass, no extra requests)
+$normalizedCandidates = @($EntryPath | ForEach-Object { ($_ -replace '\\', '/').TrimStart('/') })
+$target = $null
+foreach ($candidate in $normalizedCandidates) {
+    $target = $entries | Where-Object {
+        ($_.Filename -replace '\\', '/') -ieq $candidate
+    } | Select-Object -First 1
+    if ($target) { break }
+}
 
 if (-not $target) {
-    throw "Entry '$normalizedEntry' not found in the Central Directory ($($entries.Count) entries scanned)."
+    throw "None of the candidate entries [$($normalizedCandidates -join ', ')] found in the Central Directory ($($entries.Count) entries scanned)."
 }
 
 Write-Verbose "  [RangeRequest] Found '$($target.Filename)' (method=$($target.Method), compressed=$([math]::Round($target.CompressedSize/1KB,1)) KB, offset=$($target.HeaderOffset))"

--- a/.github/instructions/get-bc-devtools.instructions.md
+++ b/.github/instructions/get-bc-devtools.instructions.md
@@ -20,6 +20,20 @@ The `get-bc-devtools` composite GitHub Action discovers all available BC DevTool
 3. **`action.yml`** — Composite action entry point. Calls `Get-BC-DevTools.ps1`, deduplicates sources by version, determines lowest version per TFM, and sets outputs.
 4. **`Display-Sources.ps1`** — Renders a summary table to the workflow log.
 
+### VSIX layout change in BC 29 (AL 17)
+
+Starting with BC 29, `ALLanguage.vsix` no longer contains the `extension/bin/Analyzers/` folder; all SDK DLLs (including `Microsoft.Dynamics.Nav.Analyzers.Common.dll`) sit flat in `extension/bin/` alongside the compiler and third-party dependencies. Both layouts are supported via an ordered candidate-path list (current layout first, legacy fallback):
+
+1. `extension/bin/Microsoft.Dynamics.Nav.Analyzers.Common.dll` (BC 29+ / AL 17+)
+2. `extension/bin/Analyzers/Microsoft.Dynamics.Nav.Analyzers.Common.dll` (legacy, pre-BC 29)
+
+This applies in three places:
+- `Get-BC-DevTools.ps1` BCArtifact path: first-match over the local VSIX zip entries
+- `Get-BC-DevTools.ps1` Marketplace VSIX path: passes the candidate array to `Get-RemoteZipEntry.ps1`
+- `setup-bc-devtools/action.yml`: probes the local archive for the flat-layout DLL and extracts `extension/bin` (new) or `extension/bin/Analyzers` (legacy) recursively
+
+`Get-RemoteZipEntry.ps1` (shared) accepts `-EntryPath` as `[string[]]`: candidates are matched in order against the Central Directory in a single pass, so trying multiple layouts costs no extra HTTP requests.
+
 ### Assembly analysis (`Get-AssemblyInfo`)
 
 For each new BC DevTools version, the script downloads `Microsoft.Dynamics.Nav.Analyzers.Common.dll` and inspects it using `System.Reflection.Metadata` (built into the .NET runtime, no NuGet package needed):
@@ -46,6 +60,7 @@ This approach reads PE metadata directly from the file bytes without loading the
 | Assembly inspection method | `System.Reflection.Metadata` via `PEReader` + `MetadataReader` | Reads PE metadata directly from file bytes without loading the assembly into the runtime. Immune to cross-runtime version mismatches (e.g. net10.0 DLL on net8.0 host). Built into the .NET runtime, no NuGet package needed. |
 | TFM parsing | Regex on `TargetFrameworkAttribute` value | Handles `.NETStandard`, `.NETCoreApp`, and `.NETFramework` monikers. Future .NET versions are handled automatically. |
 | Cache key strategy | Content-based (SHA256 hash) | Only creates new cache entries when data actually changes |
+| VSIX DLL discovery | Ordered candidate-path list (flat `extension/bin` first, legacy `extension/bin/Analyzers` fallback) | BC 29 moved the SDK DLLs out of the `Analyzers` folder. Candidate list is predictable and cheap; the remote path resolves all candidates in one Central Directory pass. Bin-first because the `Analyzers` folder is legacy. |
 
 ## Maintenance
 
@@ -70,6 +85,7 @@ The pipeline is prepared for net10.0 BC DevTools:
 | Issue | Workaround |
 |---|---|
 | Corrupted or non-.NET assemblies cannot be read by `PEReader` | Returns `"analysis-error"` sentinel; downstream consumers should handle non-parseable versions |
+| Failed analyses write `error` entries into `TargetFramework.json`; since `Find-MissingVersions` matches on composite keys, those versions are never retried | Manually delete the `tfm-json-*` GitHub Actions cache entry; the next run re-analyzes everything |
 
 ## Key files
 


### PR DESCRIPTION
## Problem

The `get-bc-devtools` action failed on the BC 29 insider artifact:

```
WARNING:   Failed to process BCArtifact for 29.0.53721.0: Microsoft.Dynamics.Nav.Analyzers.Common.dll not found inside ALLanguage.vsix.
```

Starting with BC 29 (AL 17), `ALLanguage.vsix` no longer contains the `extension/bin/Analyzers/` folder. All SDK DLLs (including `Microsoft.Dynamics.Nav.Analyzers.Common.dll`) now sit flat in `extension/bin/`, alongside the compiler and third-party dependencies.

Verified against real artifacts:
- **BC 29.0.53721.0** (insider): DLL at `extension/bin/Microsoft.Dynamics.Nav.Analyzers.Common.dll`; no `Analyzers/` folder exists
- **BC 28.4.53241.53739** (current): DLL at `extension/bin/Analyzers/Microsoft.Dynamics.Nav.Analyzers.Common.dll` (legacy layout)

Three spots were affected, not just the one that failed:
1. `Get-BC-DevTools.ps1` BCArtifact path: exact-match lookup inside the locally extracted VSIX (the reported failure)
2. `Get-BC-DevTools.ps1` Marketplace VSIX path: hardcoded `extension/bin/Analyzers` passed to `Get-RemoteZipEntry.ps1` (AL 18.0 is already on the Marketplace with the flat layout)
3. `setup-bc-devtools/action.yml`: extracts the `extension/bin/Analyzers` folder for builds; fails on BC29 packages

## Fix

Ordered candidate-path strategy, `extension/bin` first (current layout), `extension/bin/Analyzers` as legacy fallback:

- **`shared/Get-RemoteZipEntry.ps1`**: `-EntryPath` changed from `[string]` to `[string[]]`. Candidates are matched in order against the Central Directory in a single pass, so trying multiple layouts costs **no extra HTTP requests**. Backward compatible with single-string callers.
- **`get-bc-devtools/Get-BC-DevTools.ps1`**: both VSIX code paths (BCArtifact local zip + Marketplace remote) use the candidate list.
- **`setup-bc-devtools/action.yml`**: probes the downloaded archive for the flat-layout DLL and picks `extension/bin` (new) or `extension/bin/Analyzers` (legacy). Extraction stays recursive; `Extract-RequiredFiles.ps1` is untouched. Measured delta for BC29 recursive bin extraction: 169 files / 53 MB vs 100 files / 45 MB before.
- **`get-bc-devtools.instructions.md`**: documents the dual layout, the candidate strategy, and the error-cache known issue.

NuGet packages are unaffected and unchanged.

## Validation (against real artifacts)

| Test | Source | Result |
|---|---|---|
| BCArtifact BC 29.0.53721.0 (flat) | insider CDN | `net10.0` / `18.0.40.32538` ✅ |
| BCArtifact BC 28.4.53241.53739 (legacy) | bcartifacts CDN | `net8.0` / `17.0.40.3339` ✅ |
| Marketplace VSIX AL 18.0.2498801 (flat) | gallerycdn | `net10.0` / `18.0.38.8509` ✅ |
| Marketplace VSIX AL 12.0.875970 (legacy) | gallerycdn | `12.0.13.24028` ✅ |
| NuGet 18.0.39.10160-beta (regression) | nuget.org | `net10.0` / `18.0.39.10160` ✅ |
| setup-bc-devtools extraction, both layouts | local VSIXes | all 4 required DLLs present ✅ |
| `action.yml` YAML validity | — | ✅ |

## Post-merge action required

The failed run wrote `TargetFramework = error` entries for 29.0.53721.0 into the `TargetFramework.json` cache. Since `Find-MissingVersions` matches on composite keys, that version will **not** be retried automatically. Delete the `tfm-json-*` GitHub Actions cache entry once after merging; the next run rebuilds it with this fix in place.