### PR TITLE
chore: strip UTF-8 BOM from 23 source files to satisfy charset = utf-8

### DIFF
--- a/.claude/rules/code-analysis.md
+++ b/.claude/rules/code-analysis.md
@@ -21,7 +21,7 @@ The repo ships analyzers, so it dogfoods static analysis on itself: .NET analyze
 | Decision | Why |
 |---|---|
 | Warnings-only baseline; only `CS8600;CS8602;CS8603;CS8604;CS8605` are errors | The analyzers were introduced onto an existing codebase. The ratchet plan is: rules with zero occurrences → `error`; the rest fixed and promoted category by category in dedicated PRs. |
-| IDE0055 is the first rule promoted to `error` | It is fully machine-fixable, so the count went to 0 in one tool-executed PR. Isolate the fix with `dotnet format style ALCops.sln --diagnostics IDE0055` — the `whitespace` subcommand also rewrites CHARSET (strips the UTF-8 BOM from 23 files), which is out of scope. Note IDE0055 also covers using-directive order (`dotnet_sort_system_directives_first`). |
+| IDE0055 is the first rule promoted to `error` | It is fully machine-fixable, so the count went to 0 in one tool-executed PR. Isolate the fix with `dotnet format style ALCops.sln --diagnostics IDE0055` — the `whitespace` subcommand also rewrites CHARSET (UTF-8 BOM), which was stripped in a separate PR. Note IDE0055 also covers using-directive order (`dotnet_sort_system_directives_first`). |
 | Column-aligned lookup tables keep their alignment, wrapped in `#pragma warning disable/restore IDE0055` with a reason comment | Roslyn has no aligned-assignment option (`csharp_space_around_binary_operators` cannot express it), so the formatter collapses the columns. The alignment is what makes these tables readable; the pragma is the only way to keep both. |
 | Severities live in `.editorconfig`, never in MSBuild or `#pragma` | One place to audit, and `dotnet format` honours it. `#pragma warning disable` inside an analyzer needs a justification comment. |
 | Analyzer packages use `PrivateAssets="all"` | They must not become dependencies of the shipped `ALCops.Analyzers` NuGet. |
@@ -29,15 +29,16 @@ The repo ships analyzers, so it dogfoods static analysis on itself: .NET analyze
 | `csharp_style_namespace_declarations` is `silent` | The codebase is mixed (file-scoped and block-scoped). Enforce only after a dedicated unification PR. |
 | Culture rules `CA1304/1305/1307/1309/1310` off | AL identifiers and keywords are compared ordinally by design throughout the cops. |
 | `CA1062` off | Analyzer callbacks receive contexts from the host; null-guarding every public parameter is noise. |
-| CI `dotnet format --verify-no-changes` has `continue-on-error: true` | Same baseline principle. Flip to blocking once it passes on `main`. |
+| CI `dotnet format --verify-no-changes` has `continue-on-error: true` | Same baseline principle. The `whitespace` category (IDE0055 + CHARSET) is clean; the umbrella command still reports IDE0005 (unused usings) and a few RCS fixes at `--severity warn`. Flip to blocking once those are 0 on `main`. |
 | No `end_of_line` in `.editorconfig` | The repo relies on git `autocrlf`; the index is LF, Windows working trees are CRLF. An explicit EOL rule would make `dotnet format --verify-no-changes` fail locally on Windows. |
+| `charset = utf-8` (no BOM) is enforced; all `.cs` files are BOM-less | EditorConfig `utf-8` means *without* BOM; 23 Visual Studio-saved files had one and made `dotnet format --verify-no-changes` red (`CHARSET`). Stripped with `dotnet format whitespace ALCops.sln`. |
 | `src/**/Rules/**/*.al` marked `generated_code = true` and excluded from `dotnet format` | Fixtures are test inputs and must stay byte-stable (trailing whitespace, final newline included). |
 
 ## Baseline snapshot (2026-08-26, local net10.0 build)
 
 Approximate warning counts at introduction, for the ratchet plan: IDE0055 formatting **0** (was ~340 in 17 files, mostly tab indentation in DocumentationCop; fixed and promoted to `error`), CA1725 (parameter names vs base) ~44, CA1852 (seal internal types) ~36, IDE0005 (unused usings) ~26, CA1861 ~14, CA2263 ~13, CA1859 ~10, CA1720/CA1311/CA1822 ~6 each, CA1711 ~5, CA1068/CA2249 ~4, RCS1075/RCS1102 <5, CS1570/CS1573 (malformed XML docs) ~5. Everything else <3.
 
-Remaining `dotnet format --verify-no-changes` work: CHARSET, 23 files (UTF-8 BOM) — still makes the CI format step red (`continue-on-error`). The 5 IMPORTS findings went away with IDE0055, which also enforces using order.
+Remaining `dotnet format --verify-no-changes` work: IDE0005 (~56 unused usings) and RCS1075/RCS1102 (3) — still make the CI format step red (`continue-on-error`). CHARSET (UTF-8 BOM, 23 files) is fixed. The 5 IMPORTS findings went away with IDE0055, which also enforces using order.
 
 ## Known issues / limitations
 

--- a/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/CaptionRequired.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/IntegrationEventInInternalCodeunit.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/IntegrationEventInInternalCodeunit.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/LookupPageIdAndDrillDownPageId.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/LookupPageIdAndDrillDownPageId.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/NotBlankOnPrimaryKeyField.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/NotBlankOnPrimaryKeyField.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/PermissionSetCoverage.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/PermissionSetCoverage.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using ALCops.Common;

--- a/src/ALCops.ApplicationCop/Analyzers/PublicEventPublisher.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/PublicEventPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/TableDataPerCompanyDeclaration.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/TableDataPerCompanyDeclaration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.ApplicationCop/Analyzers/ToolTipPunctuation.cs
+++ b/src/ALCops.ApplicationCop/Analyzers/ToolTipPunctuation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using ALCops.Common.Settings;

--- a/src/ALCops.DocumentationCop/Analyzers/CommitRequiresComment.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/CommitRequiresComment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/ProcedureRequiresDocumentation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.DocumentationCop/Analyzers/WriteToFlowFieldRequiresComment.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/WriteToFlowFieldRequiresComment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.DocumentationCop/Analyzers/XmlDocumentationProcedureConsistency.cs
+++ b/src/ALCops.DocumentationCop/Analyzers/XmlDocumentationProcedureConsistency.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.FormattingCop/Analyzers/SemicolonAfterMethodOrTriggerDeclaration.cs
+++ b/src/ALCops.FormattingCop/Analyzers/SemicolonAfterMethodOrTriggerDeclaration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/src/ALCops.FormattingCop/Analyzers/UseParenthesisForFunctionCall.cs
+++ b/src/ALCops.FormattingCop/Analyzers/UseParenthesisForFunctionCall.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/src/ALCops.LinterCop/Analyzers/ApplicationAreaRedundancy.cs
+++ b/src/ALCops.LinterCop/Analyzers/ApplicationAreaRedundancy.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.LinterCop/Analyzers/CyclomaticComplexityAndMaintainabilityIndex.cs
+++ b/src/ALCops.LinterCop/Analyzers/CyclomaticComplexityAndMaintainabilityIndex.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using ALCops.Common.Settings;

--- a/src/ALCops.LinterCop/Analyzers/DataClassificationRedundancy.cs
+++ b/src/ALCops.LinterCop/Analyzers/DataClassificationRedundancy.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.LinterCop/Analyzers/EventSubscriberNamingPattern.cs
+++ b/src/ALCops.LinterCop/Analyzers/EventSubscriberNamingPattern.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text;
 using ALCops.Common.Extensions;
 using ALCops.Common.Helpers;

--- a/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
+++ b/src/ALCops.LinterCop/Analyzers/ObjectIdInDeclaration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.PlatformCop/Analyzers/AccessPropertyExplicitlySet.cs
+++ b/src/ALCops.PlatformCop/Analyzers/AccessPropertyExplicitlySet.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;

--- a/src/ALCops.PlatformCop/Analyzers/AutoIncrementInTemporaryTable.cs
+++ b/src/ALCops.PlatformCop/Analyzers/AutoIncrementInTemporaryTable.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/src/ALCops.PlatformCop/Analyzers/SetRangeWithFilterOperators.cs
+++ b/src/ALCops.PlatformCop/Analyzers/SetRangeWithFilterOperators.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;

--- a/src/ALCops.PlatformCop/Analyzers/TableRelationFieldLength.cs
+++ b/src/ALCops.PlatformCop/Analyzers/TableRelationFieldLength.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using ALCops.Common.Extensions;
 using ALCops.Common.Reflection;
 using Microsoft.Dynamics.Nav.CodeAnalysis;


### PR DESCRIPTION
## What

Follow-up to #475. Removes the UTF-8 byte order mark (`EF BB BF`) from the 23 `.cs` files that had one, so they comply with `.editorconfig`'s `charset = utf-8` (which in EditorConfig means *without* BOM; `utf-8-bom` is the other value).

Tool-executed, no hand edits to code:

```
dotnet format whitespace ALCops.sln --exclude "**/Rules/**/*.al"
```

Diff shape: 23 files, each changed by exactly its first 3 bytes (line 1 only). No `.al` fixture touched.

## Why

These files made CI's `dotnet format --verify-no-changes` step report `error CHARSET: Fix file encoding`. With #475 (IDE0055 → 0) and this PR, the whole `whitespace` category is clean:

- `dotnet format whitespace ALCops.sln --verify-no-changes --exclude "**/Rules/**/*.al"` → exit 0
- `dotnet build ALCops.sln` → 0 errors
- `dotnet test ALCops.sln` → 1488 passed, 0 failed, 2 skipped (pre-existing)

## Not in this PR

The CI format gate keeps `continue-on-error: true`: the umbrella command runs `style`/`analyzers` fixers at `--severity warn` too and still reports **IDE0005 (~56 unused usings)** and **RCS1075/RCS1102 (3)**. Those are the next ratchet step; once they are 0 the gate can become blocking. `.claude/rules/code-analysis.md` updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)