### PR TITLE
test(LC0054): regression for coincidental glued prefix overlap

### DIFF
--- a/.github/instructions/lc0054-interface-object-name-guide.instructions.md
+++ b/.github/instructions/lc0054-interface-object-name-guide.instructions.md
@@ -45,7 +45,10 @@ disabled by default, `AnalyzerTestFixtureConfig.RuleSetPath` points to
 `InterfaceObjectNameGuide.ruleset.json` (action `Warning`). Affix cases inject an
 `AppSourceCop.json` (`mandatoryPrefix: "ABC "`, `mandatorySuffix: "XYZ "`,
 `mandatoryAffixes: ["FOO "]`) via `MemoryFileSystem` in dedicated
-`HasDiagnosticWithAffixes`/`NoDiagnosticWithAffixes` methods.
+`HasDiagnosticWithAffixes`/`NoDiagnosticWithAffixes` methods. The
+`NoDiagnosticWithOverlappingPrefix` method injects a coincidental glued prefix
+(`mandatoryPrefix: "ICU"`) to lock in that the fast path wins for `ICustomerFactory` (the prefix
+overlaps a compliant `I`-name and must not be stripped to `stomerFactory`).
 
 **HasDiagnostic (5 cases):** NoLeadingI, WhitespaceAfterI, AffixWithoutI, AffixThenIWithWhitespace, AffixThenNoLettersOrDigits.
-**NoDiagnostic (5 cases):** LeadingI, SingleCharacterI, PrefixThenI, AffixThenI, SuffixAsLeadingAffixThenI.
+**NoDiagnostic (6 cases):** LeadingI, SingleCharacterI, PrefixThenI, AffixThenI, SuffixAsLeadingAffixThenI, OverlappingPrefixCompliantI.

--- a/src/ALCops.LinterCop.Test/Rules/InterfaceObjectNameGuide/InterfaceObjectNameGuide.cs
+++ b/src/ALCops.LinterCop.Test/Rules/InterfaceObjectNameGuide/InterfaceObjectNameGuide.cs
@@ -48,6 +48,28 @@ namespace ALCops.LinterCop.Test
                 });
         }
 
+        private static readonly byte[] AppSourceCopWithOverlappingPrefix = System.Text.Encoding.UTF8.GetBytes(
+            """
+            {
+                "mandatoryPrefix": "ICU"
+            }
+            """);
+
+        private AnalyzerTestFixture CreateFixtureWithOverlappingPrefix()
+        {
+            var files = new Dictionary<string, byte[]>
+            {
+                { "AppSourceCop.json", AppSourceCopWithOverlappingPrefix }
+            };
+
+            return RoslynFixtureFactory.Create<Analyzers.InterfaceObjectNameGuide>(
+                new AnalyzerTestFixtureConfig
+                {
+                    RuleSetPath = Path.Combine(_testCasePath, $"{nameof(InterfaceObjectNameGuide)}.ruleset.json"),
+                    FileSystem = new MemoryFileSystem(files)
+                });
+        }
+
         [Test]
         [TestCase("NoLeadingI")]
         [TestCase("WhitespaceAfterI")]
@@ -92,6 +114,16 @@ namespace ALCops.LinterCop.Test
                 .ConfigureAwait(false);
 
             CreateFixtureWithAffixes().NoDiagnosticAtAllMarkers(code, DiagnosticIds.InterfaceObjectNameGuide);
+        }
+
+        [Test]
+        [TestCase("OverlappingPrefixCompliantI")]
+        public async Task NoDiagnosticWithOverlappingPrefix(string testCase)
+        {
+            var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+                .ConfigureAwait(false);
+
+            CreateFixtureWithOverlappingPrefix().NoDiagnosticAtAllMarkers(code, DiagnosticIds.InterfaceObjectNameGuide);
         }
     }
 }

--- a/src/ALCops.LinterCop.Test/Rules/InterfaceObjectNameGuide/NoDiagnostic/OverlappingPrefixCompliantI.al
+++ b/src/ALCops.LinterCop.Test/Rules/InterfaceObjectNameGuide/NoDiagnostic/OverlappingPrefixCompliantI.al
@@ -1,0 +1,8 @@
+interface [|"ICustomerFactory"|]
+{
+    // Coincidental overlap: the mandatory prefix "ICU" is a case-insensitive prefix of
+    // "ICustomerFactory", but the fast path (name starts with 'I', no whitespace after)
+    // returns compliant BEFORE any affix lookup. The name is therefore never stripped to
+    // "stomerFactory" (whose first letter is not 'I'), so no diagnostic is raised.
+    procedure DoSomething();
+}


### PR DESCRIPTION
## Summary

Revisits issue #436 / PR #447. Adds a regression test for **LC0054** confirming that an interface whose name coincidentally starts with a **glued** mandatory prefix is not over-stripped. **Test-only, no analyzer change.**

## Background

During the #436 revisit we verified LC0054 is already on the shared `ALCops.Common.Helpers.MandatoryAffixes` helper **and** already resolves affixes per compilation via a `CompilationStartAction` closure + `Lazy<string[]>` (the previously racy static `Affixes` field is gone). No refactor needed.

The one behaviour worth pinning: the analyzer's **fast path** (name starts with `I`, no whitespace after) returns *compliant* before any affix lookup, so a coincidental prefix overlap cannot cause a false positive.

## Change

- **`OverlappingPrefixCompliantI`** (NoDiagnostic): interface `ICustomerFactory` under `mandatoryPrefix: "ICU"`. `ICU` is a case-insensitive prefix of the name; without the fast path the name would strip to `stomerFactory` (first letter not `I`) and falsely report. The test locks in that the fast path prevents this.
- New `AppSourceCop.json` config + `NoDiagnosticWithOverlappingPrefix` method; instruction-file test coverage updated.

## Testing

`dotnet test src/ALCops.LinterCop.Test --filter InterfaceObjectNameGuide` → 11 passed, 0 skipped.