### PR TITLE
fix(FC0006): do not flag AccessByPermission values

### DIFF
--- a/.claude/rules/diagnostics/fc0006-permission-values-should-be-lowercase.md
+++ b/.claude/rules/diagnostics/fc0006-permission-values-should-be-lowercase.md
@@ -17,6 +17,7 @@ Detects uppercase permission values (e.g. `RIMD`, `Rimd`, `X`) in the `Permissio
 | One diagnostic per property, not per entry | Matches FC0004; the fix lowercases the whole list |
 | Diagnostic on `PropertySyntax` node | Ensures CodeFix can find the node via `FindNode` + ancestor/descendant traversal (same as FC0004) |
 | Exclude permissionset(extension) via syntax ancestors | Deterministic, no semantic model lookup needed |
+| Exclude `AccessByPermission` by parent property name (denylist) | It shares the `PermissionPropertyValue` node kind (`ParseAccessByPermission`), but is a UI-visibility mask with no direct/indirect semantics; uppercase is the Microsoft-documented form. Denylist keeps the diff small and preserves behaviour for every other property. Issue #474 |
 | Skip obsolete objects | Standard convention (`ctx.IsObsolete()`) |
 | `ContainsUppercase` is `internal static` on the analyzer | Shared with the CodeFix within the assembly |
 | Execute (`X`) coverage via generic uppercase check, tested with error-tolerant fixtures | `X` in scope only occurs in code with a compile error (AL0195); test methods `*InDocumentWithErrors` use `ThrowsWhenInputDocumentContainsError = false` (same pattern as `ApplicationCop.Test/TestHelper.cs`) |
@@ -36,14 +37,16 @@ src/ALCops.FormattingCop/
 1. `RegisterSyntaxNodeAction` on `EnumProvider.SyntaxKind.PermissionPropertyValue` (rare node; cheap pre-filter, covers requestpages nested in reports/xmlports which `GetDeclaredApplicationObjectSymbols()` cannot reach)
 2. Skip obsolete symbols via `ctx.IsObsolete()`
 3. Skip when any ancestor is a `PermissionSet`/`PermissionSetExtension` object (casing is semantic there: uppercase = direct, lowercase = indirect)
-4. Flag when any `PermissionSyntax.Permissions` token text contains an uppercase char
-5. Report one diagnostic per property on the `PropertySyntax` node (parent of the value node)
+4. Skip when the parent `PropertySyntax` is named `AccessByPermission` (same node kind, different property; see SDK facts)
+5. Flag when any `PermissionSyntax.Permissions` token text contains an uppercase char
+6. Report one diagnostic per property on the `PropertySyntax` node (parent of the value node)
 
 ## SDK facts (verified against nav-sdk-source and empirically)
 
 - The `Permissions` property exists on: Codeunit, Table, Page, Report, RequestPage, XmlPort, Query, PermissionSet, PermissionSetExtension (`PropertyInfoLookup`). Extension objects do not support it.
 - **The object-level `Permissions` property only accepts `tabledata` entries.** Non-`tabledata` entries (`codeunit X = X` etc.) are rejected with `AL0104: Syntax error, 'tabledata' expected`, despite Microsoft Learn docs showing such examples. Only permissionset objects accept other object types (parsed via `ParsePermissionSetPermissionListPropertyValue`).
 - Both object-level and permissionset permission lists produce `PermissionPropertyValueSyntax` (same `SyntaxKind.PermissionPropertyValue`), hence the explicit permissionset ancestor exclusion.
+- **`AccessByPermission` also produces `PermissionPropertyValueSyntax`** (a single entry, built by `ObjectParser.ParseAccessByPermission`), so registering on the node kind alone does not scope the rule to `Permissions`. It exists on table fields, page fields/parts/actions, pages and reports (`PropertyInfoLookup`) and needs an explicit parent-property-name exclusion.
 - `InherentPermissions` produces a different node kind (`InherentPermissionsPropertyValue`), so it is naturally excluded by the registration.
 - The parser uppercases permission values before validation (`GetPermissionValuesTokenWithError`), so any casing parses cleanly.
 - **Execute permission (`X`/`x`) reachability**: on object-level `Permissions`, `tabledata Foo = X` parses into the tree but carries `AL0195: Invalid permission kind. Expected: 'RIMD'` — the analyzer still sees the token and flags it. Non-`tabledata` entries (`codeunit Foo = X`) are dropped entirely by parser error recovery (`SkipBadPermissionSyntaxToken`); their `X` token never reaches a `PermissionSyntax` node, so the analyzer cannot see it (verified empirically). Since the analyzer checks every `PermissionSyntax.Permissions` token for any uppercase char, a future SDK that legalizes non-tabledata entries is covered automatically.

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/AccessByPermissionWithUppercasePermissions.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/HasDiagnostic/AccessByPermissionWithUppercasePermissions.al
@@ -1,0 +1,25 @@
+page 50100 "My Page"
+{
+    [|Permissions = tabledata Alpha = RIMD|];
+
+    actions
+    {
+        area(Processing)
+        {
+            action("BOM Level")
+            {
+                ApplicationArea = All;
+                AccessByPermission = tabledata Alpha = R;
+            }
+        }
+    }
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionPageAction.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionPageAction.al
@@ -1,0 +1,23 @@
+page 50100 "My Page"
+{
+    actions
+    {
+        area(Processing)
+        {
+            action("BOM Level")
+            {
+                ApplicationArea = All;
+                [|AccessByPermission = tabledata Alpha = R|];
+            }
+        }
+    }
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionPageObject.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionPageObject.al
@@ -1,0 +1,22 @@
+page 50100 "My Page"
+{
+    ApplicationArea = All;
+    UsageCategory = Lists;
+    [|AccessByPermission = tabledata Alpha = R|];
+}
+
+report 50101 "My Report"
+{
+    ApplicationArea = All;
+    UsageCategory = ReportsAndAnalysis;
+    [|AccessByPermission = tabledata Alpha = RIMD|];
+}
+
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionTableField.al
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/NoDiagnostic/AccessByPermissionTableField.al
@@ -1,0 +1,20 @@
+table 50100 Alpha
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            [|AccessByPermission = tabledata Bravo = IM|];
+        }
+    }
+}
+
+table 50101 Bravo
+{
+    Caption = '', Locked = true;
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop.Test/Rules/PermissionValuesShouldBeLowercase/PermissionValuesShouldBeLowercase.cs
@@ -39,6 +39,7 @@ namespace ALCops.FormattingCop.Test
         [TestCase("QueryUppercase")]
         [TestCase("RequestPageUppercase")]
         [TestCase("MultipleEntriesOneUppercase")]
+        [TestCase("AccessByPermissionWithUppercasePermissions")]
         public async Task HasDiagnostic(string testCase)
         {
             var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
@@ -64,6 +65,9 @@ namespace ALCops.FormattingCop.Test
         [TestCase("InherentPermissionsUppercase")]
         [TestCase("NoPermissionsProperty")]
         [TestCase("ObsoleteCodeunit")]
+        [TestCase("AccessByPermissionPageAction")]
+        [TestCase("AccessByPermissionTableField")]
+        [TestCase("AccessByPermissionPageObject")]
         public async Task NoDiagnostic(string testCase)
         {
             SkipTestIfVersionIsTooLow(

--- a/src/ALCops.FormattingCop/Analyzers/PermissionValuesShouldBeLowercase.cs
+++ b/src/ALCops.FormattingCop/Analyzers/PermissionValuesShouldBeLowercase.cs
@@ -28,6 +28,11 @@ public sealed class PermissionValuesShouldBeLowercase : DiagnosticAnalyzer
         if (IsInPermissionSetObject(permissionValue))
             return;
 
+        // AccessByPermission reuses the PermissionPropertyValue node but is a UI-visibility
+        // mask, not an indirect-permission grant; uppercase is its documented form (issue #474).
+        if (IsAccessByPermissionProperty(permissionValue))
+            return;
+
         if (!HasUppercasePermissionValue(permissionValue))
             return;
 
@@ -38,6 +43,10 @@ public sealed class PermissionValuesShouldBeLowercase : DiagnosticAnalyzer
             DiagnosticDescriptors.PermissionValuesShouldBeLowercase,
             location));
     }
+
+    private static bool IsAccessByPermissionProperty(PermissionPropertyValueSyntax permissionValue) =>
+        permissionValue.Parent is PropertySyntax property &&
+        property.Name?.Identifier.ValueText.IsSameName("AccessByPermission") == true;
 
     private static bool IsInPermissionSetObject(SyntaxNode node)
     {


### PR DESCRIPTION
## Root cause

`ObjectParser.ParseAccessByPermission()` wraps its single `PermissionSyntax` in
`InternalSyntaxFactory.PermissionPropertyValue(...)` — the **same
`SyntaxKind.PermissionPropertyValue` node** the `Permissions` property produces.
FC0006 registers on that syntax kind and only excluded `permissionset` /
`permissionsetextension` ancestors, so every `AccessByPermission` value was
analyzed as if it were an object-level `Permissions` grant.

`AccessByPermission` is out of the rule's scope: it is a UI-visibility mask, has
no direct/indirect notion, and Microsoft Learn documents uppercase (`R`, `IM`,
`RIMD`, `X`) as its canonical form.

## Fix

Denylist by parent property name in `AnalyzePermissionPropertyValue`, right after
the permissionset check. Purely syntactic, no semantic model call, no new
`EnumProvider` member, compiles on `netstandard2.1` as-is. The CodeFix needs no
change — it only acts on reported diagnostics.

## Fixtures

`NoDiagnostic/`
- `AccessByPermissionPageAction.al` — the issue repro (`action` with `AccessByPermission = tabledata Alpha = R;`)
- `AccessByPermissionTableField.al` — table field, `= IM`
- `AccessByPermissionPageObject.al` — object-level on a page and on a report

`HasDiagnostic/`
- `AccessByPermissionWithUppercasePermissions.al` — one page carrying both an action-level `AccessByPermission` and an object-level `Permissions = ... RIMD`; only the `Permissions` property is marked, proving the exclusion stays targeted.

All three `NoDiagnostic` fixtures fail on `main` and pass with the fix. Full `ALCops.FormattingCop.Test` suite: 148 passed, 0 failed.

Note: the new fixtures mark the property span explicitly (`[|AccessByPermission = ...|];`) rather than using the `[||]` file-start marker used by some existing FC0006 `NoDiagnostic` fixtures. `NoDiagnosticAtAllMarkers` only asserts the absence of a diagnostic *at the marker*, so a zero-width marker at position 0 does not reproduce this false positive — verified with a control fixture containing a real uppercase `Permissions` property, which passed under `[||]`.

Docs PR: ALCops/alcops.dev#155

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
