### PR TITLE
fix(DC0004): false positive on procedures in internal interfaces

### DIFF
--- a/.github/instructions/dc0004-procedure-requires-documentation.instructions.md
+++ b/.github/instructions/dc0004-procedure-requires-documentation.instructions.md
@@ -1,0 +1,85 @@
+---
+applyTo: 'src/ALCops.DocumentationCop/**/ProcedureRequiresDocumentation*'
+---
+
+# DC0004/DC0006/DC0009/DC0010: ProcedureRequiresDocumentation
+
+## Purpose
+
+Requires XML documentation comments on procedures and events that form the API surface of an
+extension. One analyzer (`ProcedureRequiresDocumentation`) emits four diagnostics:
+
+| Property | DC0004 | DC0006 | DC0009 | DC0010 |
+|----------|--------|--------|--------|--------|
+| Target | Public procedure | Internal procedure | Integration/Business event | Internal event |
+| Category | Design | Design | Design | Design |
+| Severity | Info | Info | Info | Info |
+| Enabled | Yes | No | Yes | No |
+| CodeFix | No | No | No | No |
+
+## Rule intent
+
+DC0004 targets procedures **callable from a dependent extension** (cross-extension API surface).
+The deciding factor is effective external visibility: object accessibility x procedure
+accessibility. Signatures in a public `interface` are part of the API contract and raise DC0004;
+internal interfaces route to DC0006, matching internal codeunit behavior.
+
+## Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Public interface procedures raise DC0004 | Interface signatures are the cross-extension API contract |
+| Internal interface procedures raise DC0006 | Consistent with procedures in `Access = Internal` codeunits (issue #438) |
+| ControlAddIn procedures are skipped entirely | JS-implemented contract, not cross-extension AL API |
+| Layered containing-object resolution | See SDK pitfall below; preserves requestpage behavior |
+| `local` procedures are skipped | Not callable outside the object |
+| Test codeunits are skipped | Test methods are not API surface |
+| Obsolete members are skipped | Standard cop convention |
+
+## Architecture
+
+- Registers `SyntaxNodeAction` for `MethodDeclaration`.
+- Resolves the containing object with **layered resolution**:
+  1. `GetContainingApplicationObjectTypeSymbol()` (primary),
+  2. fall back to `GetContainingObjectTypeSymbol()` only when the primary returns null.
+- Skips ControlAddIn containers (`SymbolKind.ControlAddIn`), test codeunits, obsolete members,
+  and methods with XML documentation leading trivia.
+- Routes to internal diagnostics when the procedure has the `internal` keyword or the containing
+  object's `DeclaredAccessibility` is Internal; events route via
+  `IsIntegrationOrBusinessEvent()` / `IsInternalEvent()`.
+
+## SDK pitfall: IApplicationObjectTypeSymbol vs IObjectTypeSymbol
+
+`IInterfaceTypeSymbol` and `IControlAddInTypeSymbol` implement `IObjectTypeSymbol` but **not**
+`IApplicationObjectTypeSymbol` (the two interfaces are siblings; neither extends the other, so a
+merged variable must be typed `ISymbol`). Consequences:
+
+- `GetContainingApplicationObjectTypeSymbol()` returns **null** for interface/controladdin
+  members. Before the #438 fix, the null silently defeated the internal-accessibility check and
+  internal interface procedures fell into the public DC0004 branch.
+- A naive swap to `GetContainingObjectTypeSymbol()` is **not safe**: the SDK walker returns the
+  first `IObjectTypeSymbol` walking up, and `RequestPageTypeSymbol` /
+  `RequestPageExtensionTypeSymbol` are `IObjectTypeSymbol` with hardcoded
+  `DeclaredAccessibility = Local`. Requestpage procedures would resolve to the requestpage
+  instead of the report/xmlport. Hence the layered resolution: application-object walker first,
+  object walker only as a null fallback (which in AL only happens for interface/controladdin).
+- `ObjectTypeSymbol.DeclaredAccessibility` reads the `Access` property (default Public) for all
+  object types, so the fallback gives correct accessibility for interfaces.
+
+## Test coverage
+
+**PublicHasDiagnostic (5 cases):** InterfaceProcedure, Procedure, ProcedureWithAttribute, ProcedureWithComment, ReportRequestPageProcedure.
+**PublicNoDiagnostic (11 cases):** CodeunitAccessInternal, ControlAddIn, InterfaceAccessInternal, InterfaceProcedureDocumentationComment, ProcedureDocumentationComment, ProcedureDocumentationCommentWithAttribute, ProcedureDocumentationCommentWithMultipleAttributes, ProcedureInternal, ProcedureLocal, TestCodeunit, TestCodeunitHandlerMethod.
+**InternalHasDiagnostic (7 cases):** CodeunitAccessInternal, CodeunitAccessInternalProcedureWithAttribute, CodeunitAccessInternalProcedureWithComment, InterfaceAccessInternal, InternalProcedure, InternalProcedureWithAttribute, InternalProcedureWithComment.
+**InternalNoDiagnostic (10 cases):** CodeunitAccessInternalProcedureDocumentationComment, CodeunitAccessInternalProcedureDocumentationCommentWithAttribute, CodeunitAccessInternalProcedureDocumentationCommentWithMultipleAttributes, ControlAddIn, Interface, InterfaceAccessInternalProcedureDocumentationComment, Procedure, ProcedureLocal, TestCodeunit, TestCodeunitHandlerMethod.
+**IntegrationEventHasDiagnostic (6 cases):** BusinessEvent, BusinessEventWithComment, BusinessEventWithParameters, IntegrationEvent, IntegrationEventWithComment, IntegrationEventWithParameters.
+**IntegrationEventNoDiagnostic (4 cases):** BusinessEvent, BusinessEventWithParameters, IntegrationEvent, IntegrationEventWithParameters.
+**InternalEventHasDiagnostic (3 cases):** InternalEvent, InternalEventWithComment, InternalEventWithParameters.
+**InternalEventNoDiagnostic (2 cases):** InternalEvent, InternalEventWithParameters.
+
+## Known issues
+
+- `ObjectRequiresDocumentation` (DC0007/DC0008) has the same SDK-hierarchy false negative at
+  object level: it registers Interface and ControlAddIn symbol kinds but bails on
+  `is not IApplicationObjectTypeSymbol`, so those objects never get object-level documentation
+  diagnostics. Tracked in a separate issue pending the original author's intent.

--- a/.github/instructions/instruction-maintenance.instructions.md
+++ b/.github/instructions/instruction-maintenance.instructions.md
@@ -92,6 +92,7 @@ Include: project structure, templates, step-by-step guides, API reference, commo
 | `ac0026-allow-in-customizations-for-omitted-fields` | rule-scoped | AC0026 rule |
 | `ac0031-table-data-access-requires-permissions` | rule-scoped | AC0031 rule |
 | `ac0032-table-data-access-unused-permissions` | rule-scoped | AC0032 rule |
+| `dc0004-procedure-requires-documentation` | rule-scoped | DC0004/DC0006/DC0009/DC0010 rules (one analyzer, layered containing-object resolution) |
 | `sdk-analyzer-infrastructure` | `'src/ALCops.*/Analyzers/**'` | NAV SDK internals: callback ordering, incremental compilation, GetOperation perf |
 | `analyzer-exception-harness` | `'src/ALCops.Common/Diagnostics/**'` | XX0000 harness: base class + context decorators that convert analyzer exceptions into located diagnostics |
 | `fc0002-casing-mismatch` | rule-scoped | FC0002 rule (both analyzers, XmlPort casing matrix) |

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalHasDiagnostic/InterfaceAccessInternal.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalHasDiagnostic/InterfaceAccessInternal.al
@@ -1,0 +1,6 @@
+interface MyInterface
+{
+    Access = Internal;
+
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/ControlAddIn.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/ControlAddIn.al
@@ -1,0 +1,4 @@
+controladdin MyControlAddIn
+{
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/Interface.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/Interface.al
@@ -1,0 +1,4 @@
+interface MyInterface
+{
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/InterfaceAccessInternalProcedureDocumentationComment.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/InternalNoDiagnostic/InterfaceAccessInternalProcedureDocumentationComment.al
@@ -1,0 +1,9 @@
+interface MyInterface
+{
+    Access = Internal;
+
+    /// <summary>
+    /// My procedure.
+    /// </summary>
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/ProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/ProcedureRequiresDocumentation.cs
@@ -79,6 +79,7 @@ namespace ALCops.DocumentationCop.Test
 		[TestCase("CodeunitAccessInternal")]
 		[TestCase("CodeunitAccessInternalProcedureWithAttribute")]
 		[TestCase("CodeunitAccessInternalProcedureWithComment")]
+		[TestCase("InterfaceAccessInternal")]
 		[TestCase("InternalProcedure")]
 		[TestCase("InternalProcedureWithAttribute")]
 		[TestCase("InternalProcedureWithComment")]
@@ -94,6 +95,9 @@ namespace ALCops.DocumentationCop.Test
 		[TestCase("CodeunitAccessInternalProcedureDocumentationComment")]
 		[TestCase("CodeunitAccessInternalProcedureDocumentationCommentWithAttribute")]
 		[TestCase("CodeunitAccessInternalProcedureDocumentationCommentWithMultipleAttributes")]
+		[TestCase("ControlAddIn")]
+		[TestCase("Interface")]
+		[TestCase("InterfaceAccessInternalProcedureDocumentationComment")]
 		[TestCase("Procedure")]
 		[TestCase("ProcedureLocal")]
 		[TestCase("TestCodeunit")]
@@ -107,9 +111,11 @@ namespace ALCops.DocumentationCop.Test
 		}
 
 		[Test]
+		[TestCase("InterfaceProcedure")]
 		[TestCase("Procedure")]
 		[TestCase("ProcedureWithAttribute")]
 		[TestCase("ProcedureWithComment")]
+		[TestCase("ReportRequestPageProcedure")]
 		public async Task PublicHasDiagnostic(string testCase)
 		{
 			var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(PublicHasDiagnostic), $"{testCase}.al"))
@@ -120,6 +126,9 @@ namespace ALCops.DocumentationCop.Test
 
 		[Test]
 		[TestCase("CodeunitAccessInternal")]
+		[TestCase("ControlAddIn")]
+		[TestCase("InterfaceAccessInternal")]
+		[TestCase("InterfaceProcedureDocumentationComment")]
 		[TestCase("ProcedureDocumentationComment")]
 		[TestCase("ProcedureDocumentationCommentWithAttribute")]
 		[TestCase("ProcedureDocumentationCommentWithMultipleAttributes")]

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicHasDiagnostic/InterfaceProcedure.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicHasDiagnostic/InterfaceProcedure.al
@@ -1,0 +1,4 @@
+interface MyInterface
+{
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicHasDiagnostic/ReportRequestPageProcedure.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicHasDiagnostic/ReportRequestPageProcedure.al
@@ -1,0 +1,17 @@
+report 50100 MyReport
+{
+    requestpage
+    {
+        layout
+        {
+        }
+
+        actions
+        {
+        }
+    }
+
+    procedure [|MyProcedure|]()
+    begin
+    end;
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/ControlAddIn.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/ControlAddIn.al
@@ -1,0 +1,4 @@
+controladdin MyControlAddIn
+{
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/InterfaceAccessInternal.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/InterfaceAccessInternal.al
@@ -1,0 +1,6 @@
+interface MyInterface
+{
+    Access = Internal;
+
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/InterfaceProcedureDocumentationComment.al
+++ b/src/ALCops.DocumentationCop.Test/Rules/ProcedureRequiresDocumentation/PublicNoDiagnostic/InterfaceProcedureDocumentationComment.al
@@ -1,0 +1,7 @@
+interface MyInterface
+{
+    /// <summary>
+    /// My procedure.
+    /// </summary>
+    procedure [|MyProcedure|]()
+}

--- a/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
@@ -28,9 +28,19 @@ public sealed class ProcedureRequiresDocumentation : DiagnosticAnalyzer
 		if (ctx.IsObsolete() || ctx.Node is not MethodDeclarationSyntax method)
 			return;
 
-		var containingObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
+		var containingApplicationObject = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
 
-		if (containingObject.IsTestCodeunit())
+		// Interfaces and control add-ins are IObjectTypeSymbol but not IApplicationObjectTypeSymbol,
+		// so fall back to the object-type walker only when no application object exists in the chain.
+		// The application-object walker stays primary so members nested in request pages keep
+		// resolving to their report/xmlport instead of the request page (which is always Local).
+		var containingObject = (ISymbol?)containingApplicationObject
+			?? ctx.ContainingSymbol.GetContainingObjectTypeSymbol();
+
+		if (containingObject?.Kind == EnumProvider.SymbolKind.ControlAddIn)
+			return;
+
+		if (containingApplicationObject.IsTestCodeunit())
 			return;
 
 		if (HasXmlDocumentation(method))


### PR DESCRIPTION
## Problem

DC0004 (public procedure requires documentation) fired on procedures inside an `interface` with `Access = Internal;`.

## Root cause

`IInterfaceTypeSymbol` and `IControlAddInTypeSymbol` implement `IObjectTypeSymbol` but **not** `IApplicationObjectTypeSymbol` (sibling interfaces in the SDK). `GetContainingApplicationObjectTypeSymbol()` therefore returned `null` for interface members; the null silently defeated the `containingObject?.DeclaredAccessibility == Internal` check and the code fell into the public DC0004 branch.

## Fix: layered containing-object resolution

```csharp
var containingObject = (ISymbol?)ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()
    ?? ctx.ContainingSymbol.GetContainingObjectTypeSymbol();
```

A naive swap to `GetContainingObjectTypeSymbol()` would be unsafe: the SDK walker returns the *first* `IObjectTypeSymbol` walking up, and `RequestPageTypeSymbol` hardcodes `DeclaredAccessibility = Local`, so requestpage procedures would resolve to the requestpage instead of their report/xmlport. The layered approach keeps the application-object walker primary (zero behavior change for all application objects, including requestpages) and only falls back for interface/controladdin containers.

## Behavior

| Container | Behavior |
|---|---|
| Public interface | DC0004 (signatures are the cross-extension API contract) |
| Internal interface | DC0006 (matches internal codeunits) |
| ControlAddIn | Skipped entirely (JS-implemented contract, not AL-callable API) |
| All application objects | Unchanged |

## Tests

9 new fixtures (48 rule tests, 79 project tests, all green):
- `PublicHasDiagnostic`: InterfaceProcedure, ReportRequestPageProcedure (regression guard for the layered resolution)
- `PublicNoDiagnostic`: InterfaceAccessInternal (the issue repro), InterfaceProcedureDocumentationComment, ControlAddIn
- `InternalHasDiagnostic`: InterfaceAccessInternal
- `InternalNoDiagnostic`: Interface, InterfaceAccessInternalProcedureDocumentationComment, ControlAddIn

## Related

- New instruction file `dc0004-procedure-requires-documentation.instructions.md` documents the SDK pitfall.
- The same root cause makes DC0007/DC0008 never fire for interface/controladdin objects (false negative); filed separately as #451 to ask the original author for intended behavior.

Fixes #438