### PR TITLE
fix(LC0092): strip object affixes only on pattern mismatch

### DIFF
--- a/.github/instructions/lc0092-naming-pattern.instructions.md
+++ b/.github/instructions/lc0092-naming-pattern.instructions.md
@@ -28,7 +28,7 @@ No version gate · Full netstandard2.1 support
 | Single diagnostic ID | LC0092 for all 16 naming targets | Simpler user experience; message differentiates targets |
 | Settings format | `NamingPatterns` dictionary in alcops.json | PascalCase keys, named per target |
 | Default behavior | Built-in MS convention defaults, user can override | Immediate value without configuration |
-| Object affixes | Strip AppSourceCop affixes before checking, trim whitespace | Avoids false positives on prefixed/suffixed names; handles common `"PTE MyCodeunit"` pattern where space separates affix from name |
+| Object affixes | Strip AppSourceCop affixes **only as a fallback** when the full name already violates the pattern; report against the original name | Issue #436 / PR #447: unconditional stripping produced false positives when a mandatory affix is a substring of a valid name (e.g. suffix `mer` in `Customer` → `Custo`, or prefix `Cust` → `omer`). Now the full name is checked first; the affix-stripped core is only tried if the full name fails, and it can only *suppress* a diagnostic, never introduce one. The diagnostic and suggestion always reference the original name |
 | Skip triggers | Yes | Platform-defined names, can't rename |
 | Skip interface implementations | Yes | Name is dictated by the interface |
 | Skip event subscriber params | Yes | Subscriber parameters must match publisher signature (AL0828); platform trigger params (`xRec`, `BelowxRec`, `RunTrigger`, etc.) can't be renamed |
@@ -59,7 +59,7 @@ No version gate · Full netstandard2.1 support
 
 Uses `RegisterCompilationStartAction` to:
 1. Load `ALCopsSettings` (for NamingPatterns user overrides)
-2. Load AppSourceCop affixes (for object name stripping, wrapped in try-catch)
+2. Load AppSourceCop affixes (fallback for object name stripping, wrapped in try-catch)
 3. Build `NamingPatternConfig` (resolves effective patterns per target)
 4. Register `RegisterSymbolAction` for all relevant SymbolKinds
 
@@ -171,6 +171,10 @@ Pattern-specific name transformations:
 
 `AppSourceCopConfigurationProvider.GetAppSourceCopConfiguration(compilation)` may throw exceptions in test contexts where the SDK runtime environment is minimal. The `CompilationStart` method wraps `GetAffixes` in a try-catch and continues with null affixes.
 
+### Affix over-stripping (fixed, issue #436 / PR #447)
+
+`AnalyzeObject` previously called `StripAffixes` unconditionally before the pattern check. Because `StripAffixes` uses naive case-insensitive `StartsWith`/`EndsWith` (the same matching AppSourceCop's `RuleIdentifiersMustHaveValidAffixes.VerifyAffixIsUsed` uses), any object whose name merely contained a mandatory affix as a leading/trailing substring was mutated before checking — e.g. suffix `mer` turned `Customer` into `Custo`, prefix `Cust` turned it into `omer`. The current implementation checks the full name first (`NameSatisfiesPattern`), and only falls back to the stripped core when the full name fails. Stripping can therefore only suppress a diagnostic, never create one, and the reported name/suggestion is always the original. Note: `GetAffixes` here intentionally reads only `MandatoryPrefix` + `MandatoryAffixes` (not `MandatorySuffix`); a suffix must be expressed via `MandatoryAffixes` to be considered.
+
 ### Regex compilation failures
 
 Invalid user-supplied patterns fail gracefully: `CompilePattern` catches `ArgumentException` and returns null, effectively disabling that pattern check.
@@ -184,12 +188,12 @@ Invalid user-supplied patterns fail gracefully: `CompilePattern` catches `Argume
 **HasDiagnostic (9 cases):** ProcedureLowerCaseStart, VariableLowerCaseStart, VariableWithSpecialChars, ParameterLowerCaseStart, ReturnValueLowerCaseStart, ObjectLowerCaseStart, FieldWithSpecialChars, ActionLowerCaseStart, ControlLowerCaseStart.
 **NoDiagnostic (18 cases):** ProcedurePascalCase, VariablePascalCase, FieldWithLettersAndDigits, ObsoleteProcedure, TriggerMethod, InterfaceImplementingMethod, EventSubscriberPascalCase, EventSubscriberPlatformParams, EventSubscriberUserParams, ApiPageControlCamelCase, ActionAcceleratorKey, EnumValueBlankSpace, EnumValueLowerCaseStart, SingleLetterVariable, SingleLetterParameter, UnderscorePrefix, XRecVariable, XRecParameter, ParameterPascalCase.
 **HasDiagnosticWithCustomSettings (1 case):** EnumValueLowerCaseStartCustomSettings.
+**Affix regression (3 cases):** NoDiagnostic_ObjectPrefixCollision, NoDiagnostic_ObjectSuffixCollision, HasDiagnostic_ObjectAffixGenuineViolation.
 **SchemaParity (1 case):** NamingTargetEnumMatchesSchemaPropertyNames.
 
 ## Phase 2 roadmap (not yet implemented)
 
 - **Custom pattern tests**: Test cases that inject custom NamingPatterns via alcops.json
-- **Object affix stripping tests**: Test cases with AppSourceCop configuration
 - **ControlAddIn object type**: Add ControlAddIn to the Object target registration
 - **Procedure sub-target inheritance tests**: Verify LocalProcedure/GlobalProcedure/EventSubscriber/EventDeclaration inheritance
 - **Variable sub-target inheritance tests**: Verify LocalVariable/GlobalVariable/Parameter multi-level fallback chain

--- a/src/ALCops.LinterCop.Test/Rules/NamingPattern/HasDiagnostic/ObjectAffixGenuineViolation.al
+++ b/src/ALCops.LinterCop.Test/Rules/NamingPattern/HasDiagnostic/ObjectAffixGenuineViolation.al
@@ -1,0 +1,3 @@
+codeunit 50100 [|customer|]
+{
+}

--- a/src/ALCops.LinterCop.Test/Rules/NamingPattern/NamingPattern.cs
+++ b/src/ALCops.LinterCop.Test/Rules/NamingPattern/NamingPattern.cs
@@ -11,6 +11,24 @@ namespace ALCops.LinterCop.Test
         private static readonly byte[] EnumValueNamingSettings = System.Text.Encoding.UTF8.GetBytes(
             """{"NamingPatterns": {"EnumValue": {"AllowPattern": "^[A-Z]", "AllowDescription": "should start with an uppercase letter"}}}""");
 
+        // AppSourceCop mandatory affix that is a leading substring of a valid PascalCase
+        // object name (e.g. "Cust" in "Customer"). Stripping it as a prefix used to turn
+        // "Customer" into "omer", a false positive.
+        private static readonly byte[] AppSourceCopPrefixAffix = System.Text.Encoding.UTF8.GetBytes(
+            """{"mandatoryAffixes": ["Cust"]}""");
+
+        // AppSourceCop mandatory affix that is a trailing substring of a valid object name
+        // (e.g. "mer" in "Customer"). Stripping it as a suffix used to turn "Customer" into
+        // "Custo".
+        private static readonly byte[] AppSourceCopSuffixAffix = System.Text.Encoding.UTF8.GetBytes(
+            """{"mandatoryAffixes": ["mer"]}""");
+
+        // Object names must end with "er"; combined with the suffix affix "mer", the full
+        // name "Customer" satisfies the pattern while the affix-stripped "Custo" does not.
+        private static readonly byte[] ObjectEndsWithErSettings = System.Text.Encoding.UTF8.GetBytes(
+            """{"NamingPatterns": {"Object": {"AllowPattern": "er$", "AllowDescription": "should end with 'er'"}}}""");
+
+
         [SetUp]
         public void Setup()
         {
@@ -88,6 +106,57 @@ namespace ALCops.LinterCop.Test
                 });
 
             fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.NamingPattern);
+        }
+
+        private AnalyzerTestFixture CreateFixture(Dictionary<string, byte[]> files) =>
+            RoslynFixtureFactory.Create<Analyzers.NamingPattern>(
+                new AnalyzerTestFixtureConfig
+                {
+                    FileSystem = new MemoryFileSystem(files)
+                });
+
+        // Regression tests for affix over-stripping (issue #436 / PR #447).
+        // The affix is only stripped as a fallback when the full name already violates the
+        // pattern; an object whose full name is valid must never be penalized for merely
+        // starting or ending with a mandatory affix.
+        [Test]
+        public async Task NoDiagnostic_ObjectPrefixCollision()
+        {
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), "ObjectPrefixCollision.al"))
+                .ConfigureAwait(false);
+
+            CreateFixture(new Dictionary<string, byte[]>
+            {
+                { "AppSourceCop.json", AppSourceCopPrefixAffix }
+            }).NoDiagnosticAtAllMarkers(code, DiagnosticIds.NamingPattern);
+        }
+
+        [Test]
+        public async Task NoDiagnostic_ObjectSuffixCollision()
+        {
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(NoDiagnostic), "ObjectSuffixCollision.al"))
+                .ConfigureAwait(false);
+
+            CreateFixture(new Dictionary<string, byte[]>
+            {
+                { "AppSourceCop.json", AppSourceCopSuffixAffix },
+                { "alcops.json", ObjectEndsWithErSettings }
+            }).NoDiagnosticAtAllMarkers(code, DiagnosticIds.NamingPattern);
+        }
+
+        [Test]
+        public async Task HasDiagnostic_ObjectAffixGenuineViolation()
+        {
+            var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), "ObjectAffixGenuineViolation.al"))
+                .ConfigureAwait(false);
+
+            CreateFixture(new Dictionary<string, byte[]>
+            {
+                { "AppSourceCop.json", AppSourceCopPrefixAffix }
+            }).HasDiagnosticAtAllMarkers(code, DiagnosticIds.NamingPattern);
         }
     }
 }

--- a/src/ALCops.LinterCop.Test/Rules/NamingPattern/NoDiagnostic/ObjectPrefixCollision.al
+++ b/src/ALCops.LinterCop.Test/Rules/NamingPattern/NoDiagnostic/ObjectPrefixCollision.al
@@ -1,0 +1,3 @@
+codeunit 50100 [|Customer|]
+{
+}

--- a/src/ALCops.LinterCop.Test/Rules/NamingPattern/NoDiagnostic/ObjectSuffixCollision.al
+++ b/src/ALCops.LinterCop.Test/Rules/NamingPattern/NoDiagnostic/ObjectSuffixCollision.al
@@ -1,0 +1,3 @@
+codeunit 50100 [|Customer|]
+{
+}

--- a/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
+++ b/src/ALCops.LinterCop/Analyzers/NamingPattern.cs
@@ -134,8 +134,42 @@ public sealed class NamingPattern : DiagnosticAnalyzer
         if (ctx.IsObsolete())
             return;
 
-        var name = StripAffixes(ctx.Symbol.Name, affixes);
+        var name = ctx.Symbol.Name;
+
+        // Affix stripping is a fallback, not an unconditional pre-step. An object whose
+        // full name already satisfies the pattern must never be penalized just because it
+        // happens to start or end with a mandatory affix (e.g. "Customer" with suffix
+        // "MER", which would otherwise be stripped to "Custo" and reported).
+        if (NameSatisfiesPattern(name, NamingTarget.Object, config))
+            return;
+
+        // The full name violates the pattern. Retry against the affix-stripped core so a
+        // mandatory affix does not itself count against the pattern.
+        var strippedName = StripAffixes(name, affixes);
+        if (!string.Equals(strippedName, name, StringComparison.Ordinal) &&
+            NameSatisfiesPattern(strippedName, NamingTarget.Object, config))
+            return;
+
+        // Both the full name and the stripped core fail: report against the original name.
         CheckName(ctx, name, NamingTarget.Object, config, "Object");
+    }
+
+    private static bool NameSatisfiesPattern(string name, NamingTarget target,
+        NamingPatternConfig config)
+    {
+        // Mirror CheckName's early-out: blank names are never flagged.
+        if (string.IsNullOrWhiteSpace(name))
+            return true;
+
+        var resolved = config.GetPatterns(target);
+
+        if (resolved.AllowRegex is not null && !TryIsMatch(resolved.AllowRegex, name))
+            return false;
+
+        if (resolved.DisallowRegex is not null && TryIsMatch(resolved.DisallowRegex, name))
+            return false;
+
+        return true;
     }
 
     private static void AnalyzeField(SymbolAnalysisContext ctx, NamingPatternConfig config)


### PR DESCRIPTION
## Summary

Revisits #447 (issue #436). LC0092 `NamingPattern` stripped mandatory AppSourceCop affixes from **object** names *unconditionally* before checking the naming pattern, producing false positives when an affix is a substring of an otherwise valid name.

- suffix `mer` in `Customer` -> stripped to `Custo`
- prefix `Cust` in `Customer` -> stripped to `omer` (fails `^[A-Z]`, false diagnostic)

The naive `StartsWith`/`EndsWith` matching mirrors the SDK's own `RuleIdentifiersMustHaveValidAffixes.VerifyAffixIsUsed`, so `Customer` legitimately satisfies a mandatory affix and must not be flagged.

## Fix

Strip **only on mismatch**: check the full object name first (`NameSatisfiesPattern`). If it passes, emit nothing and never strip. Only when the full name violates the pattern do we retry against the affix-stripped core; a diagnostic is reported only if **both** fail, and it always references the **original** name (no more truncated `Custo`/`omer` in the message or `Consider:` suggestion).

Scope: LC0092 only (LC0054 unchanged, per design discussion).

## Tests

New affix regression cases (inject `AppSourceCop.json` via `MemoryFileSystem`, mirroring the InterfaceObjectNameGuide test):
- `NoDiagnostic_ObjectPrefixCollision` - prefix `Cust` + `Customer` (genuine before/after regression)
- `NoDiagnostic_ObjectSuffixCollision` - suffix `mer` + `Customer` with an `er$` object pattern (the reporter's example)
- `HasDiagnostic_ObjectAffixGenuineViolation` - lowercase `customer` still flagged

Full `ALCops.LinterCop.Test` suite: 327 passed, 2 skipped.

## Instruction file

Updated `lc0092-naming-pattern.instructions.md` (design decision, known issue, test coverage counts).

Refs #436, #447