### PR TITLE
docs: record LC0096 issue #323 edge case as by-design

### DIFF
--- a/.claude/rules/diagnostics/lc0096-unnecessary-record-parameter.md
+++ b/.claude/rules/diagnostics/lc0096-unnecessary-record-parameter.md
@@ -31,6 +31,7 @@ Detects redundant record parameters passed to methods where the same record vari
 | Rec matching: `IsSynthesized` + `SemanticFacts.IsSameName` | Matches only the compiler-generated Rec variable (not user-declared globals). Name check discriminates Rec from xRec (both synthesized). |
 | Implicit `with`: not affected | Implicit with only adds `Rec.` as a scope prefix for field/method lookup. It does NOT inject `Rec` as a method argument. `MyProcedure(Rec)` requires explicit mention of `Rec` regardless of implicit with. |
 | Category: Usage | Incorrect/discouraged use of AL constructs |
+| Local procedure called with both `Rec` and other record instances: still flagged (issue #323) | By design — original rule author confirmed. Resolution is a parameterless overload that assigns `Rec` to a local variable and delegates (the delegating argument is a local variable, not the synthesized `Rec`, so it doesn't re-trigger). Documented on the alcops.dev LC0096 page. |
 | netstandard2.1: full support | No net8.0-only APIs used |
 
 ## Architecture


### PR DESCRIPTION
Adds a design-decision row to the LC0096 rule doc recording the outcome of #323: a local table procedure called with both `Rec` and other record instances is still flagged, by design (confirmed by the original rule author). The resolution is a parameterless overload that assigns `Rec` to a local variable and delegates — documented on the alcops.dev LC0096 page (ALCops/alcops.dev#163).

No analyzer code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)