### PR TITLE
chore: enable static analysis with warnings-only baseline

### DIFF
--- a/.claude/rules/code-analysis.md
+++ b/.claude/rules/code-analysis.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "Directory.Build.props"
+  - "Directory.Packages.props"
+  - ".editorconfig"
+  - "src/**/*.csproj"
+---
+
+# Code analysis on the C# codebase
+
+The repo ships analyzers, so it dogfoods static analysis on itself: .NET analyzers (`AnalysisLevel=latest-recommended`), `Microsoft.CodeAnalysis.Analyzers` (RS rules for analyzer authors), Roslynator (RCS rules) and `.editorconfig` code style enforced in build.
+
+## Where things live
+
+- `Directory.Build.props` — every property shared by all projects (`Nullable`, `LangVersion`, `WarningsAsErrors`, analysis switches) and the analyzer `PackageReference`s. A csproj should only contain what is genuinely project-specific (TFMs, NAV SDK `Reference`s, resx wiring, pack layout).
+- `Directory.Packages.props` — Central Package Management. Never put `Version=` on a `PackageReference`; add/bump versions here.
+- `.editorconfig` — all rule severities and suppressions, with a comment per suppression explaining why.
+
+## Design decisions
+
+| Decision | Why |
+|---|---|
+| Warnings-only baseline; only `CS8600;CS8602;CS8603;CS8604;CS8605` are errors | The analyzers were introduced onto an existing codebase. The ratchet plan is: rules with zero occurrences → `error`; the rest fixed and promoted category by category in dedicated PRs. |
+| Severities live in `.editorconfig`, never in MSBuild or `#pragma` | One place to audit, and `dotnet format` honours it. `#pragma warning disable` inside an analyzer needs a justification comment. |
+| Analyzer packages use `PrivateAssets="all"` | They must not become dependencies of the shipped `ALCops.Analyzers` NuGet. |
+| `GenerateDocumentationFile=true` + `CS1591` silenced | IDE0005 (unused usings) only reports in a command-line build when XML doc generation is on. The doc files are not packed (`ALCops.Analyzers.csproj` packs explicit DLL paths only). |
+| `csharp_style_namespace_declarations` is `silent` | The codebase is mixed (file-scoped and block-scoped). Enforce only after a dedicated unification PR. |
+| Culture rules `CA1304/1305/1307/1309/1310` off | AL identifiers and keywords are compared ordinally by design throughout the cops. |
+| `CA1062` off | Analyzer callbacks receive contexts from the host; null-guarding every public parameter is noise. |
+| CI `dotnet format --verify-no-changes` has `continue-on-error: true` | Same baseline principle. Flip to blocking once it passes on `main`. |
+| No `end_of_line` in `.editorconfig` | The repo relies on git `autocrlf`; the index is LF, Windows working trees are CRLF. An explicit EOL rule would make `dotnet format --verify-no-changes` fail locally on Windows. |
+| `src/**/Rules/**/*.al` marked `generated_code = true` and excluded from `dotnet format` | Fixtures are test inputs and must stay byte-stable (trailing whitespace, final newline included). |
+
+## Baseline snapshot (2026-08-26, local net10.0 build)
+
+Approximate warning counts at introduction, for the ratchet plan: IDE0055 formatting ~340 (17 files, mostly tab indentation in DocumentationCop — `dotnet format whitespace ALCops.sln` fixes all of them), CA1725 (parameter names vs base) ~44, CA1852 (seal internal types) ~36, IDE0005 (unused usings) ~26, CA1861 ~14, CA2263 ~13, CA1859 ~10, CA1720/CA1311/CA1822 ~6 each, CA1711 ~5, CA1068/CA2249 ~4, RCS1075/RCS1102 <5, CS1570/CS1573 (malformed XML docs) ~5. Everything else <3.
+
+## Known issues / limitations
+
+| Issue | Status |
+|---|---|
+| RS rules from `Microsoft.CodeAnalysis.Analyzers` mostly key on the real `Microsoft.CodeAnalysis` types; the NAV SDK is a fork (`Microsoft.Dynamics.Nav.CodeAnalysis`), so many RS rules never fire on the cops. | Accepted. Record any RS rule that *does* fire against a NAV type in the Design decisions table before suppressing it. |
+| `MSB3277` assembly-version conflicts on test projects (NAV SDK vs `Microsoft.Extensions.*` transitive refs). | Pre-existing, unrelated to analyzers. |
+| `NU1903`: transitive `System.Data.SqlClient 4.8.5` (via NAV SDK / test packages) has a known vulnerability. | Pre-existing. Candidate for `CentralPackageTransitivePinningEnabled` or an explicit `PackageVersion` override. |
+
+## Adding a suppression
+
+1. Confirm the rule is wrong for this codebase, not just for one file. Single-site exceptions use `#pragma` with a reason.
+2. Add `dotnet_diagnostic.XXXX.severity = none|suggestion` under the right section of `.editorconfig` with a one-line reason.
+3. If the reason involves a NAV SDK type, add a row to the table above.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,79 @@
+# ALCops Analyzers — editor and analyzer configuration
+# Severities here are a warnings-only baseline. Promote rules to `error` deliberately, one at a time,
+# once their occurrence count is zero. See .claude/rules/code-analysis.md.
+
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+# AL test fixtures must stay byte-stable: they are the inputs to the analyzer tests.
+[src/**/Rules/**/*.al]
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+generated_code = true
+
+[*.{csproj,props,targets,resx}]
+indent_size = 4
+
+[*.cs]
+# --- Code style (IDE*) ------------------------------------------------------
+# Only styles the codebase already follows uniformly are enforced; the rest are suggestions.
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+csharp_prefer_braces = when_multiline:silent
+# Mixed today (221 file-scoped / 110 block-scoped). Do not enforce until unified.
+csharp_style_namespace_declarations = file_scoped:silent
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+dotnet_diagnostic.IDE0005.severity = warning   # unused using directives
+dotnet_diagnostic.IDE0055.severity = warning   # formatting (whitespace/indent/newlines)
+dotnet_diagnostic.IDE0161.severity = none      # namespace style — see above
+
+# Missing XML doc comments: GenerateDocumentationFile is only on to make IDE0005 work in build.
+dotnet_diagnostic.CS1591.severity = none
+
+# --- .NET analyzers (CA*) ---------------------------------------------------
+# Analyzer callbacks receive non-null contexts from the host; validating every public parameter is pure noise.
+dotnet_diagnostic.CA1062.severity = none
+# AL identifiers are compared ordinally by design; culture-aware overloads are not wanted.
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1307.severity = none
+dotnet_diagnostic.CA1309.severity = none
+dotnet_diagnostic.CA1310.severity = none
+# Localization of diagnostic messages is handled via resx; these rules target UI strings.
+dotnet_diagnostic.CA1303.severity = none
+# Analyzer types are instantiated by the host via attributes; "unused"/"could be static" heuristics misfire.
+dotnet_diagnostic.CA1812.severity = none
+
+# --- Analyzer-authoring rules (RS*) from Microsoft.CodeAnalysis.Analyzers -----
+# The NAV SDK is a fork of Roslyn (Microsoft.Dynamics.Nav.CodeAnalysis); most RS rules key on the
+# real Microsoft.CodeAnalysis types and will simply not fire. Those that do are kept as warnings.
+# Do NOT add a suppression here without documenting which NAV SDK type triggered it.
+
+# --- Roslynator (RCS*) -----------------------------------------------------
+# Defaults, warnings-only. Downgrade the noisiest rules here after inspecting counts — never in code.
+dotnet_diagnostic.RCS1123.severity = suggestion  # add parentheses when necessary — opinionated
+dotnet_diagnostic.RCS1163.severity = suggestion  # unused parameter — analyzer callbacks often have fixed signatures
+
+[src/*.Test/**.cs]
+# Test methods are discovered by attribute; naming and static-member rules do not apply.
+dotnet_diagnostic.CA1707.severity = none   # underscores in identifiers
+dotnet_diagnostic.CA1822.severity = none   # mark members as static

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,6 +118,14 @@ jobs:
           target-path: Microsoft.Dynamics.BusinessCentral.Development.Tools/net10.0
           tfm: net10.0
 
+      # Code style / formatting gate (warnings-only baseline: reports drift, does not fail the job yet)
+      - name: Restore solution
+        run: dotnet restore ALCops.sln
+
+      - name: Verify code formatting
+        run: dotnet format ALCops.sln --verify-no-changes --no-restore --severity warn --exclude "**/Rules/**/*.al"
+        continue-on-error: true
+
       # ALCops.Common
       - name: Restore ALCops.Common
         run: dotnet restore ./src/ALCops.Common/ALCops.Common.csproj

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "dotnet.defaultSolution": "ALCops.sln",
+    "dotnet.backgroundAnalysis.analyzerDiagnosticsScope": "fullSolution",
+    "dotnet.backgroundAnalysis.compilerDiagnosticsScope": "fullSolution"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~{RuleName}"
 dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~{RuleName}.HasDiagnostic"
 ```
 
+- Shared MSBuild settings live in `Directory.Build.props`; package versions in `Directory.Packages.props` (Central Package Management - no `Version=` on `PackageReference`).
+- Static analysis (NetAnalyzers, `Microsoft.CodeAnalysis.Analyzers`, Roslynator, `.editorconfig` code style) runs as warnings; `dotnet format ALCops.sln --verify-no-changes` checks formatting. See `.claude/rules/code-analysis.md`.
+
 - Requires BC Dev Tools at `../../Microsoft.Dynamics.BusinessCentral.Development.Tools` (repo-root relative) or `/p:BcDevToolsDir=<path>`. `.vscode/Setup-BCDevTools.ps1` downloads them.
 - Local builds target `net8.0` only. CI (`ContinuousIntegrationBuild=true`) builds `netstandard2.1;net8.0;net10.0` because BC ships the SDK in all three. Test projects target `net10.0` and switch via `NavTargetFramework`.
 - Nullable warnings `CS8600;CS8602;CS8603;CS8604;CS8605` are errors.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,33 @@
+<Project>
+    <!--
+        Shared build settings for every project in the repo.
+        Per-project csproj files keep only what differs: TargetFramework(s), NAV SDK references, resx wiring, pack layout.
+        See .claude/rules/code-analysis.md for the rationale behind the analysis settings.
+    -->
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <GenerateFullPaths>true</GenerateFullPaths>
+
+        <!-- Nullable-flow violations are the only warnings promoted to errors today. -->
+        <WarningsAsErrors>$(WarningsAsErrors);CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
+    </PropertyGroup>
+
+    <!-- Static analysis: warnings-only baseline. Severities are tuned in .editorconfig, never here. -->
+    <PropertyGroup>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest-recommended</AnalysisLevel>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+
+        <!-- IDE0005 (unused usings) only reports during build when XML doc generation is on; CS1591 is silenced in .editorconfig. -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <!-- PrivateAssets="all" keeps analyzer packages out of the shipped ALCops.Analyzers NuGet. -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="Roslynator.Analyzers" PrivateAssets="all" />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,29 @@
+<Project>
+    <!-- Central Package Management: every PackageReference version lives here. -->
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    </PropertyGroup>
+
+    <!-- Analyzers (build-time only) -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
+    </ItemGroup>
+
+    <!-- Runtime (netstandard2.1 cops only) -->
+    <ItemGroup>
+        <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
+    </ItemGroup>
+
+    <!-- Test projects -->
+    <ItemGroup>
+        <PackageVersion Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageVersion Include="NUnit" Version="4.1.0" />
+        <PackageVersion Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,13 @@
         <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
     </ItemGroup>
 
-    <!-- Runtime (netstandard2.1 cops only) -->
+    <!--
+        Runtime dependency, netstandard2.1 cops only (net8.0/net10.0 get it from the framework).
+        Deliberately pinned LOW: the cop DLLs are loaded into the AL compiler's process, so this reference must
+        bind against the System.Collections.Immutable version shipped by the oldest supported AL Language
+        extension. Bumping it breaks loading on older BC/AL versions. Do not "update" without testing against
+        the lowest netstandard2.1 BC DevTools version in the CI matrix.
+    -->
     <ItemGroup>
         <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
     </ItemGroup>

--- a/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
+++ b/src/ALCops.ApplicationCop.Test/ALCops.ApplicationCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
+        <PackageReference Include="ALCops.RoslynTestKit" ExcludeAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
         <Reference Include="$(PkgALCops_RoslynTestKit)/lib/netstandard2.1/RoslynTestKit.dll">
             <Private>True</Private>
         </Reference>

--- a/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
+++ b/src/ALCops.ApplicationCop/ALCops.ApplicationCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -56,6 +51,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>

--- a/src/ALCops.Common.Test/ALCops.Common.Test.csproj
+++ b/src/ALCops.Common.Test/ALCops.Common.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Input knobs -->
         <NavTargetFramework Condition="'$(NavTargetFramework)'==''">net10.0</NavTargetFramework>
@@ -27,10 +23,10 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 

--- a/src/ALCops.Common/ALCops.Common.csproj
+++ b/src/ALCops.Common/ALCops.Common.csproj
@@ -3,11 +3,6 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <LangVersion>Latest</LangVersion>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
         
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -27,7 +22,7 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
         <Reference Include="Newtonsoft.Json">
             <SpecificVersion>False</SpecificVersion>
             <HintPath>$(BcDevToolsDir)/$(TargetFramework)/Newtonsoft.Json.dll</HintPath>

--- a/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
+++ b/src/ALCops.DocumentationCop.Test/ALCops.DocumentationCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
+        <PackageReference Include="ALCops.RoslynTestKit"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
+++ b/src/ALCops.DocumentationCop/ALCops.DocumentationCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -56,6 +51,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>

--- a/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
+++ b/src/ALCops.FormattingCop.Test/ALCops.FormattingCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
+        <PackageReference Include="ALCops.RoslynTestKit"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
+++ b/src/ALCops.FormattingCop/ALCops.FormattingCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -56,6 +51,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>

--- a/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
+++ b/src/ALCops.LinterCop.Test/ALCops.LinterCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
+        <PackageReference Include="ALCops.RoslynTestKit"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.LinterCop/ALCops.LinterCop.csproj
+++ b/src/ALCops.LinterCop/ALCops.LinterCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -59,6 +54,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>

--- a/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
+++ b/src/ALCops.PlatformCop.Test/ALCops.PlatformCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
+        <PackageReference Include="ALCops.RoslynTestKit"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
+++ b/src/ALCops.PlatformCop/ALCops.PlatformCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -56,6 +51,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>

--- a/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
+++ b/src/ALCops.TestAutomationCop.Test/ALCops.TestAutomationCop.Test.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <GenerateFullPaths>true</GenerateFullPaths>
-        <LangVersion>latest</LangVersion>
 
         <!-- Feature flags -->
         <DefineConstants>$(DefineConstants)</DefineConstants>
@@ -31,12 +27,12 @@
 
     <!-- Test/runtime infra -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
         <Using Include="NUnit.Framework" />
     </ItemGroup>
 
@@ -60,12 +56,12 @@
 
     <!-- RoslynTestKit -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'!='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0" />
+        <PackageReference Include="ALCops.RoslynTestKit" />
     </ItemGroup>
 
     <!-- On legacy NAV TFMs, suppress package assets and directly reference the netstandard2.1 DLL -->
     <ItemGroup Condition="'$(IsLegacyNavTfm)'=='true'">
-        <PackageReference Include="ALCops.RoslynTestKit" Version="1.4.0"
+        <PackageReference Include="ALCops.RoslynTestKit"
                             ExcludeAssets="all"
                             IncludeAssets="none"
                             GeneratePathProperty="true" />

--- a/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
+++ b/src/ALCops.TestAutomationCop/ALCops.TestAutomationCop.csproj
@@ -3,12 +3,7 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' != 'true'">net10.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(ContinuousIntegrationBuild)' == 'true'">netstandard2.1;net8.0;net10.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8605</WarningsAsErrors>
-        <GenerateFullPaths>true</GenerateFullPaths>
 
         <!-- Path to BC dev tools may be overridden by /p:BcDevToolsDir= -->
         <BcDevToolsDir Condition="'$(BcDevToolsDir)'==''">../../Microsoft.Dynamics.BusinessCentral.Development.Tools</BcDevToolsDir>
@@ -56,6 +51,6 @@
 
     <!-- Legacy support for netstandard2.1 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

The repo ships ~100 analyzers but applied almost none to its own C# code: no `Directory.Build.props`, no `.editorconfig`, no analyzer packages, and the same property block copy-pasted into every csproj. This PR introduces a **warnings-only** static-analysis baseline so we can ratchet up in follow-ups.

- **`Directory.Build.props`** — shared `Nullable`/`LangVersion`/`ImplicitUsings`/`WarningsAsErrors` (nullable errors now also apply to test projects); `AnalysisLevel=latest-recommended`, `EnforceCodeStyleInBuild`; `Microsoft.CodeAnalysis.Analyzers` 5.9.0 + `Roslynator.Analyzers` 5.0.0 as `PrivateAssets="all"`.
- **`Directory.Packages.props`** — Central Package Management; all package versions pinned in one place.
- **`.editorconfig`** — style rules + per-rule severities, every suppression commented (culture rules, CA1062, CA1812; CA1707/CA1822 in tests). Namespace style is `silent` because the codebase is mixed (221 file-scoped / 110 block-scoped). AL fixtures are marked `generated_code` and excluded from formatting. No `end_of_line` rule: git `autocrlf` owns line endings.
- **csproj** — 14 files trimmed to project-specific content only (−122/+59 lines).
- **CI** — `dotnet format ALCops.sln --verify-no-changes` added to the build job with `continue-on-error: true` until the baseline is clean. Test steps untouched.
- **Docs** — `.claude/rules/code-analysis.md` (design decisions, baseline counts, ratchet plan); `CLAUDE.md` pointer.

No analyzer or test source files were changed.

## Baseline (local net10.0 build)

| Rule | ~Count | Notes |
|---|---|---|
| IDE0055 | 340 | 17 files, mostly tab indentation in DocumentationCop — `dotnet format whitespace ALCops.sln` fixes all |
| CA1725 | 44 | parameter names vs base (`ctx` → `context`) |
| CA1852 | 36 | seal internal types |
| IDE0005 | 26 | unused usings |
| CA1861 / CA2263 / CA1859 | 14 / 13 / 10 | |
| others | <6 each | |
| RS* | 0 | NAV SDK is a Roslyn fork; RS rules never fire (documented) |

Pre-existing and unrelated: `NU1903` (transitive `System.Data.SqlClient 4.8.5`), `MSB3277` conflicts on test projects.

## Verification

- `dotnet build ALCops.sln` — 0 errors
- `dotnet build -p:ContinuousIntegrationBuild=true` (`netstandard2.1;net8.0;net10.0`) — 0 errors
- `dotnet test ALCops.sln` — 1,490 passed, 0 failed
- `dotnet pack ALCops.Analyzers` — nuspec has no analyzer dependencies; only cop DLLs in `lib/`
- `dotnet format --verify-no-changes` — fails today on the 17 IDE0055 files (expected; non-blocking in CI)

## Follow-ups

- Run `dotnet format whitespace` and flip the CI format step to blocking.
- Ratchet: promote zero-occurrence rules to `error`; fix and promote the rest category by category.
- Consider `Microsoft.CodeAnalysis.BannedApiAnalyzers` for version-unstable NAV SDK members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
