### PR TITLE
fix(FC0007): resolve control-flow spacing interactions

### DIFF
--- a/.github/instructions/fc0007-statement-blocks-separated-by-blank-line.instructions.md
+++ b/.github/instructions/fc0007-statement-blocks-separated-by-blank-line.instructions.md
@@ -20,7 +20,8 @@ FC0007 reports missing blank lines around statement blocks: before/after control
 - Reports when a scope-leaving statement (`exit`, built-in `Error`) is missing a blank line before it when it follows another statement in the same block.
 - Reports when `else` (block or else-if) has no blank line above it, if configured.
 - Does not report the first statement in a block, the first statement directly owned by a control-flow construct, or a one-liner (unless configured otherwise).
-- Adjacent control-flow blocks: the "after" check is skipped when the next sibling is itself another control-flow block; the second block's "before" check covers that gap.
+- Adjacent control-flow blocks have one configuration-aware owner: the "after" check is skipped only when the next sibling's "before" check is enabled and includes that statement under `OneLinerMode`.
+- A control-flow block followed by `exit` or built-in `Error(...)` produces one diagnostic for the gap. The block's active "after" check owns it; otherwise the scope-leaving "before" check does.
 
 ## Configuration surface (`alcops.json` → `StatementBlockSpacing`)
 
@@ -29,7 +30,7 @@ The rule reads settings from `alcops.json` via `ALCopsSettingsProvider`. All pro
 | Property | Type | Default | Effect |
 |---|---|---|---|
 | `ControlFlowBefore` | `bool` | `true` | Require blank line before control-flow blocks. |
-| `ControlFlowAfter` | `bool` | `true` | Require blank line after control-flow blocks (skipped when next sibling is also a control-flow block). |
+| `ControlFlowAfter` | `bool` | `true` | Require blank lines after control-flow blocks. For an adjacent control-flow sibling, the check is skipped only when that sibling's active "before" check owns the gap. |
 | `ScopeLeavingMode` | enum `Off` \| `ExitOnly` \| `ErrorOnly` \| `ExitAndError` | `ExitAndError` | Which scope-leaving statements require a blank line before them. |
 | `ElseChainBeforeMode` | enum `Off` \| `RequireBlank` | `Off` | Require blank line before `else` / `else if`. Skipped when `else` is on the same line as the previous token (one-liner). |
 | `OneLinerMode` | enum `None` \| `All` | `None` | Include or exclude one-liner statements (whole statement spans a single line) from spacing checks. |
@@ -46,7 +47,7 @@ Settings type: [src/ALCops.Common/Settings/StatementBlockSpacingSettings.cs](src
 | JSON string enums via `JsonStringEnumConverter` (net8+) and `StringEnumConverter` (netstandard2.1) | Human-readable JSON matches other alcops settings. Both converters are case-insensitive by default. |
 | Blank-line check inspects source-text lines strictly between the two token positions | Comparing token line diffs alone counts a comment-only line as a separator, contradicting the intended semantics. Iterating `SourceText.Lines` and requiring at least one whitespace-only line is robust against comments and directives. |
 | Use sibling `StatementSyntax` nodes from the parent | The rule is about statement sequencing in the same statement list and must also work in contexts not represented by `BlockSyntax` (for example `repeat`). |
-| Skip the "after" check when the next sibling is another control-flow block | Avoids duplicate diagnostics between adjacent blocks — the second block's "before" check owns that gap. |
+| Give each statement gap one configuration-aware diagnostic owner | Avoids duplicate diagnostics before scope-leavers while preserving diagnostics next to one-liners or when `ControlFlowBefore` is disabled. An adjacent block owns its "before" gap only when that check actually runs. |
 | Skip one-liners unless `OneLinerMode = All` | One-liner control-flow statements (`if X then Y`) rarely benefit from surrounding blank lines. |
 | Detect `Error(...)` via `MethodKind.BuiltInMethod` + `IsSameName` | Distinguishes the built-in from user-defined `Error` procedures. |
 | `ElseChainBeforeMode` short-circuits when `else` shares its line with the previous token | Prevents false positives on `if X then Y else Z` one-liners. |
@@ -55,11 +56,12 @@ Settings type: [src/ALCops.Common/Settings/StatementBlockSpacingSettings.cs](src
 
 Tests enable the rule via a physical `StatementBlocksSeparatedByBlankLine.ruleset.json` (same pattern as `DC0008`, `AC0028`, etc.). Config-driven tests inject `alcops.json` via `MemoryFileSystem` on the `AnalyzerTestFixtureConfig.FileSystem` slot alongside `RuleSetPath`.
 
-**HasDiagnostic (2 cases):** ControlFlowSpacingMissing, ScopeLeavingSpacingMissing.
+**HasDiagnostic (3 cases):** ControlFlowSpacingMissing, ControlFlowInteractionSpacing, ScopeLeavingSpacingMissing.
 **HasDiagnosticWithCommentBetween (1 case):** CommentBetweenStatements.
 **NoDiagnostic (3 cases):** ControlFlowSpacingValid, ScopeLeavingSpacingValid, DisabledByDefault.
 **HasDiagnosticWithOneLinerAll (1 case):** OneLinerAll.
 **NoDiagnosticWithControlFlowDisabled (1 case):** ControlFlowSpacingMissing.
+**HasDiagnosticWithScopeLeavingOff (1 case):** ControlFlowInteractionSpacing.
 **NoDiagnosticWithScopeLeavingOff (2 cases):** ExitOnly, ErrorOnly.
 **HasDiagnosticWithExitOnly (1 case):** ExitOnly.
 **NoDiagnosticWithExitOnlySuppressesError (1 case):** ErrorOnly.
@@ -68,9 +70,10 @@ Tests enable the rule via a physical `StatementBlocksSeparatedByBlankLine.rulese
 **HasDiagnosticWithElseChainRequireBlank (1 case):** ElseChainBlank.
 **NoDiagnosticWithElseChainRequireBlank (1 case):** ElseChainBlankValid.
 **HasDiagnosticWithControlFlowBeforeOnly (1 case):** ControlFlowBeforeOnly.
-**HasDiagnosticWithControlFlowAfterOnly (1 case):** ControlFlowAfterOnly.
+**HasDiagnosticWithControlFlowAfterOnly (2 cases):** ControlFlowAfterOnly, ControlFlowAfterAdjacentControlFlow.
 **HasDiagnosticWithMalformedJsonFallsBackToDefaults (1 case):** ExitOnly.
 **HasDiagnosticWithNullSettingsFallsBackToDefaults (1 case):** ExitOnly.
+**ExactDiagnosticCount (1 case):** ControlFlowInteractionSpacing.
 **SchemaParity (3 cases):** ScopeLeavingModeEnumMatchesSchema, ElseChainBeforeModeEnumMatchesSchema, OneLinerModeEnumMatchesSchema.
 
 ## Known issues / non-goals

--- a/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/HasDiagnostic/ControlFlowAfterAdjacentControlFlow.al
+++ b/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/HasDiagnostic/ControlFlowAfterAdjacentControlFlow.al
@@ -1,0 +1,12 @@
+codeunit 50113 MyControlFlowAfterCodeunit
+{
+    procedure ControlFlowBeforeDisabled(Flag: Boolean; Other: Boolean)
+    begin
+        if Flag then begin
+            Message('First');
+        end;
+        [|if|] Other then begin
+            Message('Second');
+        end;
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/HasDiagnostic/ControlFlowInteractionSpacing.al
+++ b/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/HasDiagnostic/ControlFlowInteractionSpacing.al
@@ -1,0 +1,35 @@
+codeunit 50112 MyCFInteractionCodeunit
+{
+    procedure ControlFlowFollowedByExit(Flag: Boolean)
+    begin
+        if Flag then begin
+            Message('Inside');
+        end;
+        [|exit|];
+    end;
+
+    procedure ControlFlowFollowedByError(Flag: Boolean)
+    begin
+        if Flag then begin
+            Message('Inside');
+        end;
+        [|Error|]('Failed');
+    end;
+
+    procedure ControlFlowFollowedByOneLineIf(Flag: Boolean; Other: Boolean)
+    begin
+        if Flag then begin
+            Message('First');
+        end;
+        [|if|] Other then Message('Second');
+    end;
+
+    procedure ControlFlowFollowedByMultiLineIf(Flag: Boolean; Other: Boolean)
+    begin
+        if Flag then begin
+            Message('First');
+        end;
+        [|if|] Other then
+            Message('Second');
+    end;
+}

--- a/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/StatementBlocksSeparatedByBlankLine.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/StatementBlocksSeparatedByBlankLine/StatementBlocksSeparatedByBlankLine.cs
@@ -1,4 +1,6 @@
+using System.Collections.Immutable;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using RoslynTestKit;
 
 namespace ALCops.FormattingCop.Test
@@ -45,11 +47,13 @@ namespace ALCops.FormattingCop.Test
         [Test]
         // Default settings (no alcops.json injected).
         [TestCase(null, "ControlFlowSpacingMissing")]
+        [TestCase(null, "ControlFlowInteractionSpacing")]
         [TestCase(null, "ScopeLeavingSpacingMissing")]
         // Comment-only lines between statements must not satisfy the blank-line requirement.
         [TestCase(null, "CommentBetweenStatements")]
         // Config-driven positive cases.
         [TestCase("OneLinerAll", "OneLinerAll")]
+        [TestCase("ScopeLeavingOff", "ControlFlowInteractionSpacing")]
         [TestCase("ExitOnly", "ExitOnly")]
         [TestCase("ErrorOnly", "ErrorOnly")]
         [TestCase("ElseChainRequireBlank", "ElseChainBlank")]
@@ -59,6 +63,7 @@ namespace ALCops.FormattingCop.Test
         // ControlFlowAfterOnly fixture marks only the trailing Message() call; the 'if' keyword
         // is intentionally unmarked because "before" is off.
         [TestCase("ControlFlowAfterOnly", "ControlFlowAfterOnly")]
+        [TestCase("ControlFlowAfterOnly", "ControlFlowAfterAdjacentControlFlow")]
         // Regression guard for malformed alcops.json → provider must fall back to defaults; the
         // ExitOnly fixture's exit markers require the default ScopeLeavingMode=ExitAndError.
         [TestCase("Malformed", "ExitOnly")]
@@ -97,6 +102,18 @@ namespace ALCops.FormattingCop.Test
                 .NoDiagnosticAtAllMarkers(code, DiagnosticIds.StatementBlocksSeparatedByBlankLine);
         }
 
+        [Test]
+        [TestCase("ControlFlowInteractionSpacing", 4)]
+        public async Task ReportsExpectedDiagnosticCount(string fixtureName, int expectedCount)
+        {
+            var code = await LoadFixtureAsync(fixtureName);
+            var fixture = new DiagnosticCountingFixture(_ruleSetPath);
+
+            Assert.That(
+                fixture.CountDiagnostics(code, DiagnosticIds.StatementBlocksSeparatedByBlankLine),
+                Is.EqualTo(expectedCount));
+        }
+
         // Fixtures live in either HasDiagnostic/ or NoDiagnostic/ subfolders (repo convention).
         // Since names are unique across both, callers only supply the fixture name and this helper
         // resolves the folder — keeping test signatures free of layout details.
@@ -132,5 +149,39 @@ namespace ALCops.FormattingCop.Test
                 });
 
         private static byte[] Utf8(string s) => System.Text.Encoding.UTF8.GetBytes(s);
+
+        private sealed class DiagnosticCountingFixture(string ruleSetPath) : AnalyzerTestFixture
+        {
+            protected override string LanguageName => LanguageNames.AL;
+            protected override string? RuleSetPath => ruleSetPath;
+
+            protected override DiagnosticAnalyzer CreateAnalyzer() =>
+                new Analyzers.StatementBlocksSeparatedByBlankLine();
+
+            public int CountDiagnostics(string markupCode, string diagnosticId)
+            {
+                var markup = new CodeMarkup(markupCode);
+                var document = CreateDocumentFromCode(markup.Code);
+                var compilation = document.Project
+                    .GetCompilationAsync(CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (compilation is null)
+                {
+                    return 0;
+                }
+
+                var diagnostics = compilation
+                    .WithAnalyzers(
+                        ImmutableArray.Create(CreateAnalyzer()),
+                        cancellationToken: CancellationToken.None)
+                    .GetAnalyzerDiagnosticsAsync()
+                    .GetAwaiter()
+                    .GetResult();
+
+                return diagnostics.Count(diagnostic => diagnostic.Id == diagnosticId);
+            }
+        }
     }
 }

--- a/src/ALCops.FormattingCop/Analyzers/StatementBlocksSeparatedByBlankLine.cs
+++ b/src/ALCops.FormattingCop/Analyzers/StatementBlocksSeparatedByBlankLine.cs
@@ -100,7 +100,9 @@ public sealed class StatementBlocksSeparatedByBlankLine : DiagnosticAnalyzer
                 $"before '{name}' block");
         }
 
-        if (config.ControlFlowAfter && i < siblings.Length - 1 && !IsControlFlowStatement(siblings[i + 1]))
+        if (config.ControlFlowAfter &&
+            i < siblings.Length - 1 &&
+            !WillReportControlFlowBefore(siblings[i + 1], config))
         {
             ReportIfNoBlankLineBetween(
                 ctx,
@@ -165,7 +167,10 @@ public sealed class StatementBlocksSeparatedByBlankLine : DiagnosticAnalyzer
             return;
         }
 
-        var diagnostic = GetScopeLeavingSpacingDiagnostic(statement, "before scope-leaving statement 'exit'");
+        var diagnostic = GetScopeLeavingSpacingDiagnostic(
+            statement,
+            config,
+            "before scope-leaving statement 'exit'");
 
         if (diagnostic is not null)
         {
@@ -204,7 +209,10 @@ public sealed class StatementBlocksSeparatedByBlankLine : DiagnosticAnalyzer
             return;
         }
 
-        var diagnostic = GetScopeLeavingSpacingDiagnostic(expressionStatement, "before scope-leaving statement 'Error()'");
+        var diagnostic = GetScopeLeavingSpacingDiagnostic(
+            expressionStatement,
+            config,
+            "before scope-leaving statement 'Error()'");
 
         if (diagnostic is not null)
         {
@@ -245,6 +253,20 @@ public sealed class StatementBlocksSeparatedByBlankLine : DiagnosticAnalyzer
     private static bool IsControlFlowStatement(SyntaxNode node) =>
         ControlFlowStatementKinds.Contains(node.Kind);
 
+    private static bool WillReportControlFlowBefore(
+        StatementSyntax statement,
+        StatementBlockSpacingSettings config) =>
+        config.ControlFlowBefore &&
+        IsControlFlowStatement(statement) &&
+        (!IsOneLiner(statement) || IncludesOneLiners(config));
+
+    private static bool WillReportControlFlowAfter(
+        StatementSyntax statement,
+        StatementBlockSpacingSettings config) =>
+        config.ControlFlowAfter &&
+        IsControlFlowStatement(statement) &&
+        (!IsOneLiner(statement) || IncludesOneLiners(config));
+
     private static ImmutableArray<StatementSyntax> GetSiblingStatements(StatementSyntax statement)
     {
         if (statement.Parent is null)
@@ -282,9 +304,15 @@ public sealed class StatementBlocksSeparatedByBlankLine : DiagnosticAnalyzer
 
     private static Diagnostic? GetScopeLeavingSpacingDiagnostic(
         StatementSyntax statement,
+        StatementBlockSpacingSettings config,
         string requirement)
     {
         if (!TryGetSiblingIndex(statement, out var siblings, out var i) || i == 0)
+        {
+            return null;
+        }
+
+        if (WillReportControlFlowAfter(siblings[i - 1], config))
         {
             return null;
         }


### PR DESCRIPTION
## Summary

Fixes FC0007 ownership of missing blank-line diagnostics when control-flow and scope-leaving checks overlap.

- Prevents duplicate FC0007 diagnostics for a control-flow block followed by `exit` or built-in `Error(...)`.
- Reports missing separators before an excluded one-line control-flow statement.
- Preserves reporting for adjacent control-flow blocks when `ControlFlowBefore` is disabled.
- Adds exact diagnostic-count coverage so duplicate diagnostics cannot regress unnoticed.
- Updates internal FC0007 rule instructions.
