### PR TITLE
test(FC0002): lock in context-dependent XmlPort casing behavior

### DIFF
--- a/.github/instructions/fc0002-casing-mismatch.instructions.md
+++ b/.github/instructions/fc0002-casing-mismatch.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: 'src/ALCops.FormattingCop/**/CasingMismatch*'
+---
+
+# FC0002: Casing Mismatch
+
+## Purpose
+
+Reports when the casing of a keyword or identifier reference differs from its canonical form: the declaration for user symbols, the SDK's canonical name for built-in keywords, types, and members. AL is case-insensitive; FC0002 enforces the compiler's own spelling.
+
+## Diagnostic properties
+
+- **ID**: FC0002, category Style, severity Info (see `DiagnosticDescriptors.CasingMismatch`)
+- **Two analyzers share the descriptor**: `CasingMismatchKeyword` (keyword tokens) and `CasingMismatchIdentifier` (identifiers, data types, properties, option/object access)
+- **CodeFix**: `CodeFixes/CasingMismatchKeyword.cs` (keyword tokens only; identifier diagnostics carry `CanonicalText` in properties but have no CodeFix yet)
+
+## Architecture
+
+- `CasingMismatchKeyword`: `RegisterSymbolAction` per object kind; walks descendant tokens, compares keyword tokens against `SyntaxFactory.Token(kind).ValueText`. Skips tokens whose parent is a `*DataType` node or `IdentifierName`.
+- `CasingMismatchIdentifier`: single iterative tree walk per object symbol. Dictionary-resolvable nodes are handled inline (fast); identifiers, qualified names, and triggers are batched for semantic-model resolution, grouped by (text, scope) so `GetSymbolInfo` runs once per group.
+
+Key dictionaries (all `OrdinalIgnoreCase` keyed, value = canonical text):
+
+| Dictionary | Source | Used for |
+|---|---|---|
+| `_navTypeKindDictionary` | `NavTypeKind` enum names + `Database` | Data type names (`SubtypedDataTypeSyntax`, `DataTypeSyntax`) |
+| `_symbolKindDictionary` | `SymbolKind` enum names, **`XmlPort` remapped to `Xmlport`**, + `Database`, `ObjectType` | Left side of `::` object access and member after `Database::` etc. |
+| `_objectTypeMemberDictionary` | `SymbolKind` enum names verbatim (`XmlPort`) | Members of `ObjectType::` |
+| `_enumPropertyValuesByKind/Name` | Reflection over SDK `PropertyInfoLookup` | Enum property values |
+| `KeywordTexts` | All `*Keyword` token texts | Skip identifiers named after keywords in semantic resolution |
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| XmlPort casing is context-dependent, mirroring the SDK exactly | The AL compiler itself is inconsistent; FC0002 follows the compiler/IntelliSense, not a single invented spelling. See matrix below. Issue #432 and upstream LinterCop #729 confirmed by-design. |
+| `XmlPort → Xmlport` remap in `_symbolKindDictionary` | The `::` left side and static class bind to the SDK's `XmlportClassTypeSymbol`, literally named `"Xmlport"` (`XmlportClassTypeSymbol.cs`). |
+| `.Run`/`.Import`/`.Export` receiver (`Xmlport.Run`) is NOT analyzed | The `KeywordTexts` filter in `ResolveIdentifiers` skips identifiers named after keywords to avoid false positives on user symbols. Known false negative; kept intentionally. |
+| Identifiers grouped by (text, scope) before `GetSymbolInfo` | Performance: one semantic call per distinct spelling per method scope. |
+
+### XmlPort casing matrix (SDK ground truth, `../nav-sdk-source`)
+
+| Context | Canonical | SDK evidence |
+|---|---|---|
+| Object declaration keyword | `xmlport` | `SyntaxFacts` keyword text |
+| Variable/parameter type | `XmlPort` | `NavTypeKindExtensions`: `NavTypeKind.XmlPort => "XmlPort"` |
+| Static class (`Run`/`Import`/`Export`) | `Xmlport` | `XmlportClassTypeSymbol` name |
+| `::` object access left side | `Xmlport` | Binder binds to `XmlportClassTypeSymbol` |
+| `ObjectType::XmlPort` member | `XmlPort` | `SymbolKind` enum name |
+
+## Known issues
+
+- `Xmlport.Run` receiver with wrong casing (`XMLPORT.Run`) is not flagged (keyword-named identifier filter, see design decisions).
+- Option members of platform table fields (e.g. `"Object Type"::XMLport`) resolve via semantic model to the platform's own casing.
+
+## Test coverage
+
+Test classes: `CasingMismatchKeyword`, `CasingMismatchDeclaration`, `CasingMismatchBuiltInMethod` (the latter two both exercise `CasingMismatchIdentifier`).
+
+**CasingMismatchKeyword HasDiagnostic (4 cases):** Codeunit, Enum, Table, XmlPort.
+**CasingMismatchKeyword NoDiagnostic (5 cases):** Codeunit, Enum, Table, VariableNamedAfterKeyword, XmlPort.
+**CasingMismatchKeyword HasFix (1 case):** ObjectKeyword.
+**CasingMismatchDeclaration HasDiagnostic (20 cases):** DataType, EnumDataType, FieldGroup, LabelDataType, LabelProperties, LengthDataType, MemberAccessField, OptionDataType, Property, TextConstDataType, TestType, TriggerDeclaration, ObjectTypeOptionAccess, CrossScopeIdentifierGrouping, GlobalVarAndParam, GlobalVarAndParamThisPrefix, GlobalVarAndReturnValue, GlobalVarAndLocalVar, XmlPortDataType, XmlPortObjectAccess.
+**CasingMismatchDeclaration NoDiagnostic (25 cases):** AccessByPermission, DataType, EnumDataType, FieldGroup, IdentifierNameSyntaxGrouping, LabelDataType, LabelProperties, LengthDataType, MemberAccessField, OptionDataType, Property, TextConstDataType, TestType, TriggerDeclaration, VariableNamedAfterKeyword, ObjectTypeOptionAccess, DeeplyNestedExpression, CrossScopeIdentifierGrouping, CrossScopeQualifiedNameGrouping, GlobalVarAndParam, GlobalVarAndParamThisPrefix, GlobalVarAndReturnValue, GlobalVarAndLocalVar, XmlPortDataType, XmlPortObjectAccess.
+**CasingMismatchBuiltInMethod HasDiagnostic (7 cases):** FieldAccess, GlobalReferenceExpression, InvocationExpression, LocalReferenceExpression, ParameterReferenceExpression, ReturnValueReferenceExpression, XmlPortDataItemAccess.
+**CasingMismatchBuiltInMethod NoDiagnostic (7 cases):** FieldAccess, GlobalReferenceExpression, InvocationExpression, LocalReferenceExpression, ParameterReferenceExpression, ReturnValueReferenceExpression, XmlPortDataItemAccess.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -93,6 +93,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
 | `sdk-analyzer-infrastructure` | `'src/ALCops.*/Analyzers/**'` | NAV SDK internals: callback ordering, incremental compilation, GetOperation perf |
 | `analyzer-exception-harness` | `'src/ALCops.Common/Diagnostics/**'` | XX0000 harness: base class + context decorators that convert analyzer exceptions into located diagnostics |
+| `fc0002-casing-mismatch` | rule-scoped | FC0002 rule (both analyzers, XmlPort casing matrix) |
 | `fc0004-permission-declaration-order` | rule-scoped | FC0004 rule |
 | `fc0005-use-parenthesis-for-method-assignment` | rule-scoped | FC0005 rule |
 | `fc0006-permission-values-should-be-lowercase` | rule-scoped | FC0006 rule |

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/CasingMismatchDeclaration.cs
@@ -39,6 +39,8 @@ namespace ALCops.FormattingCop.Test
         [TestCase("GlobalVarAndParamThisPrefix")]
         [TestCase("GlobalVarAndReturnValue")]
         [TestCase("GlobalVarAndLocalVar")]
+        [TestCase("XmlPortDataType")]
+        [TestCase("XmlPortObjectAccess")]
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
@@ -89,6 +91,8 @@ namespace ALCops.FormattingCop.Test
         [TestCase("GlobalVarAndParamThisPrefix")]
         [TestCase("GlobalVarAndReturnValue")]
         [TestCase("GlobalVarAndLocalVar")]
+        [TestCase("XmlPortDataType")]
+        [TestCase("XmlPortObjectAccess")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/XmlPortDataType.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/XmlPortDataType.al
@@ -1,0 +1,11 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyParam: [|Xmlport|] "My Xmlport")
+    var
+        MyPort: [|XMLPORT|] "My Xmlport";
+        MyOtherPort: [|xmlport|] "My Xmlport";
+    begin
+    end;
+}
+
+xmlport 50100 "My Xmlport" { schema { textelement(NodeName1) { } } }

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/XmlPortObjectAccess.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/HasDiagnostic/XmlPortObjectAccess.al
@@ -1,0 +1,28 @@
+page 50100 MyPage
+{
+    actions
+    {
+        area(Processing)
+        {
+            action(Import)
+            {
+                trigger OnAction()
+                begin
+                    // The receiver of Run() is intentionally not analyzed (keyword-named identifier filter)
+                    XmlPort.Run([|XmlPort|]::"My Xmlport");
+                end;
+            }
+        }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        Xmlport.Run([|XMLPORT|]::"My Xmlport");
+        Xmlport.Run([|xmlport|]::"My Xmlport", true);
+    end;
+}
+
+xmlport 50100 "My Xmlport" { schema { textelement(NodeName1) { } } }

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/XmlPortDataType.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/XmlPortDataType.al
@@ -1,0 +1,10 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyParam: [|XmlPort|] "My Xmlport")
+    var
+        MyPort: [|XmlPort|] "My Xmlport";
+    begin
+    end;
+}
+
+xmlport 50100 "My Xmlport" { schema { textelement(NodeName1) { } } }

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/XmlPortObjectAccess.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchDeclaration/NoDiagnostic/XmlPortObjectAccess.al
@@ -1,0 +1,27 @@
+page 50100 MyPage
+{
+    actions
+    {
+        area(Processing)
+        {
+            action(Import)
+            {
+                trigger OnAction()
+                begin
+                    Xmlport.Run([|Xmlport|]::"My Xmlport");
+                end;
+            }
+        }
+    }
+}
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        Xmlport.Run([|Xmlport|]::"My Xmlport");
+        Xmlport.Run([|Xmlport|]::"My Xmlport", true);
+    end;
+}
+
+xmlport 50100 "My Xmlport" { schema { textelement(NodeName1) { } } }

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/CasingMismatchKeyword.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/CasingMismatchKeyword.cs
@@ -24,6 +24,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("Codeunit")]
         [TestCase("Enum")]
         [TestCase("Table")]
+        [TestCase("XmlPort")]
         public async Task HasDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
@@ -43,6 +44,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("Enum")]
         [TestCase("Table")]
         [TestCase("VariableNamedAfterKeyword")]
+        [TestCase("XmlPort")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/HasDiagnostic/XmlPort.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/HasDiagnostic/XmlPort.al
@@ -1,0 +1,7 @@
+[|XmlPort|] 50100 "My Xmlport"
+{
+    schema
+    {
+        textelement(NodeName1) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/NoDiagnostic/XmlPort.al
+++ b/src/ALCops.FormattingCop.Test/Rules/CasingMismatchKeyword/NoDiagnostic/XmlPort.al
@@ -1,0 +1,7 @@
+[|xmlport|] 50100 "My Xmlport"
+{
+    schema
+    {
+        textelement(NodeName1) { }
+    }
+}


### PR DESCRIPTION
## Summary

Investigation of #432 against the NAV SDK source shows the reported diagnostic is **by design**: the AL compiler itself uses context-dependent canonical casings for xmlport, and FC0002 mirrors the compiler (and VS Code IntelliSense) exactly.

| Context | Canonical | SDK evidence |
|---|---|---|
| Object declaration keyword | `xmlport` | `SyntaxFacts` keyword text |
| Variable/parameter type | `XmlPort` | `NavTypeKind.XmlPort => "XmlPort"` |
| Static class (`Run`/`Import`/`Export`) | `Xmlport` | `XmlportClassTypeSymbol` name is literally `"Xmlport"` |
| `::` object access left side | `Xmlport` | Binder binds to the same class symbol |
| `ObjectType::XmlPort` member | `XmlPort` | `SymbolKind` enum name |

## Changes

- **No analyzer changes** — current behavior is correct.
- Regression fixtures freezing the per-context behavior so future refactors can't silently change it:
  - `CasingMismatchDeclaration`: `XmlPortObjectAccess` (`Xmlport::` accepted incl. the exact #432 repro shape, `XmlPort::`/`XMLPORT::`/`xmlport::` flagged), `XmlPortDataType` (`XmlPort` type accepted, other casings flagged)
  - `CasingMismatchKeyword`: `XmlPort` (lowercase `xmlport` declaration keyword accepted, `XmlPort` flagged)
- New instruction file `fc0002-casing-mismatch.instructions.md` documenting the casing matrix, dictionary architecture, and the intentional `.Run` receiver false negative (keyword-named identifier filter).

## Testing

`dotnet test src/ALCops.FormattingCop.Test/ --filter FullyQualifiedName~CasingMismatch` — 69 passed (63 existing + 6 new).

Relates to #432 (to be answered as by-design).

Upstream context: StefanMaron/BusinessCentral.LinterCop#729 reached the same conclusion.
