### PR TITLE
fix: PC0020/PC0021 fire for fields on removed tables

### DIFF
--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -103,6 +103,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `lc0092-naming-pattern` | rule-scoped | LC0092 rule |
 | `lc0096-unnecessary-record-parameter` | rule-scoped | LC0096 rule |
 | `pc0029-use-sequential-guid` | rule-scoped | PC0029 rule |
+| `pc0020-pc0021-transferfields-schema-compatibility` | rule-scoped | PC0020/PC0021 rules (one analyzer, invocation + relation paths) |
 | `pc0030-use-partial-records-on-read` | rule-scoped | PC0030 rule |
 | `pc0031-partial-records-cause-jit-load` | rule-scoped | PC0031 rule |
 | `pc0032-report-layout-property-length` | rule-scoped | PC0032 rule |

--- a/.github/instructions/pc0020-pc0021-transferfields-schema-compatibility.instructions.md
+++ b/.github/instructions/pc0020-pc0021-transferfields-schema-compatibility.instructions.md
@@ -1,0 +1,68 @@
+---
+applyTo: 'src/ALCops.PlatformCop/**/TransferFields*'
+---
+
+# PC0020 / PC0021: TransferFields schema compatibility
+
+One analyzer (`Analyzers/TransferFieldsSchemaCompatibility.cs`) reports two diagnostics:
+
+| ID | Descriptor | Meaning |
+|---|---|---|
+| PC0020 | `TransferFieldsTypeMismatch` | Same field ID, incompatible types between source and target table |
+| PC0021 | `TransferFieldsNameMismatch` | Same field ID, different field names |
+
+Category: Usage. Severity: Warning. Help URIs: `platformcop/pc0020`, `platformcop/pc0021`.
+
+## Architecture
+
+Two analysis paths:
+
+1. **Invocation path** (`AnalyzeInvocation`, `RegisterOperationAction` on InvocationExpression):
+   matches built-in `TransferFields` calls, resolves source table from argument 0 and target table
+   from `invocation.Instance` (or the containing table object for `Rec.TransferFields(...)`).
+   Reports at field level when the pair is NOT in the curated relation list, and always emits a
+   summary diagnostic at the invocation site.
+2. **Relation path** (`AnalyzeTableExtension`, `RegisterSymbolAction` on TableExtension): for
+   extensions whose base table appears as Source in the curated `TransferFieldsRelations.TableRelations`
+   list (e.g. Customer → Contact), compares extension-added fields on both sides and reports at
+   field level on both extension fields.
+
+Effective fields = base table fields + all tableextension `AddedFields` across modules (cached per
+`Compilation` via `ConditionalWeakTable`). `TransferFields(_, InitPrimaryKeyFields: false)` excludes
+PK fields; a constant-`true` third argument (`SkipFieldsNotMatchingType`) suppresses analysis.
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| Filter removed **fields** in `BuildFieldMapById` via `IsRemoved()` | Issue #148: removed fields don't participate in TransferFields at runtime |
+| Skip invocation analysis when **either** source or target table `IsRemoved()` | Issue #435: upgrade code transfers from removed tables; a removed target makes the call dead code |
+| Skip relation-path extensions that are removed or whose base table `IsRemoved()` | Issue #435: non-removed fields on removed tables were still compared |
+| Use `IsRemoved()` (Removed/Moved), NOT `IsObsolete()` | `ObsoleteState = Pending` tables/fields still participate at runtime and must keep firing |
+| Field-level `#pragma warning disable` honored on either side | Checked via `IsEitherFieldSuppressed` against field syntax directives |
+| Enum→Integer, Code→Text, Integer→BigInteger/Decimal treated as compatible | Safe implicit conversions performed by the platform |
+
+## SDK behavior notes
+
+- The AL compiler suppresses obsolete diagnostics entirely inside `Subtype = Upgrade` / `Install`
+  codeunits (`Binder.IsUpgradeOrInstallCode`, nav-sdk-source `Binder.cs`). This is why upgrade code
+  referencing removed tables compiles cleanly and reaches this analyzer.
+- Outside upgrade/install code, in-module references to removed tables are compile errors
+  (`WRN_ERR_ObsoleteStateObsolete` reported as error), so invocation-path test fixtures for removed
+  tables MUST use an upgrade codeunit.
+
+## Test coverage
+
+Rules folders: `Rules/TransferFieldsTypeMismatch/` and `Rules/TransferFieldsNameMismatch/` in
+`ALCops.PlatformCop.Test` (both use the same analyzer, asserting their own diagnostic ID).
+
+**TransferFieldsTypeMismatch HasDiagnostic (17 cases):** InvocationRecWithCodeunit, InvocationRecWithPage, InvocationRecWithTable, InvocationRecWithTablexRec, InvocationSkipFieldsNotMatchingType, InvocationWithInitPrimaryKeyFieldsIsTrue, InvocationWithReturnValue, InvocationWithVarGlobals, InvocationWithVarLocalAndGlobal, InvocationWithVarLocals, InvocationWithVarParam, InvocationWithTableExtension, Invocation_SourceTableObsoleteStatePending, TableExt_Multiple_SameBase, TableExtension, TableExtensionTypeWithType, TableExtensionTypeWithTypeLength.
+**TransferFieldsTypeMismatch NoDiagnostic (18 cases):** BuiltInInvocation, Invocation_ObsoleteStateRemoved, Invocation_Pragma, Invocation_SourceTableObsoleteStateRemoved, Invocation_TargetTableObsoleteStateRemoved, InvocationCodeToText, InvocationSkipFieldsNotMatchingType, InvocationWithInitPrimaryKeyFieldsIsFalse, InvocationWithTableExtension, InvocationWithType, InvocationWithTypeLength, TableExt_BothObsoleteStateRemoved, TableExt_ObsoleteStateRemoved, TableExt_Paired_Extension_Pragma, TableExt_Paired_SingleTableExt, TableExt_SourceBaseTableObsoleteStateRemoved, TableExt_TargetBaseTableObsoleteStateRemoved, TableExt_Unpaired.
+**TransferFieldsNameMismatch HasDiagnostic (16 cases):** InvocationRecWithCodeunit, InvocationRecWithPage, InvocationRecWithTable, InvocationRecWithTablexRec, InvocationSkipFieldsNotMatchingType, InvocationWithInitPrimaryKeyFieldsIsTrue, InvocationWithReturnValue, InvocationWithVarGlobals, InvocationWithVarLocalAndGlobal, InvocationWithVarLocals, InvocationWithVarParam, InvocationWithTableExtension, Invocation_SourceTableObsoleteStatePending, TableExt_Multiple_SameBase, TableExtension, TableExt_NamespaceCasingMismatch.
+**TransferFieldsNameMismatch NoDiagnostic (14 cases):** BuiltInInvocation, Invocation_ObsoleteStateRemoved, Invocation_Pragma, Invocation_SourceTableObsoleteStateRemoved, Invocation_TargetTableObsoleteStateRemoved, InvocationSkipFieldsNotMatchingType, InvocationWithInitPrimaryKeyFieldsIsFalse, InvocationWithTableExtension, TableExt_ObsoleteStateRemoved, TableExt_Paired_Extension_Pragma, TableExt_Paired_SingleTableExt, TableExt_SourceBaseTableObsoleteStateRemoved, TableExt_TargetBaseTableObsoleteStateRemoved, TableExt_Unpaired.
+
+## Known issues
+
+- `TransferFieldsRelations.TableRelations` is a curated static list with BC version ranges
+  (`MinVersion`/`MaxVersion`); relation-path coverage only applies to listed pairs.
+- No CodeFix.

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/HasDiagnostic/Invocation_SourceTableObsoleteStatePending.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/HasDiagnostic/Invocation_SourceTableObsoleteStatePending.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    ObsoleteState = Pending;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldA; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldB; Integer) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/Invocation_SourceTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/Invocation_SourceTableObsoleteStateRemoved.al
@@ -1,0 +1,32 @@
+codeunit 50100 MyUpgradeCodeunit
+{
+    Subtype = Upgrade;
+
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    ObsoleteState = Removed;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldA; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldB; Integer) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/Invocation_TargetTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/Invocation_TargetTableObsoleteStateRemoved.al
@@ -1,0 +1,32 @@
+codeunit 50100 MyUpgradeCodeunit
+{
+    Subtype = Upgrade;
+
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldA; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    ObsoleteState = Removed;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; FieldB; Integer) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/TableExt_SourceBaseTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/TableExt_SourceBaseTableObsoleteStateRemoved.al
@@ -1,0 +1,24 @@
+tableextension 50100 MyCustomerExt extends Customer
+{
+    fields
+    {
+        [|field(50100; FieldA; Integer) { }|]
+    }
+}
+
+tableextension 50101 MyContactExt extends Contact
+{
+    fields
+    {
+        [|field(50100; FieldB; Integer) { }|]
+    }
+}
+
+table 18 Customer
+{
+    ObsoleteState = Removed;
+
+    fields { field(1; "No."; Code[20]) { } }
+}
+
+table 5050 Contact { fields { field(1; "No."; Code[20]) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/TableExt_TargetBaseTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/NoDiagnostic/TableExt_TargetBaseTableObsoleteStateRemoved.al
@@ -1,0 +1,24 @@
+tableextension 50100 MyCustomerExt extends Customer
+{
+    fields
+    {
+        [|field(50100; FieldA; Integer) { }|]
+    }
+}
+
+tableextension 50101 MyContactExt extends Contact
+{
+    fields
+    {
+        [|field(50100; FieldB; Integer) { }|]
+    }
+}
+
+table 18 Customer { fields { field(1; "No."; Code[20]) { } } }
+
+table 5050 Contact
+{
+    ObsoleteState = Removed;
+
+    fields { field(1; "No."; Code[20]) { } }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/TransferFieldsNameMismatch.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsNameMismatch/TransferFieldsNameMismatch.cs
@@ -31,6 +31,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("InvocationWithVarLocals")]
         [TestCase("InvocationWithVarParam")]
         [TestCase("InvocationWithTableExtension")]
+        [TestCase("Invocation_SourceTableObsoleteStatePending")]
         [TestCase("TableExt_Multiple_SameBase")]
         [TestCase("TableExtension")]
         [TestCase("TableExt_NamespaceCasingMismatch")]
@@ -52,17 +53,21 @@ namespace ALCops.PlatformCop.Test
         [TestCase("BuiltInInvocation")]
         [TestCase("Invocation_ObsoleteStateRemoved")]
         [TestCase("Invocation_Pragma")]
+        [TestCase("Invocation_SourceTableObsoleteStateRemoved")]
+        [TestCase("Invocation_TargetTableObsoleteStateRemoved")]
         [TestCase("InvocationSkipFieldsNotMatchingType")]
         [TestCase("InvocationWithInitPrimaryKeyFieldsIsFalse")]
         [TestCase("InvocationWithTableExtension")]
         [TestCase("TableExt_ObsoleteStateRemoved")]
         [TestCase("TableExt_Paired_Extension_Pragma")]
         [TestCase("TableExt_Paired_SingleTableExt")]
+        [TestCase("TableExt_SourceBaseTableObsoleteStateRemoved")]
+        [TestCase("TableExt_TargetBaseTableObsoleteStateRemoved")]
         [TestCase("TableExt_Unpaired")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["InvocationWithTableExtension", "TableExt_ObsoleteStateRemoved", "TableExt_Paired_Extension_Pragma", "TableExt_Paired_SingleTableExt", "TableExt_Unpaired"],
+                ["InvocationWithTableExtension", "TableExt_ObsoleteStateRemoved", "TableExt_Paired_Extension_Pragma", "TableExt_Paired_SingleTableExt", "TableExt_SourceBaseTableObsoleteStateRemoved", "TableExt_TargetBaseTableObsoleteStateRemoved", "TableExt_Unpaired"],
                 testCase,
                 "13.0",
                 "No support for tableextensions when target itself is already declared in the same module");

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/HasDiagnostic/Invocation_SourceTableObsoleteStatePending.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/HasDiagnostic/Invocation_SourceTableObsoleteStatePending.al
@@ -1,0 +1,30 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    ObsoleteState = Pending;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Boolean) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/Invocation_SourceTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/Invocation_SourceTableObsoleteStateRemoved.al
@@ -1,0 +1,32 @@
+codeunit 50100 MyUpgradeCodeunit
+{
+    Subtype = Upgrade;
+
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    ObsoleteState = Removed;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Boolean) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/Invocation_TargetTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/Invocation_TargetTableObsoleteStateRemoved.al
@@ -1,0 +1,32 @@
+codeunit 50100 MyUpgradeCodeunit
+{
+    Subtype = Upgrade;
+
+    procedure MyProcedure()
+    var
+        FromRec: Record MyTableA;
+        ToRec: Record MyTableB;
+    begin
+        [|ToRec.TransferFields(FromRec)|];
+    end;
+}
+
+table 50100 MyTableA
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Integer) { }|]
+    }
+}
+
+table 50101 MyTableB
+{
+    ObsoleteState = Removed;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[20]) { }
+        [|field(2; MyField; Boolean) { }|]
+    }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/TableExt_SourceBaseTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/TableExt_SourceBaseTableObsoleteStateRemoved.al
@@ -1,0 +1,24 @@
+tableextension 50100 MyCustomerExt extends Customer
+{
+    fields
+    {
+        [|field(50100; MyField; Boolean) { }|]
+    }
+}
+
+tableextension 50101 MyContactExt extends Contact
+{
+    fields
+    {
+        [|field(50100; MyField; Integer) { }|]
+    }
+}
+
+table 18 Customer
+{
+    ObsoleteState = Removed;
+
+    fields { field(1; "No."; Code[20]) { } }
+}
+
+table 5050 Contact { fields { field(1; "No."; Code[20]) { } } }

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/TableExt_TargetBaseTableObsoleteStateRemoved.al
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/NoDiagnostic/TableExt_TargetBaseTableObsoleteStateRemoved.al
@@ -1,0 +1,24 @@
+tableextension 50100 MyCustomerExt extends Customer
+{
+    fields
+    {
+        [|field(50100; MyField; Boolean) { }|]
+    }
+}
+
+tableextension 50101 MyContactExt extends Contact
+{
+    fields
+    {
+        [|field(50100; MyField; Integer) { }|]
+    }
+}
+
+table 18 Customer { fields { field(1; "No."; Code[20]) { } } }
+
+table 5050 Contact
+{
+    ObsoleteState = Removed;
+
+    fields { field(1; "No."; Code[20]) { } }
+}

--- a/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/TransferFieldsTypeMismatch.cs
+++ b/src/ALCops.PlatformCop.Test/Rules/TransferFieldsTypeMismatch/TransferFieldsTypeMismatch.cs
@@ -31,6 +31,7 @@ namespace ALCops.PlatformCop.Test
         [TestCase("InvocationWithVarLocals")]
         [TestCase("InvocationWithVarParam")]
         [TestCase("InvocationWithTableExtension")]
+        [TestCase("Invocation_SourceTableObsoleteStatePending")]
         [TestCase("TableExt_Multiple_SameBase")]
         [TestCase("TableExtension")]
         [TestCase("TableExtensionTypeWithType")]
@@ -53,6 +54,8 @@ namespace ALCops.PlatformCop.Test
         [TestCase("BuiltInInvocation")]
         [TestCase("Invocation_ObsoleteStateRemoved")]
         [TestCase("Invocation_Pragma")]
+        [TestCase("Invocation_SourceTableObsoleteStateRemoved")]
+        [TestCase("Invocation_TargetTableObsoleteStateRemoved")]
         [TestCase("InvocationCodeToText")]
         [TestCase("InvocationSkipFieldsNotMatchingType")]
         [TestCase("InvocationWithInitPrimaryKeyFieldsIsFalse")]
@@ -63,11 +66,13 @@ namespace ALCops.PlatformCop.Test
         [TestCase("TableExt_ObsoleteStateRemoved")]
         [TestCase("TableExt_Paired_Extension_Pragma")]
         [TestCase("TableExt_Paired_SingleTableExt")]
+        [TestCase("TableExt_SourceBaseTableObsoleteStateRemoved")]
+        [TestCase("TableExt_TargetBaseTableObsoleteStateRemoved")]
         [TestCase("TableExt_Unpaired")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(
-                ["InvocationWithTableExtension", "TableExt_BothObsoleteStateRemoved", "TableExt_ObsoleteStateRemoved", "TableExt_Paired_Extension_Pragma", "TableExt_Paired_SingleTableExt", "TableExt_Unpaired"],
+                ["InvocationWithTableExtension", "TableExt_BothObsoleteStateRemoved", "TableExt_ObsoleteStateRemoved", "TableExt_Paired_Extension_Pragma", "TableExt_Paired_SingleTableExt", "TableExt_SourceBaseTableObsoleteStateRemoved", "TableExt_TargetBaseTableObsoleteStateRemoved", "TableExt_Unpaired"],
                 testCase,
                 "13.0",
                 "No support for tableextensions when target itself is already declared in the same module");

--- a/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TransferFieldsSchemaCompatibility.cs
@@ -136,6 +136,11 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
         if (sourceTable is null || targetTable is null)
             return;
 
+        // Removed (or moved) tables no longer participate in TransferFields at runtime,
+        // e.g. upgrade code transferring from a removed table. Pending tables still do.
+        if (sourceTable.IsRemoved() || targetTable.IsRemoved())
+            return;
+
         var tableExtensions = GetCachedTableExtensions(ctx.Compilation);
         var sourceFields = BuildEffectiveFields(sourceTable, tableExtensions);
         var targetFields = BuildEffectiveFields(targetTable, tableExtensions, IsInitPrimaryKeyFieldsEnabled(invocation));
@@ -204,6 +209,11 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
         if (tableExtension.Target is not ITableTypeSymbol sourceTable)
             return;
 
+        // Skip removed extensions and extensions of removed base tables; their fields
+        // no longer participate in TransferFields at runtime. Pending is still analyzed.
+        if (tableExtension.IsRemoved() || sourceTable.IsRemoved())
+            return;
+
         var relations = TryFindBySource(sourceTable);
         if (!relations.Any())
             return;
@@ -221,11 +231,13 @@ public sealed class TransferFieldsSchemaCompatibility : DiagnosticAnalyzer
         var sourceTableExtensions =
             tableExtensions
                 .Where(te => te.Target is not null && SemanticFacts.IsSameName(te.Target.Name, relation.Source.Name))
+                .Where(te => !te.IsRemoved() && !te.Target!.IsRemoved())
                 .SelectMany(x => x.AddedFields);
 
         var targetTableExtensions =
             tableExtensions
                 .Where(te => te.Target is not null && SemanticFacts.IsSameName(te.Target.Name, relation.Target.Name))
+                .Where(te => !te.IsRemoved() && !te.Target!.IsRemoved())
                 .SelectMany(x => x.AddedFields);
 
         var sourceById = BuildFieldMapById(sourceTableExtensions);


### PR DESCRIPTION
## Summary

Fixes #435. PC0020/PC0021 filtered removed **fields** (#148) but still fired when the **table itself** has `ObsoleteState = Removed`:

1. Non-removed fields belonging to a removed table were still compared.
2. Upgrade code calling `TransferFields` from a removed table was flagged at the invocation site. (The AL compiler suppresses obsolete diagnostics inside `Subtype = Upgrade`/`Install` codeunits, so such code compiles cleanly and reaches the analyzer.)

## Changes

- **Invocation path**: skip analysis when either the source or target table is removed.
- **Relation path**: skip removed table extensions and extensions whose base table is removed.
- Uses the existing `IsRemoved()` extension (Removed/Moved only): `ObsoleteState = Pending` still fires, since pending tables participate in `TransferFields` at runtime.

## Tests

10 new fixtures across both rule folders:
- NoDiagnostic: source/target table removed (upgrade codeunit invocation), relation-pair extension with removed source/target base table.
- HasDiagnostic: `ObsoleteState = Pending` source table still fires.

`dotnet test src/ALCops.PlatformCop.Test/`: 524/524 passed.

Also adds a rule-scoped instruction file for PC0020/PC0021.
