### PR TITLE
docs: promote session knowledge into the rules and add a rules validator

### DIFF
--- a/.claude/rules/code-analysis.md
+++ b/.claude/rules/code-analysis.md
@@ -42,7 +42,7 @@ The repo ships analyzers, so it dogfoods static analysis on itself: .NET analyze
 ## Verifying a change
 
 1. Every cop for all TFMs: `dotnet build src/ALCops.{Cop}/ALCops.{Cop}.csproj -c Release -p:ContinuousIntegrationBuild=true --no-incremental` — must show no `warning` or `error` line of any id.
-2. `dotnet format ALCops.sln --verify-no-changes --no-restore --severity warn --exclude "**/Rules/**/*.al"` — exit 0 (this is the CI gate).
+2. `dotnet format ALCops.sln --verify-no-changes --no-restore --severity warn --exclude "**/Rules/**/*.al"` — exit 0 (this is the CI gate). Read the findings, not the exit code: exit 2 with no diagnostics listed means whitespace findings (typically mixed CRLF/LF after a scripted edit; fix with `dotnet format whitespace --include <file>`), and on a clean tree the MSB3277 workspace warnings alone can produce exit 2.
 3. `dotnet test ALCops.sln` — includes the convention tests.
 
 ## Known issues / limitations

--- a/.claude/rules/common-library.md
+++ b/.claude/rules/common-library.md
@@ -85,7 +85,7 @@ Users configure settings by placing an `alcops.json` file in their AL project ro
 }
 ```
 
-Settings are cached per directory path for the analyzer session lifetime. There is no public cache-invalidation API; tests inject an isolated `IFileSystem` (typically `MemoryFileSystem` or a purpose-built `RelativeFileSystem`) to avoid contaminating the cache.
+Settings are cached per directory path for the analyzer session lifetime. There is no public cache-invalidation API, so an edited `alcops.json` takes effect only after the language server restarts; tests inject an isolated `IFileSystem` (typically `MemoryFileSystem` or a purpose-built `RelativeFileSystem`) to avoid contaminating the cache.
 
 ## Coding Standards
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -113,6 +113,12 @@ HasFix files use current/expected pairs:
 | `fixture.TestCodeFix(currentCode, expectedCode, diagnosticDescriptor)` | Assert single code fix transforms current into expected |
 | `fixture.TestFixAll(currentCode, expectedCode, diagnosticId, codeFixIndex, equivalenceKey)` | Assert `FixAllProvider` transforms current into expected across ALL `[|...|]` markers in one pass |
 
+## What the harness does not catch
+
+- **Analyzer exceptions.** `HasDiagnosticAtAllMarkers` and `NoDiagnosticAtAllMarkers` filter the reported diagnostics by the requested ID. An analyzer that throws produces the SDK's `AD0001` instead, which the filter discards, so `NoDiagnostic` passes and `HasDiagnostic` fails with "no diagnostic at marker" rather than with the exception. A rule that crashed on every compilation of older SDKs once stayed green in CI for months this way. When a rule behaves unexpectedly, assert the absence of exceptions with `fixture.NoException(code)`; it takes raw AL, so strip the `[|` and `|]` markers first or the parse errors trip `ThrowsWhenInputDocumentContainsError`.
+- **Empty markers.** `[||]` at the start of a file asserts nothing: `NoDiagnosticAtAllMarkers` checks only the marked span, so the analyzer may fire anywhere else and the test still passes. In a `NoDiagnostic` fixture wrap the exact span the rule would report (copy the span convention from the rule's `HasDiagnostic` fixtures), and confirm a new regression fixture fails before the analyzer change.
+- **Marker matching is `IntersectsWith`.** A marker anywhere inside the reported node satisfies the assertion, so a marker that is too wide or too narrow still passes. Keep markers on the node the analyzer targets.
+
 ## Testing Code Fixes
 
 `HasFix` / `HasFixAll` test methods and their `current.al` / `expected.al` layout: `.claude/skills/new-codefix/references/hasfix-tests.md` (used by `/new-codefix`). Key rule: `TestCodeFix` takes the `DiagnosticDescriptor` object, `TestFixAll` takes the ID string.
@@ -170,6 +176,17 @@ public async Task HasDiagnostic(string testCase)
 ### Why `#if` pragmas don't work in test projects
 
 Test projects always compile as `net10.0`, so `NETSTANDARD2_1` is never defined. The version difference is a runtime property of which SDK DLL gets loaded (CI tests against the netstandard2.1, net8.0 and net10.0 analyzer binaries), so it must be a runtime check.
+
+### Running the tests against the other SDK binaries locally
+
+`dotnet test` runs the net10.0 SDK only. To reproduce a CI failure on another analyzer binary, build the cop as CI does and point the test project at that output:
+
+```bash
+dotnet build src/ALCops.{Cop}/ALCops.{Cop}.csproj -c Release -p:ContinuousIntegrationBuild=true --no-incremental
+GITHUB_ACTIONS=true dotnet test src/ALCops.{Cop}.Test -c Release -p:NavTargetFramework=net8.0 --filter "FullyQualifiedName~{RuleName}"
+```
+
+Under `GITHUB_ACTIONS=true` the test project references the cop's `bin/Release/{tfm}` DLLs by `HintPath`. The net8.0 run works locally; the netstandard2.1 run fails locally with a `MissingMethodException` inside RoslynTestKit (the test project loads the net10.0 CodeAnalysis assembly), which is pre-existing and not a rule failure. CI test results are downloadable with `gh run download <runId>` as `test-results-<sdk>/TestResults_<sdk>.trx`; a failure reported at `Line:0 Col:0` is a diagnostic on a symbol without a source location, such as the module symbol.
 
 ## Testing Analyzers with File System Dependencies
 
@@ -291,6 +308,17 @@ Rules for .al fixtures:
 5. Every `HasDiagnostic` fixture must have at least one marker. Every `NoDiagnostic` fixture must also have markers (on the same kind of syntax node, but in a valid scenario).
 6. Receiver-relevant rules (those that detect record method calls or field access) need the four-form fixture set: `{Scenario}NamedVariable`, `{Scenario}RecSelf`, `{Scenario}BareSelf`, `{Scenario}ThisSelf` (+ `.InTableExtension` variant where applicable; background in `record-receiver-forms.md`). Every `this` fixture must be version-gated with `SkipTestIfVersionIsTooLow([...], testCase, "14.0", "The 'this' self-reference keyword requires runtime version 14.0 (BC 2024 wave 2).")`.
 7. When adding or creating tests, consider both a fixture **without** namespaces and one **with** a `namespace` declaration (if applicable to the analyzed syntax) — analyzers must support both. Use a generic multi-part namespace such as `MyPublisher.MyExtension.MyAppDomain`, and where relevant include fully-qualified object references (`MyPublisher.MyExtension.MyAppDomain.MyTable`). See `Rules/CasingMismatchDeclaration/HasDiagnostic/NamespacedObjectReference.al` in FormattingCop.Test for an example.
+
+### Fixtures must compile
+
+RoslynTestKit rejects a fixture with compile errors (`RoslynTestKitException: Input document contains errors`). That error means the AL is wrong, not the analyzer; read the AL diagnostic before touching code. Frequent causes:
+
+- Permission entries need object names, never ids (`tabledata 50100 = R` is AL0653); the same object twice in one `Permissions` property is AL0393; `system` entries need real system object names (AL0443).
+- A wildcard `tabledata * = RIMD` compiles only inside a `permissionset`.
+- A `#endregion` after the property's `;` sits outside the property and is unbalanced from the analyzer's view.
+- Referenced tables, enums and codeunits must be declared in the same file.
+
+A fixture that must not compile (a rule that runs on invalid code at editor time) uses a second `AnalyzerTestFixture` created with `ThrowsWhenInputDocumentContainsError = false`; name those test methods `*InDocumentWithErrors`.
 
 Typical fixture structure:
 

--- a/.claude/scripts/Validate-Rules.ps1
+++ b/.claude/scripts/Validate-Rules.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+Validates the .claude/rules/ tree: frontmatter, live path globs, required and forbidden rule-doc sections,
+stale-fact patterns in the general guides, and link targets. Run before opening a PR that touches .claude/.
+
+.EXAMPLE
+pwsh .claude/scripts/Validate-Rules.ps1
+Exit code 0 when clean, 1 when any finding is reported.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repo = (git rev-parse --show-toplevel).Trim()
+Set-Location $repo
+$tracked = @(git ls-files) | ForEach-Object { $_.Replace([char]92, [char]47) }
+$findings = [System.Collections.Generic.List[object]]::new()
+function Add-Finding([string]$Check, [string]$File, [string]$Detail) {
+    $script:findings.Add([pscustomobject]@{ Check = $Check; File = $File; Detail = $Detail })
+}
+function Get-RelPath([string]$Full) { [IO.Path]::GetRelativePath($repo, $Full).Replace([char]92, [char]47) }
+
+function ConvertTo-GlobRegex([string]$Glob) {
+    $sb = [System.Text.StringBuilder]::new('^')
+    $i = 0
+    while ($i -lt $Glob.Length) {
+        $c = $Glob[$i]
+        if ($c -eq '*' -and $i + 1 -lt $Glob.Length -and $Glob[$i + 1] -eq '*') {
+            if ($i + 2 -lt $Glob.Length -and $Glob[$i + 2] -eq '/') { [void]$sb.Append('(.*/)?'); $i += 3 } else { [void]$sb.Append('.*'); $i += 2 }
+            continue
+        }
+        switch ($c) {
+            '*' { [void]$sb.Append('[^/]*') }
+            '?' { [void]$sb.Append('[^/]') }
+            '{' { [void]$sb.Append('(') }
+            '}' { [void]$sb.Append(')') }
+            ',' { [void]$sb.Append('|') }
+            default { [void]$sb.Append([regex]::Escape([string]$c)) }
+        }
+        $i++
+    }
+    [void]$sb.Append('$')
+    return $sb.ToString()
+}
+
+$ruleFiles = Get-ChildItem -Path '.claude/rules' -Filter '*.md' -Recurse | Sort-Object FullName
+$guides = $ruleFiles | Where-Object { $_.Directory.Name -eq 'rules' }
+$ruleDocs = $ruleFiles | Where-Object { $_.Directory.Name -eq 'diagnostics' }
+
+foreach ($f in $ruleFiles) {
+    $rel = Get-RelPath $f.FullName
+    $text = Get-Content -Raw -LiteralPath $f.FullName
+    $lines = $text -split "`r?`n"
+
+    # 1. frontmatter with paths
+    if ($lines[0] -ne '---') { Add-Finding 'frontmatter' $rel 'file does not start with a --- frontmatter block'; continue }
+    $end = [array]::IndexOf($lines, '---', 1)
+    if ($end -lt 0) { Add-Finding 'frontmatter' $rel 'frontmatter block is not closed'; continue }
+    $fm = $lines[1..($end - 1)]
+    $globs = @($fm | Where-Object { $_ -match '^\s*-\s*"?([^"]+)"?\s*$' } | ForEach-Object { $Matches[1].Trim() })
+    if (-not ($fm -match '^paths:')) { Add-Finding 'frontmatter' $rel 'no paths: entry (the file would load in every session)' }
+    if ($globs.Count -eq 0) { Add-Finding 'frontmatter' $rel 'paths: has no globs' }
+
+    # 2. every glob matches a tracked file
+    foreach ($g in $globs) {
+        $rx = ConvertTo-GlobRegex $g
+        if (-not ($tracked | Where-Object { $_ -match $rx } | Select-Object -First 1)) { Add-Finding 'orphan-glob' $rel "no tracked file matches '$g'" }
+    }
+
+    # 5. link targets exist
+    foreach ($m in [regex]::Matches($text, '\.claude/[A-Za-z0-9_./-]+\.md')) {
+        if (-not (Test-Path -LiteralPath (Join-Path $repo $m.Value))) { Add-Finding 'broken-link' $rel "link target missing: $($m.Value)" }
+    }
+    foreach ($m in [regex]::Matches($text, '`([a-z0-9-]+\.md)`')) {
+        $name = $m.Groups[1].Value
+        $candidates = @("$repo/.claude/rules/$name", "$repo/.claude/rules/diagnostics/$name") + @(Get-ChildItem "$repo/.claude/skills" -Recurse -Filter $name | ForEach-Object FullName)
+        if (-not ($candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1)) { Add-Finding 'broken-link' $rel "sibling reference has no file: $name" }
+    }
+}
+
+# 3. rule docs: required and forbidden sections, test-folder glob
+foreach ($f in $ruleDocs) {
+    $rel = Get-RelPath $f.FullName
+    $text = Get-Content -Raw -LiteralPath $f.FullName
+    foreach ($h in '## Purpose', '## Design decisions') {
+        if ($text -notmatch "(?m)^$([regex]::Escape($h))\s*$") { Add-Finding 'missing-section' $rel "no '$h' heading" }
+    }
+    foreach ($m in [regex]::Matches($text, '(?m)^## (Architecture|Roadmap|Phase 2|Relationship|Method classification|Receiver forms)[^\r\n]*')) {
+        Add-Finding 'forbidden-section' $rel "heading '$($m.Value)' narrates code or defers work; move to code, a design row, or a GitHub issue"
+    }
+    if ($text -match '(?m)^## Known issues\s*\r?\n\s*\r?\n-\s*None') { Add-Finding 'empty-section' $rel "Known issues says 'None'; omit the section instead" }
+    if ($text -notmatch '(?m)^\s*-\s*"?src/ALCops\.[A-Za-z]+\.Test/') { Add-Finding 'test-glob' $rel 'paths: has no test-folder glob (src/ALCops.{Cop}.Test/...)' }
+}
+
+# 4. general guides: no bare issue refs, no measurements, no time-bound wording
+foreach ($f in $guides) {
+    $rel = Get-RelPath $f.FullName
+    $text = Get-Content -Raw -LiteralPath $f.FullName
+    foreach ($m in [regex]::Matches($text, '(?<![\w/`])#\d{2,4}\b')) { Add-Finding 'issue-ref' $rel "bare issue reference '$($m.Value)'; general guides stay issue-free (rule docs and the regression catalog keep the links)" }
+    foreach ($m in [regex]::Matches($text, '~?\b\d+(\.\d+)?\s?(ms|μs|us)\b')) { Add-Finding 'measurement' $rel "measurement '$($m.Value)' rots; state the cost qualitatively" }
+    foreach ($m in [regex]::Matches($text, '(?i)\b(currently|should migrate|not yet implemented)\b')) { Add-Finding 'time-bound' $rel "'$($m.Value)' describes a moment, not a rule; describe the current state as fact" }
+}
+
+if ($findings.Count -eq 0) {
+    Write-Host "OK: $($ruleFiles.Count) rules files ($($guides.Count) guides, $($ruleDocs.Count) rule docs) pass all checks."
+    exit 0
+}
+$findings | Sort-Object Check, File | Format-Table -AutoSize -Wrap | Out-String -Width 200 | Write-Host
+Write-Host "$($findings.Count) finding(s)."
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ dotnet test src/ALCops.LinterCop.Test/ --filter "FullyQualifiedName~{RuleName}.H
 - New shared component or convention → new `.claude/rules/<area>.md` with a `paths:` frontmatter scoped as narrowly as possible. Never add a rules file without `paths:` (it would load in every session).
 - Rules files document *why*, not *what*: no diagnostic-property tables, test-case lists, or file inventories — the code is the source of truth for those.
 - Knowledge needed whenever you edit matching files lives in `.claude/rules/`; procedural templates and checklists used only while running a skill live in `.claude/skills/*/references/`. Never keep the same content in both — leave a pointer.
+- Before opening a PR that touches `.claude/`, run `pwsh .claude/scripts/Validate-Rules.ps1`: it checks frontmatter, live `paths:` globs, rule-doc sections, link targets, and stale-fact patterns in the general guides.
 - If none of this applies to a change, say "No `.claude` doc changes needed" in the plan.
 
 ## Where to look


### PR DESCRIPTION
Third of three staged `.claude` PRs; stacked on #524 (retarget once that merges).

## What

**Knowledge promoted from session memory into the repo**

| Fact | Where |
|---|---|
| `HasDiagnostic`/`NoDiagnostic` filter by ID, so a throwing analyzer (`AD0001`) still passes; use `fixture.NoException` with markers stripped as a scratch check | `testing.md` → "What the harness does not catch" |
| `[||]` at file start asserts nothing; wrap the reported span and confirm the fixture fails pre-fix; matching is `IntersectsWith` | same section |
| Fixtures must compile: permission entries need object names, no duplicate objects, real `system` names; `Input document contains errors` means the AL is wrong; must-not-compile fixtures use `ThrowsWhenInputDocumentContainsError = false` | `testing.md` → "Fixtures must compile" |
| Local multi-TFM run (`ContinuousIntegrationBuild` build, then `GITHUB_ACTIONS=true dotnet test -p:NavTargetFramework=net8.0`); netstandard2.1 tests fail locally for a pre-existing reason; reading CI `.trx` files | `testing.md` → "Running the tests against the other SDK binaries locally" |
| `dotnet format` exit 2 with no findings = whitespace/CRLF, or MSB3277 on a clean tree; read findings, not the exit code | `code-analysis.md` → Verifying a change |
| Edited `alcops.json` needs a language-server restart (no cache invalidation) | `common-library.md` |

**Validator** `.claude/scripts/Validate-Rules.ps1` (manual, no CI coupling): frontmatter with `paths:`, every glob matches a tracked file, rule docs have Purpose and Design decisions and no Architecture/Roadmap/Relationship sections, no "None" sections, every rule doc has a test-folder glob, general guides carry no bare issue numbers, measurements or "currently"-style wording, and every `.claude/...md` link resolves. Exit 1 on findings. Run against the pre-normalization tree it reported 8 empty sections and about 40 forbidden headings; on this branch it reports none. CLAUDE.md now asks for it before any PR touching `.claude/`.

Docs and one script; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
