### PR TITLE
fix(PC0030): suppress diagnostic when record escapes via exit statement

### DIFF
--- a/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
+++ b/.github/instructions/pc0030-use-partial-records-on-read.instructions.md
@@ -54,6 +54,7 @@ These decisions were made during the initial design and should be preserved unle
 | Record-as-source assignment | Treat same as write op (suppress forward + backward) | `TempMyTable := MyTable` reads all fields; adding SetLoadFields before a preceding read would cause partial copy. Only bare variable references on RHS, not field access. |
 | HasWriteOp renamed | `HasFullRecordAccess` | Flag now covers writes AND whole-record assignments; name reflects expanded semantics |
 | Setup table suppression | Suppress on parameterless `Get()` when table is a setup table | Near-zero SQL benefit for single-record cached tables; MS BaseApp uses SetLoadFields on setup tables in only 1.8% of cases. Heuristic: single PK field, Code type, name matches "Primary Key"/"PrimaryKey" case-insensitive. Uses `TableHelper.IsSetupTable()` from ALCops.Common. Only `Get()` with no arguments suppressed; FindFirst/FindSet on setup tables still fire. See [#283](https://github.com/ALCops/Analyzers/issues/283). |
+| Exit statement escape | Retroactive-only clear of `UncoveredReads` on the current path; NO forward flow flag | `exit(Rec)` escapes the procedure scope, so the caller might need the full record. `exit` terminates the path, so forward state is unreachable; setting a flow flag would leak suppression past the enclosing branch via OR-merge, causing false negatives on reads after an early-exit guard (`if Cond then exit(Rec); Rec.Get(X);` must still fire). Only bare variable references suppress (`exit(Rec."No.")` does not). Sets method-level `EverPassedToFunction` for RecordRef SetTable suppression. See [#429](https://github.com/ALCops/Analyzers/issues/429). |
 
 ## Architecture
 
@@ -73,10 +74,11 @@ Uses `RegisterCodeBlockAction` (not `RegisterOperationAction`) to analyze entire
 4. **Read evaluation is immediate**: When a read (Get/Find/FindFirst/FindLast/FindSet) is encountered, the current flow state determines whether to flag it. If `!HasLoadFields && !HasFullRecordAccess && !PassedToFunction`, the read is added to `UncoveredReads`.
 5. **Retroactive clearing**: When a write/pass/record-assignment operation is encountered, `UncoveredReads` is cleared (reads before the operation are retroactively suppressed). This handles patterns like `Get(); Modify()` or `FindSet(); TempRec := Rec` where the full-record operation comes after the read.
 6. **Assignment detection**: `VisitAssignmentStatement` checks if the RHS of an assignment is a tracked record variable (unwrapping `IConversionExpression` if present). When matched, sets `HasFullRecordAccess` and clears `UncoveredReads`, same as write methods.
-6. **Control flow**: Override `VisitIfStatement`, `VisitCaseStatement`, and loop visit methods with fork/merge semantics.
-7. **Reset detection**: `Clear(var)`, `var.Reset()`, and `var.SetLoadFields()` with no arguments reset flow flags.
-8. Post-walk: `FinalizeResults()` deduplicates uncovered reads and copies them to `VariableState.UncoveredReadLocations`.
-9. For RecordRef variables with `SetTable(TargetRecord)` calls: suppress if any target is unresolvable, non-local, or has a suppression condition (uses method-level `EverHad*` flags).
+7. **Exit statement detection**: `VisitExitStatement` checks if the returned value is a bare tracked record variable (via `GetVariableNameFromOperation`, null-safe for plain `exit;`). When matched, clears `UncoveredReads` for that variable on the current path and sets the method-level `EverPassedToFunction` flag. No forward flow flag is set because the path terminates at `exit`. Field access returns (`exit(Rec."No.")`) do not suppress. `base.VisitExitStatement` (SDK default: `Visit(operation.ReturnedValue)`) still walks nested expressions like `exit(Rec.Get(X))`.
+8. **Control flow**: Override `VisitIfStatement`, `VisitCaseStatement`, and loop visit methods with fork/merge semantics.
+9. **Reset detection**: `Clear(var)`, `var.Reset()`, and `var.SetLoadFields()` with no arguments reset flow flags.
+10. Post-walk: `FinalizeResults()` deduplicates uncovered reads and copies them to `VariableState.UncoveredReadLocations`.
+11. For RecordRef variables with `SetTable(TargetRecord)` calls: suppress if any target is unresolvable, non-local, or has a suppression condition (uses method-level `EverHad*` flags).
 
 ### Control flow fork/merge semantics
 
@@ -184,11 +186,11 @@ AA0242 (CodeCop's `Rule0242PartialRecordsDetectJitLoads`) is the **complement** 
 
 ## Test coverage
 
-65 test cases total:
+73 test cases total:
 
-**HasDiagnostic (20 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, ClearResetsRecordAssignment, LoopNoSetLoadFields, SetupTableGetWithArgs, SetupTableFindFirst.
+**HasDiagnostic (24 cases):** LocalRecordGet, LocalRecordGetBySystemId, LocalRecordFindFirst, LocalRecordFindSet, LocalRecordFindLast, LocalRecordFind, LocalRecordMultipleReads, LocalRecordRefFindFirst, SetLoadFieldsAfterGet, ClearBetweenSetLoadFieldsAndGet, ResetBetweenSetLoadFieldsAndGet, SetLoadFieldsNoArgsBetween, CaseBranchWithoutSetLoadFields, IfBranchWithoutSetLoadFields, ClearResetsWriteOp, ClearResetsPassedToFunction, ClearResetsRecordAssignment, LoopNoSetLoadFields, SetupTableGetWithArgs, SetupTableFindFirst, ExitInOtherBranchOnly, ExitGuardThenRead, ExitFieldAccess, ExitOtherVariable.
 
-**NoDiagnostic (34 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore, FindSetWithModifyInLoop, FindSetWithPassedToFunctionInLoop, GetWithConditionalModify, RecordAssignedToOther, RecordAssignedToOtherQuotedName, RecordAssignedBeforeRead, SetupTableGet, SetupTableGetNoSpace.
+**NoDiagnostic (38 cases):** HasSetLoadFields, HasSetLoadFieldsGetBySystemId, HasAddLoadFields, HasSetBaseLoadFields, HasModify, HasInsert, HasDelete, HasDeleteAll, HasModifyAll, HasRename, HasTransferFields, HasInit, HasCopy, PassedToFunction, PassedToEvent, PassedToPageRun, TemporaryTable, GlobalVariable, ParameterVariable, IsEmptyOnly, CDSTable, RecordRefSetTableWithModify, RecordRefSetTablePassedToFunction, DatabaseObjectReference, IfBothBranchesSetLoadFields, LoopSetLoadFieldsBefore, FindSetWithModifyInLoop, FindSetWithPassedToFunctionInLoop, GetWithConditionalModify, RecordAssignedToOther, RecordAssignedToOtherQuotedName, RecordAssignedBeforeRead, SetupTableGet, SetupTableGetNoSpace, ExitRecord, ExitRecordInIfBranch, ExitRecordInCaseBranch, ExitRecordInLoop.
 
 **HasFix (11 cases):** SingleField, MultipleFields, QuotedFieldName, NoFieldAccess, SetRangeFieldExcluded, SetFilterFieldExcluded, SetRangeValueArgIncluded, AllFieldsInFilters, TestFieldIncluded, SetCurrentKeyExcluded, MixedFilterAndConsume.
 

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitFieldAccess.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitFieldAccess.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetFieldValue(EntryNo: Integer): Integer
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get(EntryNo)|];
+        exit(MyTable.MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitGuardThenRead.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitGuardThenRead.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetRecordOrDefault(EntryNo: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        if EntryNo = 0 then
+            exit(MyTable);
+
+        [|MyTable.Get(EntryNo)|];
+        MyTable.TestField(MyField);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitInOtherBranchOnly.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitInOtherBranchOnly.al
@@ -1,0 +1,28 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetRecord(EntryNo: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        if EntryNo = 0 then begin
+            [|MyTable.FindFirst()|];
+            Error('EntryNo is empty. Defaulting to entry: %1', MyTable.MyField);
+        end else begin
+            MyTable.Get(EntryNo);
+            exit(MyTable);
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitOtherVariable.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/HasDiagnostic/ExitOtherVariable.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetSelectedRecord(EntryNo: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+        SelectedTable: Record MyTable;
+    begin
+        [|MyTable.Get(EntryNo)|];
+        SelectedTable.Get(MyTable.MyField);
+        exit(SelectedTable);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecord.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecord.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetRecord(EntryNo: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Get(EntryNo)|];
+        exit(MyTable);
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInCaseBranch.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInCaseBranch.al
@@ -1,0 +1,33 @@
+codeunit 50100 MyCodeunit
+{
+    procedure GetRecordByMode(Mode: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        case Mode of
+            1:
+                begin
+                    [|MyTable.FindFirst()|];
+                    exit(MyTable);
+                end;
+            2:
+                begin
+                    [|MyTable.FindLast()|];
+                    exit(MyTable);
+                end;
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInIfBranch.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInIfBranch.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure FindRecord(ShouldFind: Boolean): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        if ShouldFind then begin
+            [|MyTable.FindFirst()|];
+            exit(MyTable);
+        end;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInLoop.al
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/NoDiagnostic/ExitRecordInLoop.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure FindMatchingRecord(TargetValue: Integer): Record MyTable
+    var
+        MyTable: Record MyTable;
+    begin
+        if [|MyTable.FindSet()|] then
+            repeat
+                if MyTable.MyField = TargetValue then
+                    exit(MyTable);
+            until MyTable.Next() = 0;
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; MyField) { }
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/UsePartialRecordsOnRead/UsePartialRecordsOnRead.cs
@@ -41,6 +41,10 @@ namespace ALCops.PlatformCop.Test
         [TestCase("LoopNoSetLoadFields")]
         [TestCase("SetupTableGetWithArgs")]
         [TestCase("SetupTableFindFirst")]
+        [TestCase("ExitInOtherBranchOnly")]
+        [TestCase("ExitGuardThenRead")]
+        [TestCase("ExitFieldAccess")]
+        [TestCase("ExitOtherVariable")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -84,6 +88,10 @@ namespace ALCops.PlatformCop.Test
         [TestCase("RecordAssignedBeforeRead")]
         [TestCase("SetupTableGet")]
         [TestCase("SetupTableGetNoSpace")]
+        [TestCase("ExitRecord")]
+        [TestCase("ExitRecordInIfBranch")]
+        [TestCase("ExitRecordInCaseBranch")]
+        [TestCase("ExitRecordInLoop")]
         public async Task NoDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))

--- a/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
+++ b/src/ALCops.PlatformCop/Analyzers/PartialRecordOperations.cs
@@ -357,6 +357,26 @@ public sealed class PartialRecordOperations : DiagnosticAnalyzer
             base.VisitAssignmentStatement(operation);
         }
 
+        public override void VisitExitStatement(IExitStatement operation)
+        {
+            // exit(MyTable): the record escapes the procedure scope and the caller
+            // might access any field, so retroactively suppress uncovered reads on
+            // this path. No forward flow flag is set: exit terminates the path, so
+            // forward state is unreachable. Setting a flag would leak suppression
+            // past the enclosing branch via OR-merge, causing false negatives on
+            // reads after an early-exit guard.
+            var returnedVarName = GetVariableNameFromOperation(operation.ReturnedValue);
+            if (returnedVarName != null &&
+                _trackedVariables.TryGetValue(returnedVarName, out var state) &&
+                _flowState.TryGetValue(returnedVarName, out var flowFlags))
+            {
+                flowFlags.UncoveredReads.Clear();
+                state.EverPassedToFunction = true;
+            }
+
+            base.VisitExitStatement(operation);
+        }
+
         #region Control flow overrides
 
         /// <summary>


### PR DESCRIPTION
Fixes #429

## Problem

PC0030 (`UsePartialRecordsOnRead`) fired on local record variables that escape the procedure via `exit(Rec)`. The `SetLoadFieldsWalker` had no `VisitExitStatement` override, so exits were invisible to the dataflow analysis. The caller may need the full record, so `SetLoadFields` must not be suggested on reads that feed an `exit(Rec)` on the same path.

## Solution

Add a `VisitExitStatement` override to `SetLoadFieldsWalker` with **retroactive-only clearing**:

- If the returned value is a bare tracked record variable, clear its `UncoveredReads` on the current flow path.
- **No forward flow flag is set.** `exit` terminates the path, so forward state is unreachable. Setting `PassedToFunction` would leak suppression past the enclosing branch via OR-merge, creating false negatives (e.g. `if Cond then exit(Rec); Rec.Get(X);` must still fire on the `Get`).
- Only bare variable references suppress; `exit(Rec."No.")` still fires (that is exactly when `SetLoadFields` helps).
- Sets method-level `EverPassedToFunction` so `RecordRef.SetTable(Rec)` suppression stays consistent.
- `base.VisitExitStatement` still walks nested expressions (`exit(Rec.Get(X))`).

Existing fork/merge rules then handle branch scenarios correctly: an else-branch `Get` + `exit(Rec)` is suppressed, while a sibling then-branch read still fires (in-branch union merge).

## Tests (8 new fixtures, 73 total for the rule)

**NoDiagnostic (suppression works):**
- `ExitRecord` - issue repro: `Get` then `exit(Rec)`
- `ExitRecordInIfBranch` - read + exit inside a then-branch
- `ExitRecordInCaseBranch` - read + exit inside case lines
- `ExitRecordInLoop` - `FindSet` + conditional `exit(Rec)` inside repeat loop

**HasDiagnostic (false-negative regression guards):**
- `ExitInOtherBranchOnly` - read fires in the branch that does NOT exit the record
- `ExitGuardThenRead` - early-exit guard must not suppress a later read (OR-merge leak guard)
- `ExitFieldAccess` - `exit(Rec."No.")` does not suppress
- `ExitOtherVariable` - `exit(OtherRec)` does not suppress reads on `Rec`

## Verification

- `dotnet build ALCops.sln` - clean
- `dotnet test --filter FullyQualifiedName~UsePartialRecordsOnRead` - 73/73 pass
- Full PlatformCop test project - 514/514 pass

SDK behavior verified against decompiled source: `IExitStatement.ReturnedValue` is nullable (plain `exit;`), `OperationWalker.VisitExitStatement` default only visits `ReturnedValue`, identical shape on net8.0/net10.0, no netstandard2.1 guard needed.