### PR TITLE
feat: add LC0100 - Global variable could be local

### DIFF
--- a/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
+++ b/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
@@ -35,7 +35,7 @@ Reports global variables in normal codeunits whose references are confined to on
 - Registers a compilation action and visits each declared application object independently.
 - Collects source global variables, resolves every identifier through the semantic model, and groups eligible variables by their single containing method or trigger.
 - Binds one operation tree per method and evaluates all candidates together with a flow-sensitive `OperationWalker`.
-- Reports at the global declaration and includes the variable and method names in the diagnostic message.
+- Reports at the global declaration and includes the AL type, variable name, and method name in the diagnostic message. Labels use wording that does not imply runtime reinitialization.
 
 ## Known issues
 

--- a/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
+++ b/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
@@ -35,7 +35,7 @@ Reports global variables in normal codeunits whose references are confined to on
 - Registers a compilation action and visits each declared application object independently.
 - Collects source global variables, resolves every identifier through the semantic model, and groups eligible variables by their single containing method or trigger.
 - Binds one operation tree per method and evaluates all candidates together with a flow-sensitive `OperationWalker`.
-- Reports at the global declaration and includes the AL type, variable name, and method name in the diagnostic message. Labels use wording that does not imply runtime reinitialization.
+- Reports at the global declaration and includes the variable name, AL type, and method name in the diagnostic message. Labels use wording that does not imply runtime reinitialization.
 
 ## Known issues
 

--- a/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
+++ b/.claude/rules/diagnostics/lc0100-global-variable-could-be-local.md
@@ -1,0 +1,46 @@
+---
+paths:
+  - "src/ALCops.LinterCop/**/GlobalVariableCouldBeLocal*"
+---
+
+# LC0100: GlobalVariableCouldBeLocal
+
+## Purpose
+
+Reports global variables in normal codeunits whose references are confined to one procedure or trigger when every read is independent of state retained by an earlier invocation. Moving those variables into the only scope that consumes them makes their lifetime and ownership explicit.
+
+**Reference:** [Discussion #499](https://github.com/ALCops/Analyzers/discussions/499)
+
+## Design decisions
+
+| Decision | Rationale |
+|---|---|
+| Opt-in `Info` diagnostic | The analysis is intentionally advisory and moving a variable still deserves behavioral review. Existing projects should not gain a new warning by default. |
+| One self-contained compilation action | Discovering declarations, references, and control flow in the same callback avoids assumptions about callback ordering and remains stable under incremental compilation. |
+| Require every reference to bind to the same global and one procedure or trigger | Textual name matches are insufficient because AL is case-insensitive and locals can shadow globals. Cross-scope use proves object-level ownership. |
+| Analyze only value-semantic scalar types, labels, and normal non-temporary records | Arrays, `TextConst`, temporary records, and handle-like types can retain or share state that the current flow model cannot prove safe to localize. Conservative exclusion trades recall for no unsafe recommendation. |
+| Analyze normal codeunit objects only | Tables, pages, reports, XMLports, queries, extension objects, and non-normal codeunit subtypes have framework-driven triggers, handlers, or lifecycle state that can affect globals without an identifier reference. Test codeunit handlers are a concrete callback example. Object-specific models can expand the scope later. |
+| Three-state initialization lattice: unknown, record fields initialized, fully initialized | `Record.Get(...)` and whole-record assignment replace field values but do not establish every part of record context. Normal fields can be read after either operation; FlowFields, FlowFilters, whole-record uses, and other receiver calls require stronger guarantees. |
+| Treat non-`Get` record receiver calls as unsafe | Record methods can read or mutate filters, keys, company, marks, temporary data, or trigger-visible state. Modeling each built-in across SDK versions would create a fragile allowlist. |
+| Track `Get`-based field initialization together with whole-record assignment | A whole-record assignment in another path can persist record context into a later invocation whose `Get` only refreshes fields. Monotone method-wide flags suppress that cross-invocation combination. |
+| Reject reads before definite initialization on every reachable path | Branches merge to the weakest reachable initialization. Optional loops include a zero-iteration path; repeat loops include multiple iterations. Flow-terminating `Error` and `exit` paths do not continue into the merge. |
+| Invalidate initialization after every non-modeled invocation | Any invoked AL or built-in operation can synchronously execute extensible code and reenter the same codeunit instance. `Clear`, `ClearAll`, modeled `Record.Get`, and terminating `Error` are handled explicitly; all other calls require a fresh initialization before a later read. |
+| Reject `var` arguments, partial writes, prior-value assignments, and stateful execution models | Each can expose or depend on object state even when the source references appear inside one method. Non-normal subtypes, `SingleInstance`, and manual event-subscriber codeunits are skipped as a whole. Recursive calls are handled by the same invocation invalidation as other calls. |
+| Skip objects with an event publisher that has `IncludeSender := true`, or an integration event with `GlobalVarAccess := true` | Integration, business, and internal event subscribers can retain the sender instance; integration-event subscribers can additionally receive global access without an identifier reference in the publisher source. Moving a global could silently break that API surface. |
+| Treat `ClearAll()` as unsafe | `ClearAll` targets object/global state rather than an equivalent set of future locals, so localization can change which value a later read observes. |
+| No CodeFix | Relocating a declaration can affect attributes, dimensions, comments, and state semantics. The diagnostic provides a review target rather than applying a structural edit automatically. |
+
+## Architecture
+
+- Registers a compilation action and visits each declared application object independently.
+- Collects source global variables, resolves every identifier through the semantic model, and groups eligible variables by their single containing method or trigger.
+- Binds one operation tree per method and evaluates all candidates together with a flow-sensitive `OperationWalker`.
+- Reports at the global declaration and includes the variable and method names in the diagnostic message.
+
+## Known issues
+
+- The analysis deliberately produces false negatives for unsupported stateful types and record-method patterns rather than risking a state-changing recommendation.
+- Every non-modeled invocation invalidates the current initialization proof. This intentionally suppresses suggestions across calls whose purity or callback behavior cannot be proven.
+- Loop handling is bounded and conservative. `break`, `continue`, and `AssertError` suppress a recommendation when their control flow cannot be represented safely.
+- `Record.Get(...)` is recognized only in the explicitly modeled statement and direct-condition forms with at least one key argument.
+- `Error(...)` is considered flow-terminating only when its first argument has a known non-`ErrorInfo` type; collectible errors remain reachable.

--- a/src/ALCops.Common/Reflection/EnumProvider.cs
+++ b/src/ALCops.Common/Reflection/EnumProvider.cs
@@ -211,12 +211,15 @@ public static class EnumProvider
     {
         private static readonly Lazy<NavCodeAnalysis.CodeunitSubtypeKind> _install =
             new(() => ParseEnum<NavCodeAnalysis.CodeunitSubtypeKind>(nameof(NavCodeAnalysis.CodeunitSubtypeKind.Install)));
+        private static readonly Lazy<NavCodeAnalysis.CodeunitSubtypeKind> _normal =
+            new(() => ParseEnum<NavCodeAnalysis.CodeunitSubtypeKind>(nameof(NavCodeAnalysis.CodeunitSubtypeKind.Normal)));
         private static readonly Lazy<NavCodeAnalysis.CodeunitSubtypeKind> _test =
             new(() => ParseEnum<NavCodeAnalysis.CodeunitSubtypeKind>(nameof(NavCodeAnalysis.CodeunitSubtypeKind.Test)));
         private static readonly Lazy<NavCodeAnalysis.CodeunitSubtypeKind> _upgrade =
             new(() => ParseEnum<NavCodeAnalysis.CodeunitSubtypeKind>(nameof(NavCodeAnalysis.CodeunitSubtypeKind.Upgrade)));
 
         public static NavCodeAnalysis.CodeunitSubtypeKind Install => _install.Value;
+        public static NavCodeAnalysis.CodeunitSubtypeKind Normal => _normal.Value;
         public static NavCodeAnalysis.CodeunitSubtypeKind Test => _test.Value;
         public static NavCodeAnalysis.CodeunitSubtypeKind Upgrade => _upgrade.Value;
     }
@@ -263,6 +266,17 @@ public static class EnumProvider
         public static NavCodeAnalysis.DirectionKind Import => _import.Value;
         public static NavCodeAnalysis.DirectionKind Export => _export.Value;
         public static NavCodeAnalysis.DirectionKind Both => _both.Value;
+    }
+
+    /// <summary>
+    /// EventSubscriberInstanceKind enum values
+    /// </summary>
+    public static class EventSubscriberInstanceKind
+    {
+        private static readonly Lazy<NavCodeAnalysis.EventSubscriberInstanceKind> _manual =
+            new(() => ParseEnum<NavCodeAnalysis.EventSubscriberInstanceKind>(nameof(NavCodeAnalysis.EventSubscriberInstanceKind.Manual)));
+
+        public static NavCodeAnalysis.EventSubscriberInstanceKind Manual => _manual.Value;
     }
     /// <summary>
     /// Feature enum values
@@ -340,6 +354,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Blob)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _boolean =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Boolean)));
+        private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _byte =
+            new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Byte)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _char =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Char)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _code =
@@ -354,6 +370,12 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.DotNet)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _dataTransfer =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.DataTransfer)));
+        private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _date =
+            new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Date)));
+        private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _dateFormula =
+            new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.DateFormula)));
+        private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _dateTime =
+            new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.DateTime)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _duration =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Duration)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _enum =
@@ -416,6 +438,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.TableFilter)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _text =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Text)));
+        private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _time =
+            new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Time)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _variant =
             new(() => ParseEnum<NavCodeAnalysis.NavTypeKind>(nameof(NavCodeAnalysis.NavTypeKind.Variant)));
         private static readonly Lazy<NavCodeAnalysis.NavTypeKind> _xmlPort =
@@ -425,6 +449,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.NavTypeKind BigInteger => _bigInteger.Value;
         public static NavCodeAnalysis.NavTypeKind Blob => _blob.Value;
         public static NavCodeAnalysis.NavTypeKind Boolean => _boolean.Value;
+        public static NavCodeAnalysis.NavTypeKind Byte => _byte.Value;
         public static NavCodeAnalysis.NavTypeKind Char => _char.Value;
         public static NavCodeAnalysis.NavTypeKind Code => _code.Value;
         public static NavCodeAnalysis.NavTypeKind Codeunit => _codeunit.Value;
@@ -432,6 +457,9 @@ public static class EnumProvider
         public static NavCodeAnalysis.NavTypeKind Decimal => _decimal.Value;
         public static NavCodeAnalysis.NavTypeKind DotNet => _dotNet.Value;
         public static NavCodeAnalysis.NavTypeKind DataTransfer => _dataTransfer.Value;
+        public static NavCodeAnalysis.NavTypeKind Date => _date.Value;
+        public static NavCodeAnalysis.NavTypeKind DateFormula => _dateFormula.Value;
+        public static NavCodeAnalysis.NavTypeKind DateTime => _dateTime.Value;
         public static NavCodeAnalysis.NavTypeKind Duration => _duration.Value;
         public static NavCodeAnalysis.NavTypeKind Enum => _enum.Value;
         public static NavCodeAnalysis.NavTypeKind ErrorInfo => _errorInfo.Value;
@@ -463,6 +491,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.NavTypeKind TableExtension => _tableExtension.Value;
         public static NavCodeAnalysis.NavTypeKind TableFilter => _tableFilter.Value;
         public static NavCodeAnalysis.NavTypeKind Text => _text.Value;
+        public static NavCodeAnalysis.NavTypeKind Time => _time.Value;
         public static NavCodeAnalysis.NavTypeKind Variant => _variant.Value;
         public static NavCodeAnalysis.NavTypeKind XmlPort => _xmlPort.Value;
     }
@@ -489,6 +518,9 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.OperationKind>(nameof(NavCodeAnalysis.OperationKind.BinaryOperatorExpression)));
         private static readonly Lazy<NavCodeAnalysis.OperationKind> _compoundAssignmentStatement =
             new(() => ParseEnum<NavCodeAnalysis.OperationKind>("CompoundAssignmentStatement"));
+        // ContinueStatement was introduced after the oldest supported AL SDK.
+        private static readonly Lazy<NavCodeAnalysis.OperationKind?> _continueStatement =
+            new(() => Enum.TryParse<NavCodeAnalysis.OperationKind>("ContinueStatement", out var value) ? value : null);
         private static readonly Lazy<NavCodeAnalysis.OperationKind> _conversionExpression =
             new(() => ParseEnum<NavCodeAnalysis.OperationKind>(nameof(NavCodeAnalysis.OperationKind.ConversionExpression)));
         private static readonly Lazy<NavCodeAnalysis.OperationKind> _emptyStatement =
@@ -519,6 +551,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.OperationKind AssignmentStatement => _assignmentStatement.Value;
         public static NavCodeAnalysis.OperationKind BinaryOperatorExpression => _binaryOperatorExpression.Value;
         public static NavCodeAnalysis.OperationKind CompoundAssignmentStatement => _compoundAssignmentStatement.Value;
+        public static NavCodeAnalysis.OperationKind? ContinueStatement => _continueStatement.Value;
         public static NavCodeAnalysis.OperationKind ConversionExpression => _conversionExpression.Value;
         public static NavCodeAnalysis.OperationKind EmptyStatement => _emptyStatement.Value;
         public static NavCodeAnalysis.OperationKind ExitStatement => _exitStatement.Value;
@@ -628,6 +661,8 @@ public static class EnumProvider
             new(() => ParseEnum<NavCodeAnalysis.PropertyKind>(nameof(NavCodeAnalysis.PropertyKind.Editable)));
         private static readonly Lazy<NavCodeAnalysis.PropertyKind> _enabled =
             new(() => ParseEnum<NavCodeAnalysis.PropertyKind>(nameof(NavCodeAnalysis.PropertyKind.Enabled)));
+        private static readonly Lazy<NavCodeAnalysis.PropertyKind> _eventSubscriberInstance =
+            new(() => ParseEnum<NavCodeAnalysis.PropertyKind>(nameof(NavCodeAnalysis.PropertyKind.EventSubscriberInstance)));
         private static readonly Lazy<NavCodeAnalysis.PropertyKind> _extensible =
             new(() => ParseEnum<NavCodeAnalysis.PropertyKind>(nameof(NavCodeAnalysis.PropertyKind.Extensible)));
         private static readonly Lazy<NavCodeAnalysis.PropertyKind> _inherentPermissions =
@@ -686,6 +721,7 @@ public static class EnumProvider
         public static NavCodeAnalysis.PropertyKind DrillDownPageId => _drillDownPageId.Value;
         public static NavCodeAnalysis.PropertyKind Editable => _editable.Value;
         public static NavCodeAnalysis.PropertyKind Enabled => _enabled.Value;
+        public static NavCodeAnalysis.PropertyKind EventSubscriberInstance => _eventSubscriberInstance.Value;
         public static NavCodeAnalysis.PropertyKind Extensible => _extensible.Value;
         public static NavCodeAnalysis.PropertyKind InherentPermissions => _inherentPermissions.Value;
         public static NavCodeAnalysis.PropertyKind LookupPageId => _lookupPageId.Value;
@@ -781,6 +817,20 @@ public static class EnumProvider
         public static NavCodeAnalysis.TableTypeKind CDS => _cds.Value;
         public static NavCodeAnalysis.TableTypeKind Normal => _normal.Value;
         public static NavCodeAnalysis.TableTypeKind Temporary => _temporary.Value;
+    }
+
+    /// <summary>
+    /// UnaryOperationKind enum values
+    /// </summary>
+    public static class UnaryOperationKind
+    {
+        private static readonly Lazy<NavCodeAnalysis.UnaryOperationKind> _booleanLogicalNot =
+            new(() => ParseEnum<NavCodeAnalysis.UnaryOperationKind>(nameof(NavCodeAnalysis.UnaryOperationKind.BooleanLogicalNot)));
+        private static readonly Lazy<NavCodeAnalysis.UnaryOperationKind> _operatorMethodLogicalNot =
+            new(() => ParseEnum<NavCodeAnalysis.UnaryOperationKind>(nameof(NavCodeAnalysis.UnaryOperationKind.OperatorMethodLogicalNot)));
+
+        public static NavCodeAnalysis.UnaryOperationKind BooleanLogicalNot => _booleanLogicalNot.Value;
+        public static NavCodeAnalysis.UnaryOperationKind OperatorMethodLogicalNot => _operatorMethodLogicalNot.Value;
     }
     /// <summary>
     /// XmlPortSourceTypeKind enum values

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
@@ -1,5 +1,6 @@
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 using RoslynTestKit;
 
 namespace ALCops.LinterCop.Test;
@@ -26,6 +27,7 @@ public class GlobalVariableCouldBeLocal : NavCodeAnalysisBase
 
     [Test]
     [TestCase("Case01UnconditionalOverwrite")]
+    [TestCase("BooleanVariable")]
     [TestCase("Case02AllBranchesInitialize")]
     [TestCase("Case03RecordGetBeforeFieldRead")]
     [TestCase("Case04ClearBeforeConditionalRecordGet")]
@@ -138,17 +140,64 @@ public class GlobalVariableCouldBeLocal : NavCodeAnalysisBase
     }
 
     [Test]
-    public void DiagnosticMessageIncludesVariableAndScopeNames()
+    [TestCase(
+        "BooleanVariable",
+        "Global 'Boolean' variable 'MyTestVariable' is only used in 'MyTestProcedure' and appears to be reinitialized before every read. Consider moving it to local scope.")]
+    [TestCase(
+        "Case05ImmutableLabel",
+        "Global 'Label' variable 'MyProcedureOnlyLabel' is only used in 'ShowCustomerName'. Consider moving it to local scope.")]
+    [TestCase(
+        "Case03RecordGetBeforeFieldRead",
+        "Global 'Record Customer' variable 'MyCustomerFromGet' is only used in 'ShowCustomerFromOriginalPost' and appears to be reinitialized before every read. Consider moving it to local scope.")]
+    public async Task DiagnosticMessageIncludesTypeAndUsesStateAppropriateWording(
+        string testCase,
+        string expectedMessage)
     {
-        var diagnostic = Diagnostic.Create(
-            DiagnosticDescriptors.GlobalVariableCouldBeLocal,
-            Location.None,
-            "MyGlobalVariable",
-            "MyDummyProcedure");
+        var code = await File.ReadAllTextAsync(
+                Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = new DiagnosticMessageFixture(
+            Path.Combine(_testCasePath, $"{nameof(GlobalVariableCouldBeLocal)}.ruleset.json"));
 
         Assert.That(
-            diagnostic.GetMessage(),
-            Is.EqualTo(
-                "Global variable 'MyGlobalVariable' is only used in 'MyDummyProcedure' and appears to be reinitialized before every read. Consider moving it to local scope."));
+            fixture.GetDiagnosticMessages(code, DiagnosticIds.GlobalVariableCouldBeLocal),
+            Is.EqualTo(new[] { expectedMessage }));
+    }
+
+    private sealed class DiagnosticMessageFixture(string ruleSetPath) : AnalyzerTestFixture
+    {
+        protected override string LanguageName => LanguageNames.AL;
+        protected override string? RuleSetPath => ruleSetPath;
+
+        protected override DiagnosticAnalyzer CreateAnalyzer() =>
+            new Analyzers.GlobalVariableCouldBeLocal();
+
+        public string[] GetDiagnosticMessages(string markupCode, string diagnosticId)
+        {
+            var markup = new CodeMarkup(markupCode);
+            var document = CreateDocumentFromCode(markup.Code);
+            var compilation = document.Project
+                .GetCompilationAsync(CancellationToken.None)
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+
+            if (compilation is null)
+            {
+                return [];
+            }
+
+            return compilation
+                .WithAnalyzers(
+                    ImmutableArray.Create(CreateAnalyzer()),
+                    cancellationToken: CancellationToken.None)
+                .GetAnalyzerDiagnosticsAsync()
+                .GetAwaiter()
+                .GetResult()
+                .Where(diagnostic => diagnostic.Id == diagnosticId)
+                .Select(diagnostic => diagnostic.GetMessage())
+                .ToArray();
+        }
     }
 }

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
@@ -45,6 +45,7 @@ public class GlobalVariableCouldBeLocal : NavCodeAnalysisBase
     [TestCase("UnrelatedRecursionDoesNotSuppress")]
     [TestCase("ConditionalRecordGetReadOnSuccess")]
     [TestCase("RecordAssignmentInitializesFields")]
+    [TestCase("RecordTypeNameRequiresQuotes")]
     [TestCase("ThisQualifiedInitialization")]
     [TestCase("RecursiveThenReinitialize")]
     public async Task HasDiagnostic(string testCase)
@@ -142,13 +143,16 @@ public class GlobalVariableCouldBeLocal : NavCodeAnalysisBase
     [Test]
     [TestCase(
         "BooleanVariable",
-        "Global 'Boolean' variable 'MyTestVariable' is only used in 'MyTestProcedure' and appears to be reinitialized before every read. Consider moving it to local scope.")]
+        "Global variable 'MyTestVariable' (Boolean) is only used in 'MyTestProcedure' and appears to be reinitialized before every read. Consider moving it to local scope.")]
     [TestCase(
         "Case05ImmutableLabel",
-        "Global 'Label' variable 'MyProcedureOnlyLabel' is only used in 'ShowCustomerName'. Consider moving it to local scope.")]
+        "Global variable 'MyProcedureOnlyLabel' (Label) is only used in 'ShowCustomerName'. Consider moving it to local scope.")]
     [TestCase(
         "Case03RecordGetBeforeFieldRead",
-        "Global 'Record Customer' variable 'MyCustomerFromGet' is only used in 'ShowCustomerFromOriginalPost' and appears to be reinitialized before every read. Consider moving it to local scope.")]
+        "Global variable 'MyCustomerFromGet' (Record Customer) is only used in 'ShowCustomerFromOriginalPost' and appears to be reinitialized before every read. Consider moving it to local scope.")]
+    [TestCase(
+        "RecordTypeNameRequiresQuotes",
+        "Global variable 'SalesHeader' (Record \"Sales Header\") is only used in 'JustATest' and appears to be reinitialized before every read. Consider moving it to local scope.")]
     public async Task DiagnosticMessageIncludesTypeAndUsesStateAppropriateWording(
         string testCase,
         string expectedMessage)

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.cs
@@ -1,0 +1,154 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
+using RoslynTestKit;
+
+namespace ALCops.LinterCop.Test;
+
+public class GlobalVariableCouldBeLocal : NavCodeAnalysisBase
+{
+    private AnalyzerTestFixture _fixture;
+    private string _testCasePath;
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCasePath = Path.Combine(
+            Directory.GetParent(
+                Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            Path.Combine("Rules", nameof(GlobalVariableCouldBeLocal)));
+
+        _fixture = RoslynFixtureFactory.Create<Analyzers.GlobalVariableCouldBeLocal>(
+            new AnalyzerTestFixtureConfig
+            {
+                RuleSetPath = Path.Combine(_testCasePath, $"{nameof(GlobalVariableCouldBeLocal)}.ruleset.json")
+            });
+    }
+
+    [Test]
+    [TestCase("Case01UnconditionalOverwrite")]
+    [TestCase("Case02AllBranchesInitialize")]
+    [TestCase("Case03RecordGetBeforeFieldRead")]
+    [TestCase("Case04ClearBeforeConditionalRecordGet")]
+    [TestCase("Case05ImmutableLabel")]
+    [TestCase("Case06GuardExitThenInitialize")]
+    [TestCase("ScalarClearBeforeRead")]
+    [TestCase("CaseEveryBranchInitializes")]
+    [TestCase("ErrorBranchDoesNotContinue")]
+    [TestCase("ConditionalReadInsideInitializedBranch")]
+    [TestCase("ClearThenCompoundAssignment")]
+    [TestCase("RecordGetFailureGuard")]
+    [TestCase("ByValueArgumentAfterAssignment")]
+    [TestCase("CodeunitOnRunTrigger")]
+    [TestCase("RepeatAssignsBeforeRead")]
+    [TestCase("UnrelatedRecursionDoesNotSuppress")]
+    [TestCase("ConditionalRecordGetReadOnSuccess")]
+    [TestCase("RecordAssignmentInitializesFields")]
+    [TestCase("ThisQualifiedInitialization")]
+    [TestCase("RecursiveThenReinitialize")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        SkipTestIfVersionIsTooLow(
+            ["ThisQualifiedInitialization"],
+            testCase,
+            "14.0",
+            "Explicit this-qualified global access requires AL runtime 14.0 or higher.");
+
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(HasDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.GlobalVariableCouldBeLocal);
+    }
+
+    [Test]
+    [TestCase("Case07CompoundAssignmentReadsPreviousState")]
+    [TestCase("Case08ConditionalInitialization")]
+    [TestCase("Case09PassedByReference")]
+    [TestCase("Case10RecursiveProcedure")]
+    [TestCase("UsedByMultipleProcedures")]
+    [TestCase("ReadBeforeAssignment")]
+    [TestCase("AssignmentReadsPreviousValue")]
+    [TestCase("InitializedButPassedByVar")]
+    [TestCase("RecordGetThenGetFilters")]
+    [TestCase("RecordGetThenGetView")]
+    [TestCase("RecordGetArgumentReadsPreviousField")]
+    [TestCase("RecordGetThenFlowFilter")]
+    [TestCase("RecordGetThenWholeRecordArgument")]
+    [TestCase("PartialRecordFieldAssignment")]
+    [TestCase("CaseWithoutElse")]
+    [TestCase("WhileMayNotExecuteBeforeRead")]
+    [TestCase("IndirectRecursion")]
+    [TestCase("SingleInstanceCodeunit")]
+    [TestCase("ManualEventSubscriberCodeunit")]
+    [TestCase("ProtectedPageVariable")]
+    [TestCase("PagePropertyReference")]
+    [TestCase("ShadowedLocalDoesNotReferenceGlobal")]
+    [TestCase("UnknownExternalCallMayReenter")]
+    [TestCase("LabelUsedInMultipleProcedures")]
+    [TestCase("NestedRecordGetResultIsObserved")]
+    [TestCase("RecordGetWithoutKeyReadsState")]
+    [TestCase("BreakMaySkipInitialization")]
+    [TestCase("TemporaryRecordStatePersists")]
+    [TestCase("ReferenceTypeStateMayEscape")]
+    [TestCase("RecordContextChangesAfterRead")]
+    [TestCase("RecordAssignmentCanAffectNextCall")]
+    [TestCase("ArrayElementStateIsNotModeled")]
+    [TestCase("IntegrationEventExposesGlobalVariables")]
+    [TestCase("ClearAllTargetsObjectState")]
+    [TestCase("CollectibleErrorDoesNotTerminateFlow")]
+    [TestCase("RenameTriggerMayReenter")]
+    [TestCase("TemporaryTableStatePersists")]
+    [TestCase("TableResetCanClearGlobals")]
+    [TestCase("TableExtensionObjectIsExcluded")]
+    [TestCase("PageObjectIsExcluded")]
+    [TestCase("TestCodeunitSubtypeIsExcluded")]
+    [TestCase("IntegrationEventIncludesSender")]
+    [TestCase("BusinessEventIncludesSender")]
+    [TestCase("InternalEventIncludesSender")]
+    [TestCase("BuiltInInvocationMayReenter")]
+    [TestCase("RecordAssignmentDoesNotInitializeWholeRecord")]
+    [TestCase("ThisQualifiedReadBeforeAssignment")]
+    [TestCase("AssignmentTargetTraversal")]
+    [TestCase("VarArgumentTraversal")]
+    [TestCase("ContinueMaySkipInitialization")]
+    [TestCase("AssignmentTargetBeforeValue")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        SkipTestIfVersionIsTooLow(
+            ["TableExtensionObjectIsExcluded"],
+            testCase,
+            "13.0",
+            "AL versions prior to 13.0 cannot extend a table declared in the same test module.");
+
+        SkipTestIfVersionIsTooLow(
+            ["ThisQualifiedReadBeforeAssignment"],
+            testCase,
+            "14.0",
+            "Explicit this-qualified global access requires AL runtime 14.0 or higher.");
+
+        SkipTestIfVersionIsTooLow(
+            ["ContinueMaySkipInitialization"],
+            testCase,
+            "15.0",
+            "The continue statement requires AL runtime 15.0 or higher.");
+
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCasePath, nameof(NoDiagnostic), $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        _fixture.NoDiagnosticAtAllMarkers(code, DiagnosticIds.GlobalVariableCouldBeLocal);
+    }
+
+    [Test]
+    public void DiagnosticMessageIncludesVariableAndScopeNames()
+    {
+        var diagnostic = Diagnostic.Create(
+            DiagnosticDescriptors.GlobalVariableCouldBeLocal,
+            Location.None,
+            "MyGlobalVariable",
+            "MyDummyProcedure");
+
+        Assert.That(
+            diagnostic.GetMessage(),
+            Is.EqualTo(
+                "Global variable 'MyGlobalVariable' is only used in 'MyDummyProcedure' and appears to be reinitialized before every read. Consider moving it to local scope."));
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.ruleset.json
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/GlobalVariableCouldBeLocal.ruleset.json
@@ -1,0 +1,10 @@
+{
+    "name": "Enable LC0100",
+    "description": "Enables the default-disabled LC0100 rule so it can be tested.",
+    "rules": [
+        {
+            "id": "LC0100",
+            "action": "Warning"
+        }
+    ]
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/BooleanVariable.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/BooleanVariable.al
@@ -1,0 +1,11 @@
+codeunit 50100 VariableScopeBoolean
+{
+    var
+        [|MyTestVariable|]: Boolean;
+
+    local procedure MyTestProcedure()
+    begin
+        MyTestVariable := true;
+        Message('%1', MyTestVariable);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ByValueArgumentAfterAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ByValueArgumentAfterAssignment.al
@@ -1,0 +1,16 @@
+codeunit 50100 ByValueArgumentAfterAssignment
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 10;
+        Consume(MyValue);
+    end;
+
+    local procedure Consume(Value: Integer)
+    begin
+        Message('%1', Value);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case01UnconditionalOverwrite.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case01UnconditionalOverwrite.al
@@ -1,0 +1,16 @@
+codeunit 50100 VariableScopeCase01
+{
+    var
+        [|MyGlobalVariable|]: Integer;
+
+    local procedure MyDummyProcedure()
+    begin
+        MyGlobalVariable := 1;
+        Message('%1', MyGlobalVariable);
+    end;
+
+    local procedure MyOtherDummyProcedure()
+    begin
+        Message('Hello World');
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case02AllBranchesInitialize.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case02AllBranchesInitialize.al
@@ -1,0 +1,15 @@
+codeunit 50100 VariableScopeCase02
+{
+    var
+        [|MyBranchValue|]: Integer;
+
+    local procedure ShowBranchValue(UseFirstValue: Boolean)
+    begin
+        if UseFirstValue then
+            MyBranchValue := 1
+        else
+            MyBranchValue := 2;
+
+        Message('%1', MyBranchValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case03RecordGetBeforeFieldRead.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case03RecordGetBeforeFieldRead.al
@@ -1,0 +1,25 @@
+codeunit 50100 VariableScopeCase03
+{
+    var
+        [|MyCustomerFromGet|]: Record Customer;
+
+    local procedure ShowCustomerFromOriginalPost()
+    begin
+        MyCustomerFromGet.Get('10000');
+        Message('%1', MyCustomerFromGet.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case04ClearBeforeConditionalRecordGet.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case04ClearBeforeConditionalRecordGet.al
@@ -1,0 +1,27 @@
+codeunit 50100 VariableScopeCase04
+{
+    var
+        [|MyClearedCustomer|]: Record Customer;
+
+    local procedure ShowCustomer(CustomerNo: Code[20])
+    begin
+        Clear(MyClearedCustomer);
+
+        if MyClearedCustomer.Get(CustomerNo) then
+            Message('%1', MyClearedCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case05ImmutableLabel.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case05ImmutableLabel.al
@@ -1,0 +1,10 @@
+codeunit 50100 VariableScopeCase05
+{
+    var
+        [|MyProcedureOnlyLabel|]: Label 'Customer: %1', Comment = '%1 = Customer name';
+
+    local procedure ShowCustomerName(CustomerName: Text)
+    begin
+        Message(MyProcedureOnlyLabel, CustomerName);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case06GuardExitThenInitialize.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/Case06GuardExitThenInitialize.al
@@ -1,0 +1,14 @@
+codeunit 50100 VariableScopeCase06
+{
+    var
+        [|MyGuardedValue|]: Integer;
+
+    local procedure ShowGuardedValue(ShouldContinue: Boolean)
+    begin
+        if not ShouldContinue then
+            exit;
+
+        MyGuardedValue := 42;
+        Message('%1', MyGuardedValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/CaseEveryBranchInitializes.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/CaseEveryBranchInitializes.al
@@ -1,0 +1,19 @@
+codeunit 50100 CaseEveryBranchInitializes
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(Selection: Integer)
+    begin
+        case Selection of
+            1:
+                MyValue := 10;
+            2:
+                MyValue := 20;
+            else
+                MyValue := 30;
+        end;
+
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ClearThenCompoundAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ClearThenCompoundAssignment.al
@@ -1,0 +1,12 @@
+codeunit 50100 ClearThenCompoundAssignment
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        Clear(MyValue);
+        MyValue += 1;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/CodeunitOnRunTrigger.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/CodeunitOnRunTrigger.al
@@ -1,0 +1,11 @@
+codeunit 50100 CodeunitOnRunTrigger
+{
+    trigger OnRun()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+
+    var
+        [|MyValue|]: Integer;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ConditionalReadInsideInitializedBranch.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ConditionalReadInsideInitializedBranch.al
@@ -1,0 +1,13 @@
+codeunit 50100 ConditionalReadBranch
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(ShouldShow: Boolean)
+    begin
+        if ShouldShow then begin
+            MyValue := 10;
+            Message('%1', MyValue);
+        end;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ConditionalRecordGetReadOnSuccess.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ConditionalRecordGetReadOnSuccess.al
@@ -1,0 +1,25 @@
+codeunit 50100 ConditionalRecordGet
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowCustomer(CustomerNo: Code[20])
+    begin
+        if MyCustomer.Get(CustomerNo) then
+            Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ErrorBranchDoesNotContinue.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ErrorBranchDoesNotContinue.al
@@ -1,0 +1,14 @@
+codeunit 50100 ErrorBranchDoesNotContinue
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(ShouldFail: Boolean)
+    begin
+        if ShouldFail then
+            Error('Stopped');
+
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordAssignmentInitializesFields.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordAssignmentInitializesFields.al
@@ -1,0 +1,25 @@
+codeunit 50100 RecordAssignmentFields
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowReplacement(Replacement: Record Customer)
+    begin
+        MyCustomer := Replacement;
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordGetFailureGuard.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordGetFailureGuard.al
@@ -1,0 +1,27 @@
+codeunit 50100 RecordGetFailureGuard
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowCustomer(CustomerNo: Code[20])
+    begin
+        if not MyCustomer.Get(CustomerNo) then
+            Error('Customer not found');
+
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordTypeNameRequiresQuotes.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecordTypeNameRequiresQuotes.al
@@ -1,0 +1,24 @@
+codeunit 50100 RecordTypeNameRequiresQuotes
+{
+    var
+        [|SalesHeader|]: Record "Sales Header";
+
+    local procedure JustATest()
+    begin
+        SalesHeader.Get('10000');
+        Message('%1', SalesHeader."No.");
+    end;
+}
+
+table 50101 "Sales Header"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecursiveThenReinitialize.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RecursiveThenReinitialize.al
@@ -1,0 +1,14 @@
+codeunit 50100 RecursiveThenReinitialize
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(Number: Integer)
+    begin
+        if Number > 0 then
+            ShowValue(Number - 1);
+
+        MyValue := Number;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RepeatAssignsBeforeRead.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/RepeatAssignsBeforeRead.al
@@ -1,0 +1,16 @@
+codeunit 50100 RepeatAssignsBeforeRead
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValues(Maximum: Integer)
+    var
+        Index: Integer;
+    begin
+        repeat
+            MyValue := Index;
+            Message('%1', MyValue);
+            Index += 1;
+        until Index > Maximum;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ScalarClearBeforeRead.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ScalarClearBeforeRead.al
@@ -1,0 +1,11 @@
+codeunit 50100 ScalarClearBeforeRead
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        Clear(MyValue);
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ThisQualifiedInitialization.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/ThisQualifiedInitialization.al
@@ -1,0 +1,11 @@
+codeunit 50100 ThisQualifiedInitialization
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        this.MyValue := 42;
+        Message('%1', this.MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/UnrelatedRecursionDoesNotSuppress.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/HasDiagnostic/UnrelatedRecursionDoesNotSuppress.al
@@ -1,0 +1,17 @@
+codeunit 50100 UnrelatedRecursion
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+
+    local procedure UnrelatedRecursiveProcedure(Number: Integer)
+    begin
+        if Number > 0 then
+            UnrelatedRecursiveProcedure(Number - 1);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ArrayElementStateIsNotModeled.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ArrayElementStateIsNotModeled.al
@@ -1,0 +1,12 @@
+codeunit 50100 ArrayElementStateNotModeled
+{
+    var
+        [|MyNumbers|]: array[2] of Integer;
+
+    local procedure RebuildNumbers()
+    begin
+        Clear(MyNumbers);
+        MyNumbers[1] := 1;
+        Message('%1', MyNumbers[1]);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentReadsPreviousValue.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentReadsPreviousValue.al
@@ -1,0 +1,11 @@
+codeunit 50100 AssignmentReadsPreviousValue
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure IncrementValue()
+    begin
+        MyValue := MyValue + 1;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentTargetBeforeValue.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentTargetBeforeValue.al
@@ -1,0 +1,22 @@
+codeunit 50100 AssignmentTargetBeforeValue
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure StoreValue()
+    var
+        Values: array[10] of Integer;
+        Worker: Codeunit IndexWorker;
+    begin
+        MyValue := 42;
+        Values[Worker.GetIndex()] := MyValue;
+    end;
+}
+
+codeunit 50101 IndexWorker
+{
+    procedure GetIndex(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentTargetTraversal.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/AssignmentTargetTraversal.al
@@ -1,0 +1,25 @@
+codeunit 50100 AssignmentTargetTraversal
+{
+    var
+        [|MyValue|]: Integer;
+        MyIndex: Integer;
+
+    local procedure ShowValue()
+    var
+        Values: array[10] of Integer;
+        Worker: Codeunit IndexWorker;
+    begin
+        MyValue := 42;
+        MyIndex := 1;
+        Values[Worker.GetIndex(MyIndex)] := 0;
+        Message('%1', MyValue);
+    end;
+}
+
+codeunit 50101 IndexWorker
+{
+    procedure GetIndex(Value: Integer): Integer
+    begin
+        exit(Value);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BreakMaySkipInitialization.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BreakMaySkipInitialization.al
@@ -1,0 +1,17 @@
+codeunit 50100 BreakMaySkipInitialization
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(StopImmediately: Boolean)
+    begin
+        repeat
+            if StopImmediately then
+                break;
+
+            MyValue := 10;
+        until true;
+
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BuiltInInvocationMayReenter.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BuiltInInvocationMayReenter.al
@@ -1,0 +1,42 @@
+codeunit 50100 BuiltInInvocationMayReenter
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    var
+        CallbackQuery: Query CallbackQuery;
+    begin
+        MyValue := 42;
+        CallbackQuery.Open();
+        Message('%1', MyValue);
+    end;
+}
+
+query 50101 CallbackQuery
+{
+    elements
+    {
+        dataitem(Customer; Customer)
+        {
+            column(Id; Id) { }
+        }
+    }
+
+    trigger OnBeforeOpen()
+    begin
+    end;
+}
+
+table 50102 Customer
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BusinessEventIncludesSender.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/BusinessEventIncludesSender.al
@@ -1,0 +1,16 @@
+codeunit 50100 BusinessEventIncludesSender
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure DoWork()
+    begin
+        MyValue := 42;
+        Message('%1', MyValue);
+    end;
+
+    [BusinessEvent(true)]
+    local procedure OnSomethingHappened()
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case07CompoundAssignmentReadsPreviousState.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case07CompoundAssignmentReadsPreviousState.al
@@ -1,0 +1,11 @@
+codeunit 50100 VariableScopeCase07
+{
+    var
+        [|MyCounter|]: Integer;
+
+    local procedure ShowNextNumber()
+    begin
+        MyCounter += 1;
+        Message('%1', MyCounter);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case08ConditionalInitialization.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case08ConditionalInitialization.al
@@ -1,0 +1,13 @@
+codeunit 50100 VariableScopeCase08
+{
+    var
+        [|MyConditionalValue|]: Integer;
+
+    local procedure ShowConditionalValue(InitializeValue: Boolean)
+    begin
+        if InitializeValue then
+            MyConditionalValue := 42;
+
+        Message('%1', MyConditionalValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case09PassedByReference.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case09PassedByReference.al
@@ -1,0 +1,19 @@
+codeunit 50100 VariableScopeCase09
+{
+    var
+        [|MyByReferenceValue|]: Integer;
+
+    local procedure ShowValueChangedByReference()
+    begin
+        UpdateValue(MyByReferenceValue);
+        Message('%1', MyByReferenceValue);
+    end;
+
+    local procedure UpdateValue(var Value: Integer)
+    begin
+        if Value = 0 then
+            Value := 42
+        else
+            Value += 1;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case10RecursiveProcedure.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/Case10RecursiveProcedure.al
@@ -1,0 +1,15 @@
+codeunit 50100 VariableScopeCase10
+{
+    var
+        [|MyRecursiveValue|]: Integer;
+
+    local procedure RecursiveProcedure(Number: Integer): Integer
+    begin
+        MyRecursiveValue := Number;
+
+        if Number > 1 then
+            RecursiveProcedure(Number - 1);
+
+        exit(MyRecursiveValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/CaseWithoutElse.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/CaseWithoutElse.al
@@ -1,0 +1,17 @@
+codeunit 50100 CaseWithoutElse
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(Selection: Integer)
+    begin
+        case Selection of
+            1:
+                MyValue := 10;
+            2:
+                MyValue := 20;
+        end;
+
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ClearAllTargetsObjectState.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ClearAllTargetsObjectState.al
@@ -1,0 +1,12 @@
+codeunit 50100 ClearAllTargetsObjectState
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ResetValue()
+    begin
+        MyValue := 42;
+        ClearAll();
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/CollectibleErrorDoesNotTerminateFlow.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/CollectibleErrorDoesNotTerminateFlow.al
@@ -1,0 +1,17 @@
+codeunit 50100 CollectibleErrorContinues
+{
+    var
+        [|MyValue|]: Integer;
+
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    local procedure ShowValue(ShouldFail: Boolean)
+    begin
+        if ShouldFail then
+            Error(ErrorInfo.Create('Collected error', true))
+        else
+            MyValue := 42;
+
+        Message('%1', MyValue);
+        ClearCollectedErrors();
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ContinueMaySkipInitialization.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ContinueMaySkipInitialization.al
@@ -1,0 +1,17 @@
+codeunit 50100 ContinueSkipsInitialization
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(Skip: Boolean)
+    begin
+        repeat
+            if Skip then
+                continue;
+
+            MyValue := 42;
+        until true;
+
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IndirectRecursion.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IndirectRecursion.al
@@ -1,0 +1,20 @@
+codeunit 50100 IndirectRecursion
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure RecursiveProcedure(Number: Integer): Integer
+    begin
+        MyValue := Number;
+
+        if Number > 1 then
+            Reenter(Number - 1);
+
+        exit(MyValue);
+    end;
+
+    local procedure Reenter(Number: Integer)
+    begin
+        RecursiveProcedure(Number);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/InitializedButPassedByVar.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/InitializedButPassedByVar.al
@@ -1,0 +1,17 @@
+codeunit 50100 InitializedButPassedByVar
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 10;
+        ChangeValue(MyValue);
+        Message('%1', MyValue);
+    end;
+
+    local procedure ChangeValue(var Value: Integer)
+    begin
+        Value += 1;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IntegrationEventExposesGlobalVariables.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IntegrationEventExposesGlobalVariables.al
@@ -1,0 +1,17 @@
+codeunit 50100 IntegrationEventExposesGlobals
+{
+    var
+        [|MyPublishedValue|]: Integer;
+
+    local procedure DoWork()
+    begin
+        MyPublishedValue := 1;
+        Message('%1', MyPublishedValue);
+        OnAfterDoWork();
+    end;
+
+    [IntegrationEvent(false, true)]
+    local procedure OnAfterDoWork()
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IntegrationEventIncludesSender.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/IntegrationEventIncludesSender.al
@@ -1,0 +1,16 @@
+codeunit 50100 IntegrationEventIncludesSender
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure DoWork()
+    begin
+        MyValue := 42;
+        Message('%1', MyValue);
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnSomethingHappened()
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/InternalEventIncludesSender.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/InternalEventIncludesSender.al
@@ -1,0 +1,16 @@
+codeunit 50100 InternalEventIncludesSender
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure DoWork()
+    begin
+        MyValue := 42;
+        Message('%1', MyValue);
+    end;
+
+    [InternalEvent(true)]
+    local procedure OnSomethingHappened()
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/LabelUsedInMultipleProcedures.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/LabelUsedInMultipleProcedures.al
@@ -1,0 +1,15 @@
+codeunit 50100 LabelUsedInMultipleProcedures
+{
+    var
+        [|MyLabel|]: Label 'Hello';
+
+    local procedure ShowFirst()
+    begin
+        Message(MyLabel);
+    end;
+
+    local procedure ShowSecond()
+    begin
+        Message(MyLabel);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ManualEventSubscriberCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ManualEventSubscriberCodeunit.al
@@ -1,0 +1,13 @@
+codeunit 50100 ManualEventSubscriberCodeunit
+{
+    EventSubscriberInstance = Manual;
+
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/NestedRecordGetResultIsObserved.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/NestedRecordGetResultIsObserved.al
@@ -1,0 +1,25 @@
+codeunit 50100 NestedRecordGetResult
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowCustomer(CustomerNo: Code[20])
+    begin
+        Message('%1', MyCustomer.Get(CustomerNo));
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PageObjectIsExcluded.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PageObjectIsExcluded.al
@@ -1,0 +1,39 @@
+page 50100 PageObjectIsExcluded
+{
+    PageType = Card;
+    ApplicationArea = All;
+    SourceTable = Customer;
+
+    layout
+    {
+        area(Content)
+        {
+            field(Id; Rec.Id)
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 42;
+        Message('%1', MyValue);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PagePropertyReference.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PagePropertyReference.al
@@ -1,0 +1,24 @@
+page 50100 PagePropertyReference
+{
+    PageType = Card;
+
+    layout
+    {
+        area(Content)
+        {
+            field(ValueControl; MyValue)
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+
+    var
+        [|MyValue|]: Integer;
+
+    trigger OnOpenPage()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PartialRecordFieldAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/PartialRecordFieldAssignment.al
@@ -1,0 +1,20 @@
+codeunit 50100 PartialRecordFieldAssignment
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowCustomer()
+    begin
+        MyCustomer.Name := 'New name';
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ProtectedPageVariable.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ProtectedPageVariable.al
@@ -1,0 +1,13 @@
+page 50100 ProtectedPageVariable
+{
+    PageType = Card;
+
+    protected var
+        [|MyValue|]: Integer;
+
+    trigger OnOpenPage()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ReadBeforeAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ReadBeforeAssignment.al
@@ -1,0 +1,11 @@
+codeunit 50100 ReadBeforeAssignment
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        Message('%1', MyValue);
+        MyValue := 10;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordAssignmentCanAffectNextCall.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordAssignmentCanAffectNextCall.al
@@ -1,0 +1,28 @@
+codeunit 50100 RecordAssignmentNextCall
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowOrReplaceCustomer(ShowCurrent: Boolean; Replacement: Record Customer)
+    begin
+        if ShowCurrent then begin
+            MyCustomer.Get('10000');
+            Message('%1', MyCustomer.Name);
+        end else
+            MyCustomer := Replacement;
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordAssignmentDoesNotInitializeWholeRecord.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordAssignmentDoesNotInitializeWholeRecord.al
@@ -1,0 +1,25 @@
+codeunit 50100 RecordAssignmentWholeRecord
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowReplacement(Replacement: Record Customer)
+    begin
+        MyCustomer := Replacement;
+        Message('%1', Format(MyCustomer));
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordContextChangesAfterRead.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordContextChangesAfterRead.al
@@ -1,0 +1,27 @@
+codeunit 50100 RecordContextChangesAfterRead
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowCustomer()
+    begin
+        MyCustomer.Get('10000');
+        Message('%1', MyCustomer.Name);
+        Clear(MyCustomer);
+        MyCustomer.ChangeCompany('CRONUS');
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetArgumentReadsPreviousField.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetArgumentReadsPreviousField.al
@@ -1,0 +1,25 @@
+codeunit 50100 RecordGetReadsOldField
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ReloadCustomer()
+    begin
+        MyCustomer.Get(MyCustomer."No.");
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenFlowFilter.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenFlowFilter.al
@@ -1,0 +1,25 @@
+codeunit 50100 RecordGetThenFlowFilter
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowDateFilter()
+    begin
+        MyCustomer.Get('10000');
+        Message('%1', MyCustomer."Date Filter");
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Date Filter"; Date) { FieldClass = FlowFilter; }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenGetFilters.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenGetFilters.al
@@ -1,0 +1,24 @@
+codeunit 50100 RecordGetThenGetFilters
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowFilters()
+    begin
+        MyCustomer.Get('10000');
+        Message('%1', MyCustomer.GetFilters());
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenGetView.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenGetView.al
@@ -1,0 +1,24 @@
+codeunit 50100 RecordGetThenGetView
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ShowView()
+    begin
+        MyCustomer.Get('10000');
+        Message('%1', MyCustomer.GetView());
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenWholeRecordArgument.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetThenWholeRecordArgument.al
@@ -1,0 +1,30 @@
+codeunit 50100 RecordGetWholeRecordArg
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ConsumeCustomer()
+    begin
+        MyCustomer.Get('10000');
+        Consume(MyCustomer);
+    end;
+
+    local procedure Consume(CustomerValue: Record Customer)
+    begin
+        Message('%1', CustomerValue.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetWithoutKeyReadsState.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RecordGetWithoutKeyReadsState.al
@@ -1,0 +1,25 @@
+codeunit 50100 RecordGetWithoutKey
+{
+    var
+        [|MyCustomer|]: Record Customer;
+
+    local procedure ReloadCustomer()
+    begin
+        MyCustomer.Get();
+        Message('%1', MyCustomer.Name);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ReferenceTypeStateMayEscape.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ReferenceTypeStateMayEscape.al
@@ -1,0 +1,12 @@
+codeunit 50100 ReferenceTypeStateMayEscape
+{
+    var
+        [|MyValues|]: List of [Integer];
+
+    local procedure RebuildValues()
+    begin
+        Clear(MyValues);
+        MyValues.Add(1);
+        Message('%1', MyValues.Count());
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RenameTriggerMayReenter.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/RenameTriggerMayReenter.al
@@ -1,0 +1,27 @@
+codeunit 50100 RenameTriggerMayReenter
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure RenameCustomer(Value: Integer; NewId: Integer)
+    var
+        Customer: Record Customer;
+    begin
+        MyValue := Value;
+        Customer.Rename(NewId);
+        Message('%1', MyValue);
+    end;
+}
+
+table 50101 Customer
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ShadowedLocalDoesNotReferenceGlobal.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ShadowedLocalDoesNotReferenceGlobal.al
@@ -1,0 +1,13 @@
+codeunit 50100 ShadowedLocal
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    var
+        MyValue: Integer;
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/SingleInstanceCodeunit.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/SingleInstanceCodeunit.al
@@ -1,0 +1,13 @@
+codeunit 50100 SingleInstanceCodeunit
+{
+    SingleInstance = true;
+
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        MyValue := 10;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TableExtensionObjectIsExcluded.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TableExtensionObjectIsExcluded.al
@@ -1,0 +1,25 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+tableextension 50100 MyTableExtension extends MyTable
+{
+    var
+        [|MyValue|]: Integer;
+
+    procedure ResetTableState()
+    begin
+        MyValue := 42;
+        Rec.Reset();
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TableResetCanClearGlobals.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TableResetCanClearGlobals.al
@@ -1,0 +1,22 @@
+table 50100 TableResetCanClearGlobals
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    var
+        [|MyValue|]: Integer;
+
+    procedure ResetTableState()
+    begin
+        MyValue := 42;
+        Rec.Reset();
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TemporaryRecordStatePersists.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TemporaryRecordStatePersists.al
@@ -1,0 +1,24 @@
+codeunit 50100 TemporaryRecordStatePersists
+{
+    var
+        [|MyBuffer|]: Record Buffer temporary;
+
+    local procedure ShowEntryCount()
+    begin
+        Clear(MyBuffer);
+        Message('%1', MyBuffer.Count());
+    end;
+}
+
+table 50101 Buffer
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TemporaryTableStatePersists.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TemporaryTableStatePersists.al
@@ -1,0 +1,26 @@
+codeunit 50100 TemporaryTableStatePersists
+{
+    var
+        [|MyBuffer|]: Record Buffer;
+
+    local procedure ShowEntryCount()
+    begin
+        Clear(MyBuffer);
+        Message('%1', MyBuffer.Count());
+    end;
+}
+
+table 50101 Buffer
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TestCodeunitSubtypeIsExcluded.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/TestCodeunitSubtypeIsExcluded.al
@@ -1,0 +1,14 @@
+codeunit 50100 TestCodeunitSubtypeIsExcluded
+{
+    Subtype = Test;
+
+    var
+        [|MyValue|]: Integer;
+
+    [Test]
+    procedure ShowValue()
+    begin
+        MyValue := 42;
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ThisQualifiedReadBeforeAssignment.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/ThisQualifiedReadBeforeAssignment.al
@@ -1,0 +1,11 @@
+codeunit 50100 ThisQualifiedPriorRead
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    begin
+        Message('%1', this.MyValue);
+        this.MyValue := 42;
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/UnknownExternalCallMayReenter.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/UnknownExternalCallMayReenter.al
@@ -1,0 +1,21 @@
+codeunit 50100 UnknownExternalCallMayReenter
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue()
+    var
+        Worker: Codeunit ExternalWorker;
+    begin
+        MyValue := 10;
+        Worker.DoWork();
+        Message('%1', MyValue);
+    end;
+}
+
+codeunit 50101 ExternalWorker
+{
+    procedure DoWork()
+    begin
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/UsedByMultipleProcedures.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/UsedByMultipleProcedures.al
@@ -1,0 +1,15 @@
+codeunit 50100 UsedByMultipleProcedures
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure SetValue()
+    begin
+        MyValue := 10;
+    end;
+
+    local procedure ShowValue()
+    begin
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/VarArgumentTraversal.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/VarArgumentTraversal.al
@@ -1,0 +1,25 @@
+codeunit 50100 VarArgumentTraversal
+{
+    var
+        [|MyValue|]: Integer;
+        MyIndex: Integer;
+
+    local procedure ShowValue()
+    var
+        Values: array[10] of Integer;
+        Worker: Codeunit IndexWorker;
+    begin
+        MyValue := 42;
+        MyIndex := 1;
+        Evaluate(Values[Worker.GetIndex(MyIndex)], '0');
+        Message('%1', MyValue);
+    end;
+}
+
+codeunit 50101 IndexWorker
+{
+    procedure GetIndex(Value: Integer): Integer
+    begin
+        exit(Value);
+    end;
+}

--- a/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/WhileMayNotExecuteBeforeRead.al
+++ b/src/ALCops.LinterCop.Test/Rules/GlobalVariableCouldBeLocal/NoDiagnostic/WhileMayNotExecuteBeforeRead.al
@@ -1,0 +1,15 @@
+codeunit 50100 WhileMayNotExecuteBeforeRead
+{
+    var
+        [|MyValue|]: Integer;
+
+    local procedure ShowValue(ShouldRun: Boolean)
+    begin
+        while ShouldRun do begin
+            MyValue := 10;
+            ShouldRun := false;
+        end;
+
+        Message('%1', MyValue);
+    end;
+}

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -423,6 +423,15 @@
   <data name="EventSubscriberParameterNotReferencedCodeAction" xml:space="preserve">
     <value>ALCops: Remove unreferenced event subscriber parameter</value>
   </data>
+  <data name="GlobalVariableCouldBeLocalTitle" xml:space="preserve">
+    <value>Global variable could be local</value>
+  </data>
+  <data name="GlobalVariableCouldBeLocalMessageFormat" xml:space="preserve">
+    <value>Global variable '{0}' is only used in '{1}' and appears to be reinitialized before every read. Consider moving it to local scope.</value>
+  </data>
+  <data name="GlobalVariableCouldBeLocalDescription" xml:space="preserve">
+    <value>Reports high-confidence cases in normal codeunits where all references to a global variable are contained in one procedure or trigger and prior object state cannot influence a read. The suggested move still requires behavioral review, especially for stateful objects and reentrant execution.</value>
+  </data>
   <data name="MixedExitAndNamedReturnAssignmentTitle" xml:space="preserve">
     <value>Avoid mixing exit() and named return variable assignments</value>
   </data>

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -427,7 +427,7 @@
     <value>Global variable could be local</value>
   </data>
   <data name="GlobalVariableCouldBeLocalMessageFormat" xml:space="preserve">
-    <value>Global '{0}' variable '{1}' is only used in '{2}'{3} Consider moving it to local scope.</value>
+    <value>Global variable '{0}' ({1}) is only used in '{2}'{3} Consider moving it to local scope.</value>
   </data>
   <data name="GlobalVariableCouldBeLocalMutableStateClause" xml:space="preserve">
     <value> and appears to be reinitialized before every read.</value>

--- a/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
+++ b/src/ALCops.LinterCop/ALCops.LinterCopAnalyzers.resx
@@ -427,7 +427,13 @@
     <value>Global variable could be local</value>
   </data>
   <data name="GlobalVariableCouldBeLocalMessageFormat" xml:space="preserve">
-    <value>Global variable '{0}' is only used in '{1}' and appears to be reinitialized before every read. Consider moving it to local scope.</value>
+    <value>Global '{0}' variable '{1}' is only used in '{2}'{3} Consider moving it to local scope.</value>
+  </data>
+  <data name="GlobalVariableCouldBeLocalMutableStateClause" xml:space="preserve">
+    <value> and appears to be reinitialized before every read.</value>
+  </data>
+  <data name="GlobalVariableCouldBeLocalLabelStateClause" xml:space="preserve">
+    <value>.</value>
   </data>
   <data name="GlobalVariableCouldBeLocalDescription" xml:space="preserve">
     <value>Reports high-confidence cases in normal codeunits where all references to a global variable are contained in one procedure or trigger and prior object state cannot influence a read. The suggested move still requires behavioral review, especially for stateful objects and reentrant execution.</value>

--- a/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
@@ -340,12 +340,33 @@ public sealed class GlobalVariableCouldBeLocal : DiagnosticAnalyzer
     private static void Report(
         CompilationAnalysisContext context,
         IVariableSymbol variable,
-        IMethodSymbol method) =>
+        IMethodSymbol method)
+    {
+        var stateClause = IsLabel(variable)
+            ? LinterCopAnalyzers.GlobalVariableCouldBeLocalLabelStateClause
+            : LinterCopAnalyzers.GlobalVariableCouldBeLocalMutableStateClause;
+
         context.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.GlobalVariableCouldBeLocal,
             variable.GetLocation(),
+            GetTypeDisplay(variable.Type),
             variable.Name,
-            method.Name));
+            method.Name,
+            stateClause));
+    }
+
+    private static string GetTypeDisplay(ITypeSymbol type)
+    {
+        var typeKind = type.GetNavTypeKindSafe();
+
+        if (typeKind == EnumProvider.NavTypeKind.Record &&
+            type is IRecordTypeSymbol { OriginalDefinition: ITableTypeSymbol tableType })
+        {
+            return $"{typeKind} {tableType.Name.QuoteIdentifierIfNeededWithReflection()}";
+        }
+
+        return typeKind.ToString();
+    }
 
     private static bool IsSameVariable(ISymbol? symbol, IVariableSymbol candidate)
     {

--- a/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
@@ -349,8 +349,8 @@ public sealed class GlobalVariableCouldBeLocal : DiagnosticAnalyzer
         context.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.GlobalVariableCouldBeLocal,
             variable.GetLocation(),
-            GetTypeDisplay(variable.Type),
             variable.Name,
+            GetTypeDisplay(variable.Type),
             method.Name,
             stateClause));
     }

--- a/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
+++ b/src/ALCops.LinterCop/Analyzers/GlobalVariableCouldBeLocal.cs
@@ -1,0 +1,1036 @@
+using System.Collections.Immutable;
+using ALCops.Common.Extensions;
+using ALCops.Common.Reflection;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
+
+namespace ALCops.LinterCop.Analyzers;
+
+[DiagnosticAnalyzer]
+public sealed class GlobalVariableCouldBeLocal : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.GlobalVariableCouldBeLocal);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterCompilationAction(AnalyzeCompilation);
+
+    private static void AnalyzeCompilation(CompilationAnalysisContext context)
+    {
+        foreach (var applicationObject in context.Compilation.GetDeclaredApplicationObjectSymbols())
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            AnalyzeApplicationObject(context, applicationObject);
+        }
+    }
+
+    private static void AnalyzeApplicationObject(
+        CompilationAnalysisContext context,
+        IApplicationObjectTypeSymbol applicationObject)
+    {
+        if (applicationObject.IsObsolete())
+        {
+            return;
+        }
+
+        if (applicationObject is not ICodeunitTypeSymbol)
+        {
+            return;
+        }
+
+        if (HasUnsupportedExecutionModel(applicationObject))
+        {
+            return;
+        }
+
+        if (ExposesObjectStateThroughEventPublisher(applicationObject))
+        {
+            return;
+        }
+
+        var candidates = applicationObject.GetMembers()
+            .OfType<IVariableSymbol>()
+            .Where(IsCandidate)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return;
+        }
+
+        var objectSyntax = GetApplicationObjectSyntax(applicationObject, candidates, context.CancellationToken);
+        if (objectSyntax is null)
+        {
+            return;
+        }
+
+        var semanticModel = context.Compilation.GetSemanticModel(objectSyntax.SyntaxTree);
+        var usages = CollectUsages(objectSyntax, semanticModel, candidates, context.CancellationToken);
+        var groups = new Dictionary<int, MethodGroup>();
+
+        foreach (var candidate in candidates)
+        {
+            if (!usages.TryGetValue(candidate.Name, out var usage) ||
+                usage.IsInvalid ||
+                usage.Scope is null ||
+                usage.HasMultipleScopes)
+            {
+                continue;
+            }
+
+            if (semanticModel.GetDeclaredSymbol(usage.Scope, context.CancellationToken) is not IMethodSymbol method ||
+                method.IsObsolete())
+            {
+                continue;
+            }
+
+            if (!groups.TryGetValue(method.Id, out var group))
+            {
+                group = new MethodGroup(method, usage.Scope);
+                groups.Add(method.Id, group);
+            }
+
+            group.Candidates.Add(candidate);
+        }
+
+        foreach (var group in groups.Values)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var labels = group.Candidates
+                .Where(IsLabel)
+                .ToArray();
+
+            foreach (var label in labels)
+            {
+                Report(context, label, group.Method);
+            }
+
+            var mutableCandidates = group.Candidates
+                .Where(candidate => !IsLabel(candidate))
+                .ToArray();
+
+            if (mutableCandidates.Length == 0 || group.Declaration.Body is null)
+            {
+                continue;
+            }
+
+            var operation = semanticModel.GetOperation(group.Declaration.Body, context.CancellationToken);
+            if (operation is null || operation.IsInvalid)
+            {
+                continue;
+            }
+
+            var walker = new DefiniteInitializationWalker(mutableCandidates, context.CancellationToken);
+            walker.Visit(operation);
+
+            foreach (var candidate in mutableCandidates)
+            {
+                if (walker.IsSafe(candidate))
+                {
+                    Report(context, candidate, group.Method);
+                }
+            }
+        }
+    }
+
+    private static bool IsCandidate(IVariableSymbol variable) =>
+        variable.Kind == EnumProvider.SymbolKind.GlobalVariable &&
+        !variable.IsSynthesized &&
+        !variable.IsObsolete() &&
+        variable.DeclaredAccessibility != EnumProvider.Accessibility.Protected &&
+        variable.DeclaringSyntaxReference is not null &&
+        HasSupportedValueSemantics(variable.Type);
+
+    private static bool HasSupportedValueSemantics(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol or ITextConstTypeSymbol)
+        {
+            return false;
+        }
+
+        if (type is IRecordTypeSymbol recordType)
+        {
+            return !recordType.IsTemporary() &&
+                recordType.OriginalDefinition is ITableTypeSymbol tableType &&
+                tableType.TableType == EnumProvider.TableTypeKind.Normal;
+        }
+
+        var typeKind = type.GetNavTypeKindSafe();
+        return typeKind == EnumProvider.NavTypeKind.BigInteger ||
+            typeKind == EnumProvider.NavTypeKind.Boolean ||
+            typeKind == EnumProvider.NavTypeKind.Byte ||
+            typeKind == EnumProvider.NavTypeKind.Char ||
+            typeKind == EnumProvider.NavTypeKind.Code ||
+            typeKind == EnumProvider.NavTypeKind.Date ||
+            typeKind == EnumProvider.NavTypeKind.DateFormula ||
+            typeKind == EnumProvider.NavTypeKind.DateTime ||
+            typeKind == EnumProvider.NavTypeKind.Decimal ||
+            typeKind == EnumProvider.NavTypeKind.Duration ||
+            typeKind == EnumProvider.NavTypeKind.Enum ||
+            typeKind == EnumProvider.NavTypeKind.Guid ||
+            typeKind == EnumProvider.NavTypeKind.Integer ||
+            typeKind == EnumProvider.NavTypeKind.Label ||
+            typeKind == EnumProvider.NavTypeKind.Option ||
+            typeKind == EnumProvider.NavTypeKind.RecordId ||
+            typeKind == EnumProvider.NavTypeKind.Text ||
+            typeKind == EnumProvider.NavTypeKind.Time;
+    }
+
+    private static bool IsLabel(IVariableSymbol variable) =>
+        variable.Type.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Label;
+
+    private static bool ExposesObjectStateThroughEventPublisher(
+        IApplicationObjectTypeSymbol applicationObject) =>
+        applicationObject.GetMembers()
+            .OfType<IMethodSymbol>()
+            .SelectMany(method => method.Attributes)
+            .Any(attribute =>
+                ((attribute.AttributeKind == EnumProvider.AttributeKind.IntegrationEvent ||
+                  attribute.AttributeKind == EnumProvider.AttributeKind.BusinessEvent ||
+                  attribute.AttributeKind == EnumProvider.AttributeKind.InternalEvent) &&
+                 attribute.Arguments.Length > 0 &&
+                 bool.TryParse(attribute.Arguments[0].ValueText, out var includeSender) &&
+                 includeSender) ||
+                (attribute.AttributeKind == EnumProvider.AttributeKind.IntegrationEvent &&
+                 attribute.Arguments.Length > 1 &&
+                 bool.TryParse(attribute.Arguments[1].ValueText, out var globalVarAccess) &&
+                 globalVarAccess));
+
+    private static ApplicationObjectSyntax? GetApplicationObjectSyntax(
+        IApplicationObjectTypeSymbol applicationObject,
+        IVariableSymbol[] candidates,
+        CancellationToken cancellationToken)
+    {
+        if (applicationObject.DeclaringSyntaxReference?.GetSyntax(cancellationToken) is ApplicationObjectSyntax objectSyntax)
+        {
+            return objectSyntax;
+        }
+
+        var syntax = candidates[0].DeclaringSyntaxReference?.GetSyntax(cancellationToken);
+        while (syntax is not null)
+        {
+            if (syntax is ApplicationObjectSyntax containingObject)
+            {
+                return containingObject;
+            }
+
+            syntax = syntax.Parent;
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, VariableUsage> CollectUsages(
+        ApplicationObjectSyntax objectSyntax,
+        SemanticModel semanticModel,
+        IEnumerable<IVariableSymbol> candidates,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, VariableUsage>(SemanticFacts.NameEqualityComparer);
+
+        foreach (var candidate in candidates)
+        {
+            result[candidate.Name] = new VariableUsage(candidate);
+        }
+
+        foreach (var identifier in objectSyntax.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var name = identifier.Identifier.ValueText;
+            if (name is null || !result.TryGetValue(name, out var usage) || IsInsideVariableDeclaration(identifier))
+            {
+                continue;
+            }
+
+            var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
+            if (symbol is null)
+            {
+                usage.IsInvalid = true;
+                continue;
+            }
+
+            if (!IsSameVariable(symbol, usage.Variable))
+            {
+                continue;
+            }
+
+            var scope = GetContainingMethodOrTrigger(identifier);
+            if (scope is null)
+            {
+                usage.IsInvalid = true;
+                continue;
+            }
+
+            if (usage.Scope is null)
+            {
+                usage.Scope = scope;
+            }
+            else if (usage.Scope.SpanStart != scope.SpanStart)
+            {
+                usage.HasMultipleScopes = true;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsInsideVariableDeclaration(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is VariableDeclarationSyntax)
+            {
+                return true;
+            }
+
+            if (current is MethodOrTriggerDeclarationSyntax || current is ApplicationObjectSyntax)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static MethodOrTriggerDeclarationSyntax? GetContainingMethodOrTrigger(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is MethodOrTriggerDeclarationSyntax methodOrTrigger)
+            {
+                return methodOrTrigger;
+            }
+
+            if (current is ApplicationObjectSyntax)
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasUnsupportedExecutionModel(IApplicationObjectTypeSymbol applicationObject)
+    {
+        if (applicationObject is not ICodeunitTypeSymbol codeunit)
+        {
+            return false;
+        }
+
+        if (codeunit.Subtype != EnumProvider.CodeunitSubtypeKind.Normal)
+        {
+            return true;
+        }
+
+        if (codeunit.GetBooleanPropertyValue(EnumProvider.PropertyKind.SingleInstance) is true)
+        {
+            return true;
+        }
+
+        return codeunit.GetEnumPropertyValue<EventSubscriberInstanceKind>(
+            EnumProvider.PropertyKind.EventSubscriberInstance) == EnumProvider.EventSubscriberInstanceKind.Manual;
+    }
+
+    private static void Report(
+        CompilationAnalysisContext context,
+        IVariableSymbol variable,
+        IMethodSymbol method) =>
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.GlobalVariableCouldBeLocal,
+            variable.GetLocation(),
+            variable.Name,
+            method.Name));
+
+    private static bool IsSameVariable(ISymbol? symbol, IVariableSymbol candidate)
+    {
+        if (symbol is not IVariableSymbol variable)
+        {
+            return false;
+        }
+
+        return variable.Equals(candidate) || variable.OriginalDefinition.Equals(candidate.OriginalDefinition);
+    }
+
+    private sealed class VariableUsage(IVariableSymbol variable)
+    {
+        public IVariableSymbol Variable { get; } = variable;
+        public MethodOrTriggerDeclarationSyntax? Scope { get; set; }
+        public bool HasMultipleScopes { get; set; }
+        public bool IsInvalid { get; set; }
+    }
+
+    private sealed class MethodGroup(IMethodSymbol method, MethodOrTriggerDeclarationSyntax declaration)
+    {
+        public IMethodSymbol Method { get; } = method;
+        public MethodOrTriggerDeclarationSyntax Declaration { get; } = declaration;
+        public List<IVariableSymbol> Candidates { get; } = [];
+    }
+
+    private enum InitializationKind
+    {
+        Unknown,
+        RecordFieldsInitialized,
+        FullyInitialized
+    }
+
+    private sealed class CandidateState
+    {
+        public InitializationKind Initialization { get; set; }
+        public bool IsReachable { get; set; } = true;
+        public bool IsUnsafe { get; set; }
+        public bool ReliesOnGetFieldInitialization { get; set; }
+        public bool HasPersistentRecordStateMutation { get; set; }
+
+        public CandidateState Clone() => new()
+        {
+            Initialization = Initialization,
+            IsReachable = IsReachable,
+            IsUnsafe = IsUnsafe,
+            ReliesOnGetFieldInitialization = ReliesOnGetFieldInitialization,
+            HasPersistentRecordStateMutation = HasPersistentRecordStateMutation
+        };
+    }
+
+    private sealed class DefiniteInitializationWalker : OperationWalker
+    {
+        private readonly Dictionary<string, IVariableSymbol> _candidates;
+        private readonly CancellationToken _cancellationToken;
+        private Dictionary<string, CandidateState> _states;
+        private bool _standaloneInvocation;
+
+        public DefiniteInitializationWalker(
+            IEnumerable<IVariableSymbol> candidates,
+            CancellationToken cancellationToken)
+        {
+            _cancellationToken = cancellationToken;
+            _candidates = new Dictionary<string, IVariableSymbol>(SemanticFacts.NameEqualityComparer);
+            _states = new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+
+            foreach (var candidate in candidates)
+            {
+                _candidates.Add(candidate.Name, candidate);
+                _states.Add(candidate.Name, new CandidateState());
+            }
+        }
+
+        public bool IsSafe(IVariableSymbol candidate) =>
+            _states.TryGetValue(candidate.Name, out var state) &&
+            !state.IsUnsafe &&
+            !(state.ReliesOnGetFieldInitialization && state.HasPersistentRecordStateMutation);
+
+        public override void Visit(IOperation operation)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (EnumProvider.OperationKind.ContinueStatement is { } continueStatement &&
+                operation.Kind == continueStatement)
+            {
+                MarkAllCandidatesUnsafe();
+                return;
+            }
+
+            if (operation is IGlobalReferenceExpression globalReference &&
+                TryGetCandidate(globalReference.GlobalVariable, out var candidate, out var state))
+            {
+                Require(state, InitializationKind.FullyInitialized);
+                return;
+            }
+
+            base.Visit(operation);
+        }
+
+        public override void VisitExpressionStatement(IExpressionStatement operation)
+        {
+            if (operation.Expression is IInvocationExpression invocation)
+            {
+                var previous = _standaloneInvocation;
+                _standaloneInvocation = true;
+                VisitInvocationExpression(invocation);
+                _standaloneInvocation = previous;
+                return;
+            }
+
+            Visit(operation.Expression);
+        }
+
+        public override void VisitAssignmentStatement(IAssignmentStatement operation)
+        {
+            if (TryGetDirectCandidate(operation.Target, out var candidate, out var state))
+            {
+                Visit(operation.Value);
+
+                if (state.IsReachable)
+                {
+                    var isRecord = candidate.Type.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Record;
+                    if (isRecord)
+                    {
+                        state.HasPersistentRecordStateMutation = true;
+                    }
+
+                    state.Initialization = isRecord
+                        ? InitializationKind.RecordFieldsInitialized
+                        : InitializationKind.FullyInitialized;
+                }
+
+                return;
+            }
+
+            if (ContainsCandidate(operation.Target))
+            {
+                MarkReferencedCandidatesUnsafe(operation.Target);
+            }
+
+            Visit(operation.Target);
+            Visit(operation.Value);
+        }
+
+        public override void VisitCompoundAssignmentStatement(ICompoundAssignmentStatement operation)
+        {
+            if (TryGetDirectCandidate(operation.Target, out var candidate, out var state))
+            {
+                Require(state, InitializationKind.FullyInitialized);
+                Visit(operation.Value);
+                return;
+            }
+
+            if (ContainsCandidate(operation.Target))
+            {
+                MarkReferencedCandidatesUnsafe(operation.Target);
+                Visit(operation.Target);
+                Visit(operation.Value);
+                return;
+            }
+
+            Visit(operation.Target);
+            Visit(operation.Value);
+        }
+
+        public override void VisitFieldAccess(IFieldAccess operation)
+        {
+            if (TryGetDirectCandidate(operation.Instance, out var candidate, out var state))
+            {
+                var requiredState = operation.FieldSymbol.FieldClass == EnumProvider.FieldClassKind.Normal
+                    ? InitializationKind.RecordFieldsInitialized
+                    : InitializationKind.FullyInitialized;
+                Require(state, requiredState);
+                return;
+            }
+
+            base.VisitFieldAccess(operation);
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            var resultIsDiscarded = _standaloneInvocation;
+            _standaloneInvocation = false;
+
+            try
+            {
+                if (TryHandleClear(operation) ||
+                    TryHandleClearAll(operation) ||
+                    TryHandleRecordGet(operation, resultIsDiscarded))
+                {
+                    return;
+                }
+
+                if (TryGetDirectCandidate(operation.Instance, out var receiver, out var receiverState))
+                {
+                    if (receiver.Type.GetNavTypeKindSafe() == EnumProvider.NavTypeKind.Record)
+                    {
+                        receiverState.HasPersistentRecordStateMutation = true;
+                        receiverState.IsUnsafe = true;
+                    }
+
+                    Require(receiverState, InitializationKind.FullyInitialized);
+                }
+                else if (operation.Instance is not null)
+                {
+                    Visit(operation.Instance);
+                }
+
+                foreach (var argument in operation.Arguments)
+                {
+                    if (argument.Parameter?.IsVar == true && ContainsCandidate(argument.Value))
+                    {
+                        MarkReferencedCandidatesUnsafe(argument.Value);
+                    }
+
+                    Visit(argument.Value);
+                }
+
+                if (IsFlowTerminatingCall(operation))
+                {
+                    foreach (var state in _states.Values)
+                    {
+                        state.IsReachable = false;
+                    }
+
+                    return;
+                }
+
+                InvalidateInitializedStateForPotentialReentrancy();
+            }
+            finally
+            {
+                _standaloneInvocation = resultIsDiscarded;
+            }
+        }
+
+        public override void VisitIfStatement(IIfStatement operation)
+        {
+            if (TryVisitConditionalRecordGet(operation.Condition, out var getCandidate, out var successOnTrueBranch))
+            {
+                var beforeGetBranches = CloneStates();
+                var trueSeed = CloneStateDictionary(beforeGetBranches);
+                var falseSeed = CloneStateDictionary(beforeGetBranches);
+                var successSeed = successOnTrueBranch ? trueSeed : falseSeed;
+                var successState = successSeed[getCandidate.Name];
+
+                if (successState.IsReachable && !successState.IsUnsafe &&
+                    successState.Initialization < InitializationKind.RecordFieldsInitialized)
+                {
+                    successState.ReliesOnGetFieldInitialization = true;
+                    successState.Initialization = InitializationKind.RecordFieldsInitialized;
+                }
+
+                RestoreStates(trueSeed);
+                Visit(operation.IfTrueStatement);
+                var getTrueStates = CloneStates();
+
+                RestoreStates(falseSeed);
+                if (operation.IfFalseStatement is not null)
+                {
+                    Visit(operation.IfFalseStatement);
+                }
+                var getFalseStates = CloneStates();
+
+                _states = MergeStates(getTrueStates, getFalseStates);
+                return;
+            }
+
+            Visit(operation.Condition);
+            var beforeBranches = CloneStates();
+
+            RestoreStates(beforeBranches);
+            Visit(operation.IfTrueStatement);
+            var trueStates = CloneStates();
+
+            RestoreStates(beforeBranches);
+            if (operation.IfFalseStatement is not null)
+            {
+                Visit(operation.IfFalseStatement);
+            }
+            var falseStates = CloneStates();
+
+            _states = MergeStates(trueStates, falseStates);
+        }
+
+        public override void VisitCaseStatement(ICaseStatement operation)
+        {
+            Visit(operation.Value);
+            var beforeBranches = CloneStates();
+            var branches = new List<Dictionary<string, CandidateState>>();
+
+            foreach (var caseLine in operation.CaseLines)
+            {
+                RestoreStates(beforeBranches);
+                foreach (var expression in caseLine.Expressions)
+                {
+                    Visit(expression);
+                }
+                Visit(caseLine.Statement);
+                branches.Add(CloneStates());
+            }
+
+            RestoreStates(beforeBranches);
+            if (operation.ElseStatement is not null)
+            {
+                Visit(operation.ElseStatement);
+            }
+            branches.Add(CloneStates());
+
+            _states = MergeStates(branches);
+        }
+
+        public override void VisitWhileRepeatLoopStatement(IWhileRepeatLoopStatement operation)
+        {
+            if (operation.LoopKind == EnumProvider.LoopKind.Repeat)
+            {
+                Visit(operation.Body);
+                Visit(operation.Condition);
+                var afterFirstRepeatIteration = CloneStates();
+
+                RestoreStates(afterFirstRepeatIteration);
+                Visit(operation.Body);
+                Visit(operation.Condition);
+                var afterSecondRepeatIteration = CloneStates();
+
+                _states = MergeStates(afterFirstRepeatIteration, afterSecondRepeatIteration);
+                return;
+            }
+
+            Visit(operation.Condition);
+            var zeroIterations = CloneStates();
+
+            RestoreStates(zeroIterations);
+            Visit(operation.Body);
+            Visit(operation.Condition);
+            var afterFirstIteration = CloneStates();
+
+            RestoreStates(afterFirstIteration);
+            Visit(operation.Body);
+            Visit(operation.Condition);
+            var afterSecondIteration = CloneStates();
+
+            _states = MergeStates([zeroIterations, afterFirstIteration, afterSecondIteration]);
+        }
+
+        public override void VisitForLoopStatement(IForLoopStatement operation)
+        {
+            Visit(operation.LoopVariable);
+            Visit(operation.InitialValue);
+            Visit(operation.EndValue);
+            VisitOptionalLoopBodyTwice(operation.Body);
+        }
+
+        public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
+        {
+            Visit(operation.IterationVariable);
+            Visit(operation.Expression);
+            VisitOptionalLoopBodyTwice(operation.Body);
+        }
+
+        public override void VisitExitStatement(IExitStatement operation)
+        {
+            if (operation.ReturnedValue is not null)
+            {
+                Visit(operation.ReturnedValue);
+            }
+
+            foreach (var state in _states.Values)
+            {
+                state.IsReachable = false;
+            }
+        }
+
+        public override void VisitAssertErrorStatement(IAssertErrorStatement operation)
+        {
+            foreach (var state in _states.Values)
+            {
+                state.IsUnsafe = true;
+            }
+        }
+
+        public override void VisitBreakStatement(IBreakStatement operation)
+        {
+            MarkAllCandidatesUnsafe();
+        }
+
+        private void VisitOptionalLoopBodyTwice(IOperation body)
+        {
+            var zeroIterations = CloneStates();
+
+            RestoreStates(zeroIterations);
+            Visit(body);
+            var afterFirstIteration = CloneStates();
+
+            RestoreStates(afterFirstIteration);
+            Visit(body);
+            var afterSecondIteration = CloneStates();
+
+            _states = MergeStates([zeroIterations, afterFirstIteration, afterSecondIteration]);
+        }
+
+        private bool TryHandleClear(IInvocationExpression operation)
+        {
+            if (operation.TargetMethod?.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+                !SemanticFacts.IsSameName(operation.TargetMethod.Name, "Clear") ||
+                operation.Arguments.Length != 1 ||
+                !TryGetDirectCandidate(operation.Arguments[0].Value, out var candidate, out var state))
+            {
+                return false;
+            }
+
+            if (state.IsReachable)
+            {
+                state.Initialization = InitializationKind.FullyInitialized;
+            }
+
+            return true;
+        }
+
+        private bool TryHandleClearAll(IInvocationExpression operation)
+        {
+            if (operation.TargetMethod?.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+                !SemanticFacts.IsSameName(operation.TargetMethod.Name, "ClearAll"))
+            {
+                return false;
+            }
+
+            MarkAllCandidatesUnsafe();
+            return true;
+        }
+
+        private bool TryHandleRecordGet(IInvocationExpression operation, bool resultIsDiscarded)
+        {
+            if (!resultIsDiscarded ||
+                operation.TargetMethod?.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+                !SemanticFacts.IsSameName(operation.TargetMethod.Name, "Get") ||
+                operation.Arguments.Length == 0 ||
+                !TryGetDirectCandidate(operation.Instance, out var candidate, out var state) ||
+                candidate.Type.GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Record)
+            {
+                return false;
+            }
+
+            foreach (var argument in operation.Arguments)
+            {
+                Visit(argument.Value);
+            }
+
+            if (state.IsReachable && !state.IsUnsafe &&
+                state.Initialization < InitializationKind.RecordFieldsInitialized)
+            {
+                state.ReliesOnGetFieldInitialization = true;
+                state.Initialization = InitializationKind.RecordFieldsInitialized;
+            }
+
+            return true;
+        }
+
+        private bool TryVisitConditionalRecordGet(
+            IOperation condition,
+            out IVariableSymbol candidate,
+            out bool successOnTrueBranch)
+        {
+            candidate = null!;
+            successOnTrueBranch = true;
+            condition = condition.UnwrapConversions();
+
+            if (condition is IUnaryOperatorExpression unary &&
+                (unary.UnaryOperationKind == EnumProvider.UnaryOperationKind.BooleanLogicalNot ||
+                 unary.UnaryOperationKind == EnumProvider.UnaryOperationKind.OperatorMethodLogicalNot))
+            {
+                successOnTrueBranch = false;
+                condition = unary.Operand.UnwrapConversions();
+            }
+
+            if (condition is not IInvocationExpression invocation ||
+                invocation.TargetMethod?.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+                !SemanticFacts.IsSameName(invocation.TargetMethod.Name, "Get") ||
+                invocation.Arguments.Length == 0 ||
+                !TryGetDirectCandidate(invocation.Instance, out candidate, out var state) ||
+                candidate.Type.GetNavTypeKindSafe() != EnumProvider.NavTypeKind.Record)
+            {
+                candidate = null!;
+                return false;
+            }
+
+            foreach (var argument in invocation.Arguments)
+            {
+                Visit(argument.Value);
+            }
+
+            return true;
+        }
+
+        private static bool IsFlowTerminatingCall(IInvocationExpression operation)
+        {
+            if (operation.TargetMethod?.MethodKind != EnumProvider.MethodKind.BuiltInMethod ||
+                !SemanticFacts.IsSameName(operation.TargetMethod.Name, "Error") ||
+                operation.Arguments.Length == 0 ||
+                operation.Arguments[0].Value.Type is not { } argumentType)
+            {
+                return false;
+            }
+
+            return argumentType.GetNavTypeKindSafe() != EnumProvider.NavTypeKind.ErrorInfo;
+        }
+
+        private void InvalidateInitializedStateForPotentialReentrancy()
+        {
+            foreach (var state in _states.Values)
+            {
+                if (state.IsReachable)
+                {
+                    state.Initialization = InitializationKind.Unknown;
+                }
+            }
+        }
+
+        private void MarkAllCandidatesUnsafe()
+        {
+            foreach (var state in _states.Values)
+            {
+                state.IsUnsafe = true;
+            }
+        }
+
+        private static void Require(CandidateState state, InitializationKind required)
+        {
+            if (state.IsReachable && state.Initialization < required)
+            {
+                state.IsUnsafe = true;
+            }
+        }
+
+        private bool TryGetDirectCandidate(
+            IOperation? operation,
+            out IVariableSymbol candidate,
+            out CandidateState state)
+        {
+            candidate = null!;
+            state = null!;
+
+            if (operation is null)
+            {
+                return false;
+            }
+
+            operation = operation.UnwrapConversions();
+            return operation is IGlobalReferenceExpression globalReference &&
+                TryGetCandidate(globalReference.GlobalVariable, out candidate, out state);
+        }
+
+        private bool TryGetCandidate(
+            ISymbol? symbol,
+            out IVariableSymbol candidate,
+            out CandidateState state)
+        {
+            candidate = null!;
+            state = null!;
+
+            if (symbol is not IVariableSymbol variable ||
+                !_candidates.TryGetValue(variable.Name, out var possibleCandidate) ||
+                !IsSameVariable(variable, possibleCandidate))
+            {
+                return false;
+            }
+
+            candidate = possibleCandidate;
+            state = _states[possibleCandidate.Name];
+            return true;
+        }
+
+        private bool ContainsCandidate(IOperation operation)
+        {
+            var finder = new CandidateReferenceFinder(_candidates);
+            finder.Visit(operation);
+            return finder.FoundNames.Count > 0;
+        }
+
+        private void MarkReferencedCandidatesUnsafe(IOperation operation)
+        {
+            var finder = new CandidateReferenceFinder(_candidates);
+            finder.Visit(operation);
+
+            foreach (var name in finder.FoundNames)
+            {
+                _states[name].IsUnsafe = true;
+            }
+        }
+
+        private Dictionary<string, CandidateState> CloneStates()
+        {
+            var clone = new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+            foreach (var pair in _states)
+            {
+                clone.Add(pair.Key, pair.Value.Clone());
+            }
+            return clone;
+        }
+
+        private static Dictionary<string, CandidateState> CloneStateDictionary(
+            Dictionary<string, CandidateState> states)
+        {
+            var clone = new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+            foreach (var pair in states)
+            {
+                clone.Add(pair.Key, pair.Value.Clone());
+            }
+            return clone;
+        }
+
+        private void RestoreStates(Dictionary<string, CandidateState> states)
+        {
+            _states = new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+            foreach (var pair in states)
+            {
+                _states.Add(pair.Key, pair.Value.Clone());
+            }
+        }
+
+        private static Dictionary<string, CandidateState> MergeStates(
+            Dictionary<string, CandidateState> first,
+            Dictionary<string, CandidateState> second) =>
+            MergeStates([first, second]);
+
+        private static Dictionary<string, CandidateState> MergeStates(
+            IEnumerable<Dictionary<string, CandidateState>> branches)
+        {
+            Dictionary<string, CandidateState>? merged = null;
+
+            foreach (var branch in branches)
+            {
+                if (merged is null)
+                {
+                    merged = new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+                    foreach (var pair in branch)
+                    {
+                        merged.Add(pair.Key, pair.Value.Clone());
+                    }
+                    continue;
+                }
+
+                foreach (var pair in merged)
+                {
+                    var other = branch[pair.Key];
+                    pair.Value.IsUnsafe |= other.IsUnsafe;
+                    pair.Value.ReliesOnGetFieldInitialization |= other.ReliesOnGetFieldInitialization;
+                    pair.Value.HasPersistentRecordStateMutation |= other.HasPersistentRecordStateMutation;
+
+                    if (!pair.Value.IsReachable)
+                    {
+                        pair.Value.Initialization = other.Initialization;
+                        pair.Value.IsReachable = other.IsReachable;
+                    }
+                    else if (other.IsReachable)
+                    {
+                        pair.Value.Initialization =
+                            (InitializationKind)Math.Min((int)pair.Value.Initialization, (int)other.Initialization);
+                    }
+                }
+            }
+
+            return merged ?? new Dictionary<string, CandidateState>(SemanticFacts.NameEqualityComparer);
+        }
+
+        private sealed class CandidateReferenceFinder(
+            IReadOnlyDictionary<string, IVariableSymbol> candidates) : OperationWalker
+        {
+            private readonly IReadOnlyDictionary<string, IVariableSymbol> _candidates = candidates;
+
+            public HashSet<string> FoundNames { get; } = new(SemanticFacts.NameEqualityComparer);
+
+            public override void Visit(IOperation operation)
+            {
+                if (operation is IGlobalReferenceExpression globalReference &&
+                    globalReference.GlobalVariable is IVariableSymbol variable &&
+                    _candidates.TryGetValue(variable.Name, out var candidate) &&
+                    IsSameVariable(variable, candidate))
+                {
+                    FoundNames.Add(candidate.Name);
+                    return;
+                }
+
+                base.Visit(operation);
+            }
+        }
+    }
+}

--- a/src/ALCops.LinterCop/DiagnosticDescriptors.cs
+++ b/src/ALCops.LinterCop/DiagnosticDescriptors.cs
@@ -324,6 +324,16 @@ public static class DiagnosticDescriptors
         description: LinterCopAnalyzers.EventSubscriberParameterNotReferencedDescription,
         helpLinkUri: GetHelpUri(DiagnosticIds.EventSubscriberParameterNotReferenced));
 
+    public static readonly DiagnosticDescriptor GlobalVariableCouldBeLocal = new(
+        id: DiagnosticIds.GlobalVariableCouldBeLocal,
+        title: LinterCopAnalyzers.GlobalVariableCouldBeLocalTitle,
+        messageFormat: LinterCopAnalyzers.GlobalVariableCouldBeLocalMessageFormat,
+        category: Category.Design,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: LinterCopAnalyzers.GlobalVariableCouldBeLocalDescription,
+        helpLinkUri: GetHelpUri(DiagnosticIds.GlobalVariableCouldBeLocal));
+
     public static readonly DiagnosticDescriptor MixedExitAndNamedReturnAssignment = new(
         id: DiagnosticIds.MixedExitAndNamedReturnAssignment,
         title: LinterCopAnalyzers.MixedExitAndNamedReturnAssignmentTitle,

--- a/src/ALCops.LinterCop/DiagnosticIds.cs
+++ b/src/ALCops.LinterCop/DiagnosticIds.cs
@@ -36,4 +36,5 @@ public static class DiagnosticIds
     public static readonly string MixedExitAndNamedReturnAssignment = "LC0097";
     public static readonly string EventSubscriberNamingPattern = "LC0098";
     public static readonly string EventSubscriberParameterNotReferenced = "LC0099";
+    public static readonly string GlobalVariableCouldBeLocal = "LC0100";
 }


### PR DESCRIPTION
Implements the proposal from [Discussion #499](https://github.com/ALCops/Analyzers/discussions/499).

## Summary

Adds LC0100, `GlobalVariableCouldBeLocal`, to LinterCop. The diagnostic identifies global variables in **normal codeunits** (see reason in the end) that are used by only one procedure or trigger and whose previous object state cannot affect any reachable read.

- Categorized as `Design` with `Info` severity and disabled by default.
- Includes the AL data type in the diagnostic message, including quoted record type names.
- Uses separate wording for immutable labels without implying reinitialization.
- Provides no code action, so moving a declaration remains an explicit developer decision.

The analysis recognizes definite initialization through assignments, `Clear`, complete branches, and supported record operations such as successful `Record.Get(...)` calls. It deliberately stays silent when retained object state may matter, including reads before initialization, multiple-procedure usage, `var` arguments, unsafe recursive or reentrant paths, temporary records, reference-like types, event publishers exposing object state, and unsupported execution models.

## Tests

- 77 focused LC0100 test cases cover the discussion scenarios and additional control-flow, record, recursion, event, reentrancy, shadowing, and type-display edge cases.
- The complete LinterCop test suite passed on .NET 10: 415 passed, with 2 expected skips.
- The .NET 8 analyzer build and repository formatting verification passed against the latest `main`.
- The locally built analyzer was tested with the Microsoft Base Application and Microsoft Subcontracting App.

Companion documentation draft PR: https://github.com/ALCops/alcops.dev/pull/165

---

**Base Application:**
Filtered on 'Label':
<img width="1042" height="608" alt="image" src="https://github.com/user-attachments/assets/b0faa585-7ff0-4cbd-9daf-f0f30c7e8bbb" />

Filtered on everything else than 'Label':
<img width="1267" height="240" alt="image" src="https://github.com/user-attachments/assets/c7475d26-efd5-4ef2-b928-6cf7965449da" />

**Subcontracting:**
Filtered on 'Label':
<img width="1196" height="616" alt="image" src="https://github.com/user-attachments/assets/6b4eb556-bc8a-4baa-ad92-b7b2dfa1ba96" />

Filtered on everything else than 'Label' (have added cases myself; nothing found in the original source):
<img width="1170" height="89" alt="image" src="https://github.com/user-attachments/assets/f9452e3b-1369-491c-a62c-f0f1cd0c6ced" />

---

This implementation and draft PR were created with Codex using **GPT-5.6 Sol** with **Ultra** reasoning.

---

**Reason: Why only codeunits for the moment?**

LC0100 is intentionally restricted to normal codeunits in its initial implementation. Other AL object types have framework-controlled lifecycles: triggers may be invoked repeatedly or re-entered by the platform, and global variables may be consumed through declarative properties rather than ordinary procedure code. Therefore, having all procedural references inside a single trigger does not necessarily mean that procedure-local lifetime is appropriate.

For example, a report trigger is invoked once per data item record, and a global variable may intentionally retain state between those invocations:

```al
report 50100 "Sales Totals"
{
    dataset
    {
        dataitem(SalesLine; "Sales Line")
        {
            trigger OnAfterGetRecord()
            begin
                RunningTotal += SalesLine.Amount;
            end;
        }
    }

    var
        RunningTotal: Decimal;
}
```

Page globals can also be read implicitly by the UI through declarative bindings:

```al
page 50100 "Customer Example"
{
    PageType = Card;
    SourceTable = Customer;

    layout
    {
        area(Content)
        {
            field(StatusText; StatusText)
            {
                ApplicationArea = All;
            }
        }
    }

    trigger OnAfterGetCurrRecord()
    begin
        StatusText := StrSubstNo('Customer %1', Rec."No.");
    end;

    var
        StatusText: Text;
}
```

In this case, the runtime consumes `StatusText` outside the procedure operation tree. Treating pages, tables, reports, and similar objects exactly like codeunits could therefore introduce false positives. Support for additional object types can be added later once their lifecycle, declarative consumers, and reentrancy behavior are modeled and covered by dedicated tests.
