### PR TITLE
docs: correct stale local-TFM and RoslynTestKit statements in the rules files

### DIFF
--- a/.claude/rules/netstandard21-compatibility.md
+++ b/.claude/rules/netstandard21-compatibility.md
@@ -5,7 +5,7 @@ paths:
 
 # netstandard2.1 Backward Compatibility
 
-All analyzer and common projects multi-target in CI: `netstandard2.1;net8.0;net10.0`. Several C# 9+ features and newer SDK APIs are unavailable in `netstandard2.1`. Code that compiles fine locally (net8.0 only) will fail in CI without conditional compilation guards.
+All analyzer and common projects multi-target in CI: `netstandard2.1;net8.0;net10.0`. Several C# 9+ features and newer SDK APIs are unavailable in `netstandard2.1`. Code that compiles fine locally (net10.0 only) will fail in CI without conditional compilation guards; build every cop with `-p:ContinuousIntegrationBuild=true` before merging (see CLAUDE.md).
 
 ## C# language features that require guards
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -5,7 +5,7 @@ paths:
 
 # Testing Guide for ALCops Analyzers
 
-Tests use **NUnit 4.1.0** with **ALCops.RoslynTestKit 0.4.1** to test AL code analyzers for Business Central. All test projects target **net8.0**. Each of the 6 analyzer/test project pairs follows the namespace pattern `ALCops.{Cop}.Test`.
+Tests use **NUnit 4.1.0** with **ALCops.RoslynTestKit** (version in `Directory.Packages.props`) to test AL code analyzers for Business Central. All test projects target **net10.0**; CI additionally runs them against the netstandard2.1 and net8.0 analyzer binaries via `NavTargetFramework`. Each of the 6 analyzer/test project pairs follows the namespace pattern `ALCops.{Cop}.Test`.
 
 For running tests and the step-by-step flow for a new rule: use `/new-analyzer` / see CLAUDE.md for `dotnet test` filters.
 
@@ -169,7 +169,7 @@ public async Task HasDiagnostic(string testCase)
 
 ### Why `#if` pragmas don't work in test projects
 
-Test projects always compile as `net8.0`, so `NETSTANDARD2_1` is never defined. The version difference is a runtime property of which SDK DLL gets loaded (CI tests against both netstandard2.1 and net8.0 analyzer binaries), so it must be a runtime check.
+Test projects always compile as `net10.0`, so `NETSTANDARD2_1` is never defined. The version difference is a runtime property of which SDK DLL gets loaded (CI tests against the netstandard2.1, net8.0 and net10.0 analyzer binaries), so it must be a runtime check.
 
 ## Testing Analyzers with File System Dependencies
 


### PR DESCRIPTION
Follow-up to #487 (which fixed the same class of error in CLAUDE.md). Three statements in `.claude/rules/` still described the old setup:

| File | Was | Now |
|---|---|---|
| `testing.md` intro | "ALCops.RoslynTestKit 0.4.1 … All test projects target net8.0" | version lives in `Directory.Packages.props`; test projects target net10.0, CI also runs them against the netstandard2.1 and net8.0 analyzer binaries via `NavTargetFramework` |
| `testing.md` § Why `#if` pragmas don't work in test projects | "always compile as net8.0 … both netstandard2.1 and net8.0 binaries" | net10.0; all three binaries |
| `netstandard21-compatibility.md` intro | "compiles fine locally (net8.0 only)" | net10.0 only, plus the multi-TFM pre-merge build |

The other `net8.0` mentions in `netstandard21-compatibility.md` refer to SDK target frameworks and are correct. Docs only; no code, no `.al`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
