### PR TITLE
fix(PC0035): preserve qualified receivers in SetAutoCalcFields CodeFix

### DIFF
--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -68,13 +68,15 @@ This follows the same `_branchDepth` pattern used in `PartialRecordOperations` (
 4. Insert `SetAutoCalcFields(fields)` before the insertion target
 5. Arguments are passed through directly from CalcFields (unqualified field names)
 
+The receiver expression is reused verbatim from the CalcFields member access (trivia stripped), so qualified receivers like `this.Job` are preserved. Rebuilding it via `SyntaxFactory.IdentifierName(expression.ToString())` produced the quoted identifier `"this.Job"` (issue #428). An `SyntaxFactory.ElasticMarker` leading trivia is attached to the reused node: the SDK's `CodeAction` post-formats only elastic-annotated spans, and source nodes (unlike factory-created tokens) carry no elastic trivia, so without it the inserted statement loses its indentation.
+
 The insertion target must be an element of a statement list (`BlockSyntax` or `RepeatStatementSyntax` body). When the target is a single-statement branch (e.g. the `if X.FindSet() then repeat...` is itself an unblocked then-branch of an outer `if`), `InsertNodesBefore` would throw `InvalidOperationException` in the SDK's `SyntaxReplacer`. The `InsertableOrNull` guard returns null in that case, so no CodeFix is offered (issue #398); the diagnostic still appears.
 
 ## Test coverage
 
-**HasDiagnostic (7 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop, NestedLoopInConditional.
+**HasDiagnostic (8 cases):** FindSetRepeatUntil, FindRepeatUntil, WhileLoop, ReportOnAfterGetRecord, MultipleCalcFields, NestedLoop, NestedLoopInConditional, ThisQualifiedGlobalVariable.
 **NoDiagnostic (10 cases):** DifferentVariable, CalcFieldsOutsideLoop, CrossMethodCall, SingleRecord, CalcFieldsInIfBlock, CalcFieldsInCaseBlock, CalcFieldsInIfElseBlock, TemporaryVariable, TemporaryTableType, ReportTemporaryTableType.
-**HasFix (4 cases):** FindSetRepeatUntil, MultipleFields, IfFindSetRepeatUntil, IfFindSetBeginRepeatUntil.
+**HasFix (5 cases):** FindSetRepeatUntil, MultipleFields, IfFindSetRepeatUntil, IfFindSetBeginRepeatUntil, ThisQualifiedGlobalVariable.
 **NoFix (2 cases):** UnblockedThenBranch, UnblockedThenBranchBeforeElse.
 
 ## Known limitations

--- a/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
+++ b/.github/instructions/pc0035-use-set-auto-calc-fields-for-loops.instructions.md
@@ -79,6 +79,8 @@ The insertion target must be an element of a statement list (`BlockSyntax` or `R
 **HasFix (5 cases):** FindSetRepeatUntil, MultipleFields, IfFindSetRepeatUntil, IfFindSetBeginRepeatUntil, ThisQualifiedGlobalVariable.
 **NoFix (2 cases):** UnblockedThenBranch, UnblockedThenBranchBeforeElse.
 
+ThisQualifiedGlobalVariable (HasDiagnostic and HasFix) is gated with `SkipTestIfVersionIsTooLow("14.0")`: the `this` self-reference keyword requires runtime version 14.0 (BC 2024 wave 2).
+
 ## Known limitations
 
 - Cross-method CalcFields calls (passed record variable) are not detected

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/ThisQualifiedGlobalVariable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasDiagnostic/ThisQualifiedGlobalVariable.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        MyTable: Record MyTable;
+
+    procedure MyProcedure()
+    begin
+        if this.MyTable.FindSet() then
+            repeat
+                [|this.MyTable.CalcFields(MyFlowField)|];
+            until this.MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/ThisQualifiedGlobalVariable/current.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/ThisQualifiedGlobalVariable/current.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        MyTable: Record MyTable;
+
+    procedure MyProcedure()
+    begin
+        if this.MyTable.FindSet() then
+            repeat
+                [|this.MyTable.CalcFields(MyFlowField)|];
+            until this.MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/ThisQualifiedGlobalVariable/expected.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/HasFix/ThisQualifiedGlobalVariable/expected.al
@@ -1,0 +1,31 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        MyTable: Record MyTable;
+
+    procedure MyProcedure()
+    begin
+        this.MyTable.SetAutoCalcFields(MyFlowField);
+        if this.MyTable.FindSet() then
+            repeat
+            until this.MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; MyFlowField; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(MyTable);
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -28,6 +28,7 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("MultipleCalcFields")]
     [TestCase("NestedLoop")]
     [TestCase("NestedLoopInConditional")]
+    [TestCase("ThisQualifiedGlobalVariable")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -60,6 +61,7 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("MultipleFields")]
     [TestCase("IfFindSetRepeatUntil")]
     [TestCase("IfFindSetBeginRepeatUntil")]
+    [TestCase("ThisQualifiedGlobalVariable")]
     public async Task HasFix(string testCase)
     {
         var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))

--- a/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UseSetAutoCalcFieldsForLoops/UseSetAutoCalcFieldsForLoops.cs
@@ -31,6 +31,12 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("ThisQualifiedGlobalVariable")]
     public async Task HasDiagnostic(string testCase)
     {
+        SkipTestIfVersionIsTooLow(
+            ["ThisQualifiedGlobalVariable"],
+            testCase,
+            "14.0",
+            "The 'this' self-reference keyword requires runtime version 14.0 (BC 2024 wave 2).");
+
         var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
             .ConfigureAwait(false);
 
@@ -64,6 +70,12 @@ public class UseSetAutoCalcFieldsForLoops : NavCodeAnalysisBase
     [TestCase("ThisQualifiedGlobalVariable")]
     public async Task HasFix(string testCase)
     {
+        SkipTestIfVersionIsTooLow(
+            ["ThisQualifiedGlobalVariable"],
+            testCase,
+            "14.0",
+            "The 'this' self-reference keyword requires runtime version 14.0 (BC 2024 wave 2).");
+
         var currentCode = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasFix), testCase, "current.al"))
             .ConfigureAwait(false);
 

--- a/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
+++ b/src/ALCops.PlatformCop/CodeFixes/UseSetAutoCalcFieldsForLoopsCodeFixProvider.cs
@@ -78,14 +78,18 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             return document;
 
-        var variableName = memberAccess.Expression.ToString();
         var arguments = invocation.ArgumentList?.Arguments ?? default;
 
         if (arguments.Count == 0)
             return document;
 
-        // Build SetAutoCalcFields statement
-        var setAutoCalcFieldsStatement = BuildSetAutoCalcFieldsStatement(variableName, arguments);
+        // Build SetAutoCalcFields statement, reusing the original receiver expression
+        // so qualified receivers like 'this.Job' are preserved verbatim (issue #428).
+        // The elastic marker makes the CodeAction formatter indent the inserted
+        // statement; source nodes lack the elastic trivia factory tokens carry.
+        var setAutoCalcFieldsStatement = BuildSetAutoCalcFieldsStatement(
+            memberAccess.Expression.WithoutTrivia().WithLeadingTrivia(SyntaxFactory.ElasticMarker),
+            arguments);
 
         // Find the insertion point: before the loop or before the FindSet/Find call
         var insertionTarget = FindInsertionTarget(invocation);
@@ -139,12 +143,10 @@ public sealed class UseSetAutoCalcFieldsForLoopsCodeFixProvider : CodeFixProvide
     }
 
     private static ExpressionStatementSyntax BuildSetAutoCalcFieldsStatement(
-        string variableName, SeparatedSyntaxList<CodeExpressionSyntax> calcFieldsArguments)
+        CodeExpressionSyntax instanceExpression, SeparatedSyntaxList<CodeExpressionSyntax> calcFieldsArguments)
     {
-        var variableIdentifier = SyntaxFactory.IdentifierName(variableName);
-
         var setAutoCalcFieldsAccess = SyntaxFactory.MemberAccessExpression(
-            variableIdentifier,
+            instanceExpression,
             SyntaxFactory.Token(EnumProvider.SyntaxKind.DotToken),
             SyntaxFactory.IdentifierName("SetAutoCalcFields"));
 


### PR DESCRIPTION
## Problem

The PC0035 CodeFix rebuilt the SetAutoCalcFields receiver via `SyntaxFactory.IdentifierName(memberAccess.Expression.ToString())`. For `this.`-qualified globals the expression is a `MemberAccessExpressionSyntax`, and round-tripping it through a string quoted it as an identifier, generating non-compiling AL:

```al
"this.Job".SetAutoCalcFields("Scheduled Res. Qty.");
```

## Fix

Reuse the original receiver expression node (`memberAccess.Expression.WithoutTrivia()`), preserving `this.Job` verbatim. A `SyntaxFactory.ElasticMarker` leading trivia is attached because the SDK's `CodeAction` post-formats only elastic-annotated spans; source nodes carry no elastic trivia (unlike factory-created tokens), so without it the inserted statement lost its indentation.

The analyzer itself was unaffected (it resolves receivers via `GetSymbolSafe()?.Name`).

## Tests

- New `HasDiagnostic/ThisQualifiedGlobalVariable.al` and `HasFix/ThisQualifiedGlobalVariable` fixtures
- All 25 UseSetAutoCalcFieldsForLoops tests pass

## Out of scope

An audit for the same pattern across all CodeFixes found two related (lower-severity) spots in PC0030 and MandatoryFieldMissingOnApiPage; filed as #440.

Fixes #428