### PR TITLE
chore(ci): retry BC DevTools download and surface missing test results

### DIFF
--- a/.github/actions/setup-bc-devtools/action.yml
+++ b/.github/actions/setup-bc-devtools/action.yml
@@ -40,7 +40,7 @@ runs:
             exit 1
         }
 
-        Write-Output "Selected source: $($selectedSource.version) from $($selectedSource.source)"
+        Write-Output "Selected source: $($selectedSource.version) (package $($selectedSource.packageVersion))"
         Write-Output "Package Type: $($selectedSource.packageType)"
 
         # Set outputs
@@ -83,9 +83,26 @@ runs:
           
           Write-Output "Initiating download..."
           $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-          
-          Invoke-WebRequest $env:ASSET_URI -OutFile $downloadFilePath -Verbose
-          
+
+          # Retry with backoff: nuget.org / CDN occasionally drops the connection mid-stream
+          # ("The response ended prematurely"). -MaximumRetryCount only retries on HTTP status
+          # codes, not on connection drops, so use an explicit loop.
+          $maxAttempts = 5
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            try {
+              Write-Output "Download attempt $attempt of $maxAttempts..."
+              Invoke-WebRequest $env:ASSET_URI -OutFile $downloadFilePath
+              break
+            }
+            catch {
+              if (Test-Path $downloadFilePath) { Remove-Item $downloadFilePath -Force }
+              if ($attempt -eq $maxAttempts) { throw }
+              $delay = [math]::Pow(2, $attempt) * 5   # 10s, 20s, 40s, 80s
+              Write-Warning "Download failed: $($_.Exception.Message). Retrying in $delay s..."
+              Start-Sleep -Seconds $delay
+            }
+          }
+
           $stopwatch.Stop()
           
           # Verify download

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -402,7 +402,15 @@ jobs:
 
       - name: Merge Test Results
         if: always()
+        shell: bash
         run: |
+          # Every 'Run *.Test' step is continue-on-error, so this is the step that fails the job
+          # when tests never ran (e.g. BC DevTools download failed). Fail with a clear message
+          # instead of letting trx-merge crash on a missing directory.
+          if ! compgen -G "./TestResults/*.trx" > /dev/null; then
+            echo "::error::No .trx files found in ./TestResults - tests did not run. Check the 'Setup BC DevTools' and 'Run *.Test' steps above."
+            exit 1
+          fi
           trx-merge --dir ./TestResults/ --output ./TestResults_${{ matrix.version }}.trx
           
       - name: Upload Test Results


### PR DESCRIPTION
## Why

Run https://github.com/ALCops/Analyzers/actions/runs/32939282919 (`Test v18.0.36.33307`) failed with a `trx-merge` `DirectoryNotFoundException` for `./TestResults`. That was a secondary symptom: two steps earlier the BC DevTools download from nuget.org died with *The response ended prematurely (ResponseEnded)*. The composite action did a single `Invoke-WebRequest` with no retry, so tests never ran and the `if: always()` merge step crashed on the missing directory, burying the real cause.

## Changes

- **`.github/actions/setup-bc-devtools/action.yml`** — retry the download up to 5× with exponential backoff (10/20/40/80 s), deleting partial files between attempts. `-MaximumRetryCount` was not used because pwsh only retries on HTTP status codes, not mid-stream connection drops.
- **`.github/workflows/build-test.yml`** — `Merge Test Results` now fails with an explicit `::error::No .trx files found…` annotation when nothing ran, instead of a trx-merge stack trace. Deliberately still fails (not skipped): every `Run *.Test` step is `continue-on-error`, so this step is what turns "no tests ran" into a red job.
- Cosmetic: the `Selected source: … from` log line referenced a field that doesn't exist in the sources JSON.

No `.claude` doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)